### PR TITLE
add dynamic fees option

### DIFF
--- a/src/specter/controller.py
+++ b/src/specter/controller.py
@@ -270,6 +270,11 @@ def wallet_receive(wallet_alias):
             wallet.getnewaddress()
     return render_template("wallet_receive.html", wallet_alias=wallet_alias, wallet=wallet, specter=app.specter, rand=rand)
 
+@app.route('/get_fee/<blocks>')
+def fees(blocks):
+    res = app.specter.estimatesmartfee(int(blocks))
+    return res
+
 @app.route('/wallets/<wallet_alias>/send/', methods=['GET', 'POST'])
 def wallet_send(wallet_alias):
     app.specter.check()
@@ -289,10 +294,16 @@ def wallet_send(wallet_alias):
             address = request.form['address']
             amount = float(request.form['amount'])
             subtract = bool(request.form.get("subtract", False))
-            if request.form.get('fee_rate'):
-                fee_rate = float(request.form.get('fee_rate'))
+            fee_unit = request.form.get('fee_unit')
+
+            if 'dynamic' in request.form.get('fee_options'):
+                fee_rate = float(request.form.get('fee_rate_dynamic'))
+            else:
+                if request.form.get('fee_rate'):
+                    fee_rate = float(request.form.get('fee_rate'))
+
             # try:
-            psbt = wallet.createpsbt(address, amount, subtract=subtract, fee_rate=fee_rate)
+            psbt = wallet.createpsbt(address, amount, subtract=subtract, fee_rate=fee_rate, fee_unit=fee_unit)
             if psbt is None:
                 err = "Probably you don't have enough funds, or something else..."
             else:

--- a/src/specter/logic.py
+++ b/src/specter/logic.py
@@ -170,6 +170,9 @@ class Specter:
         res = self.cli.sendrawtransaction(raw)
         return res
 
+    def estimatesmartfee(self, blocks):
+        return self.cli.estimatesmartfee(blocks)
+
     @property
     def chain(self):
         return self._info["chain"]
@@ -670,12 +673,16 @@ class Wallet(dict):
             return None
         return self.balance["trusted"]+self.balance["untrusted_pending"]
 
-    def createpsbt(self, address:str, amount:float, subtract:bool=False, fee_rate:float=0.0, coinselects=[]):
+    def createpsbt(self, address:str, amount:float, subtract:bool=False, fee_rate:float=0.0, fee_unit="SAT_B", coinselects=[]):
         """
-            fee_rate: in sat/B. Default (None) bitcoin core sets feeRate automatically.
+            fee_rate: in sat/B or BTC/kB. Default (None) bitcoin core sets feeRate automatically.
         """
         if self.fullbalance < amount:
             return None
+        print (fee_unit)
+        if fee_unit not in ["SAT_B", "BTC_KB"]:
+            raise ValueError('Invalid bitcoin unit')
+
         extra_inputs = []
         if self.balance["trusted"] < amount:
             txlist = self.cli.listunspent(0,0)
@@ -696,7 +703,8 @@ class Wallet(dict):
             "changeAddress": self["change_address"],
             "subtractFeeFromOutputs": subtract_arr
         }
-        if fee_rate > 0.0:
+
+        if fee_rate > 0.0 and fee_unit == "SAT_B":
             # bitcoin core needs us to convert sat/B to BTC/kB
             options["feeRate"] = fee_rate / 10 ** 8 * 1024
 

--- a/src/specter/static/styles.css
+++ b/src/specter/static/styles.css
@@ -276,6 +276,9 @@ input.inline, .input.inline{
 input[type="checkbox"].inline{
 	min-width: auto;
 }
+input[type="radio"].inline{
+	min-width: auto;
+}
 input[type="number"].inline, .input.inline{
 	min-width: 30px;
 	width: 80px;

--- a/src/specter/templates/wallet_send.html
+++ b/src/specter/templates/wallet_send.html
@@ -11,6 +11,9 @@
 		text-align: center;
 		margin-bottom: 2em;
 	}
+        .fee_container {
+                height: 11em;
+        }
 	.fee_rate {
 		width: 6em;
 		min-width: 6em;
@@ -21,6 +24,7 @@
 	.hwi-column-btn {
 		margin: 0.75em;
 	}
+
 </style>
 <h1>{{wallet.name}}</h1>
 <div class="row">
@@ -45,11 +49,26 @@
 			<div class="note">Available: {{"%.8f" % wallet.fullbalance}}</div>
 			<div><label><input type="checkbox" class="inline" name="subtract" value="1"> Subtract from amount</label></div>
 			<br><br>
+
+			<div class="fee_container">
+			<div>Fees: <label><input type="radio" class="inline" style="margin: 0 10px 0 20px;" id="fee_option_dynamic"  name="fee_options" value="dynamic" onclick="showFeeOption(this)">dynamic</label>
+			<label><input type="radio" class="inline" style="margin: 0 10px 0 20px" name="fee_options" value="manual" onclick="showFeeOption(this);">manual</label></div>
+			<br><br>
+			<input type="hidden" id="fee_unit" name="fee_unit" value="">
+			<div id = "fee_manual" style="display:none">
 			Fee rate:<br>
 			<input type="number" class="fee_rate" name="fee_rate" id="fee_rate" max="100" min=0 step="0.25"> sat/B
 			<div class="note">leave blank to set automatically</div>
 			<br><br>
+			</div>
+			<div id ="fee_dynamic" style="display:block">
+			<div id="blocks"></div>
+			<input type="range" style="width: 12em" min="1" max="25" value="6" step="1" id="slider_confTime" oninput="loadDynamicFees(this.value)">
+			<input type="hidden" id="fee_rate_dynamic" name="fee_rate_dynamic" value="0">
+			<div> Fee rate: <span id="fee_rate_dynamic_text"></span></div>
 			<br><br>
+			</div></div>
+
 			<button type="submit" name="action" value="createpsbt" class="btn centered">Create unsigned transaction</button>&nbsp; &nbsp; &nbsp; 
 		</div>
 		<br>
@@ -135,6 +154,53 @@
 <div class="popup" id="popup">
 	<video muted playsinline id="qr-video" class="video"></video>
 </div>
+<script>
+function replace(hide, show) {
+	document.getElementById(hide).style.display="none";
+	document.getElementById(show).style.display="block";
+}
+
+function showFeeOption(myRadio) {
+	if (myRadio.value == "dynamic") {
+		replace("fee_manual", "fee_dynamic")
+		document.getElementById("fee_unit").value = "BTC_KB"
+	}
+	else {
+		replace("fee_dynamic", "fee_manual")
+		document.getElementById("fee_unit").value = "SAT_B"
+	}
+}
+
+function loadDynamicFees() {
+	var xhttp = new XMLHttpRequest();
+	xhttp.onreadystatechange = function() {
+		if (this.readyState == 4 && this.status == 200) {
+			let feesJson = JSON.parse(this.responseText);
+			let blocks = "Dynamic fees are currently not available."
+			if (feesJson.hasOwnProperty('feerate')) {
+				let fee = feesJson.feerate
+				blocks = feesJson.blocks
+				document.getElementById("fee_rate_dynamic_text").innerHTML = fee.toString().concat(" BTC/kB")
+				document.getElementById("fee_rate_dynamic").value = fee
+			}
+			else
+			{
+				document.getElementById("fee_rate_dynamic_text").innerHTML = "will be set by Bitcoin Core automatically"
+				document.getElementById("fee_rate_dynamic").value = 0
+			}
+			document.getElementById("blocks").innerHTML = "Confirmation time: ".concat(blocks, " blocks")
+		}
+	}
+	var request = "/get_fee/".concat(document.getElementById("slider_confTime").value)
+	xhttp.open("GET", request, true);
+	xhttp.send();
+	}
+
+	window.onload = loadDynamicFees;
+	document.getElementById("fee_option_dynamic").checked = true
+	document.getElementById("fee_unit").value = "BTC_KB"
+	document.getElementById("slider_confTime").value = 6
+</script>
 <script type="module">
 
 {% if psbt %}


### PR DESCRIPTION
## Abstract

Close #55. Adding option to choose dynamic fees based on block confirmation time (estimatesmartfee). Open for discussion.

## Status
Ready for review or it can be put on hold. See comments below.

- [x] first draft
- [x] style fixes (python should have spaces, JS tabs?)



