### PR TITLE
Fix "overflow: scroll-x" in Firefox for xpubs, txids and addresses cells in tables.

### DIFF
--- a/src/specter/static/styles.css
+++ b/src/specter/static/styles.css
@@ -497,11 +497,19 @@ tbody tr:hover{
 }
 td.xpub{
 	max-width: 300px;
-	overflow-x: scroll;
 }
-td.txid{
+td.tx{
 	max-width: 200px;
+}
+td.scroll{
+	padding: 0 10px;
+}
+td.scroll > *{
+	/* ugly fix for firefox - scrolling child element */
+	display: block;
 	overflow-x: scroll;
+	width: 100%;
+	padding: 20px 0;
 }
 table a{
 	display: inline;

--- a/src/specter/templates/device.html
+++ b/src/specter/templates/device.html
@@ -35,7 +35,7 @@
 					<img src="{{qrcode('name='+device['name']+'\n'+key['combined'])}}">
 				</div>
 			</td>
-			<td class="xpub">{{key["original"]}}</td>
+			<td class="xpub scroll"><span>{{key["original"]}}</span></td>
 			<td width="80px">
 				<form action="./" method="POST">
 					<form action="./" method="POST">

--- a/src/specter/templates/new_simple_keys.html
+++ b/src/specter/templates/new_simple_keys.html
@@ -48,7 +48,7 @@
 		</td>
 		<td>{{ purposes[key["type"]] }}</td>
 		<td>{{key["derivation"]}}</td>
-		<td class="xpub">{{key["original"]}}</td>
+		<td class="scroll xpub"><span>{{key["original"]}}</span></td>
 		<td width="120px">
 			<label>
 			<input type="radio" name="key{{outer_loop.index0}}" value="{{key['original']}}" class="hidden" {% if loop.index == 1 %}checked{% endif %}/>
@@ -102,7 +102,7 @@
 			</td>
 			<td>{{ purposes[key["type"]] }}</td>
 			<td>{{key["derivation"]}}</td>
-			<td class="xpub">{{key["original"]}}</td>
+			<td class="scroll xpub"><span>{{key["original"]}}</span></td>
 			<td width="120px">
 				<form action="./" method="POST">
 					<input type="hidden" name="key" value="{{key['original']}}">

--- a/src/specter/templates/wallet_tx.html
+++ b/src/specter/templates/wallet_tx.html
@@ -54,8 +54,8 @@
 						{% endif %}
 					{% endif %}
 				</td>
-				<td class="txid"><a target="blank" href="{{url}}tx/{{tx['txid']}}">{{tx["txid"]}}</a></td>
-				<td class="txid"><a target="blank" href="{{url}}address/{{tx['address']}}">{{tx["address"]}}</a></td>
+				<td class="tx scroll"><a target="blank" href="{{url}}tx/{{tx['txid']}}">{{tx["txid"]}}</a></td>
+				<td class="tx scroll"><a target="blank" href="{{url}}address/{{tx['address']}}">{{tx["address"]}}</a></td>
 				<td>{{tx["amount"]}}</td><td>
 				{%if tx["confirmations"] == 0 %}
 					Pending


### PR DESCRIPTION
Fixes https://github.com/cryptoadvance/specter-desktop/issues/21
Checked in Firefox, Chrome, and Safari
Solved by adding a child element inside the overflow table cells and scrolling that one instead.