### PR TITLE
unique path for bitcoin core wallets

### DIFF
--- a/src/specter/static/img/generate_icon.svg
+++ b/src/specter/static/img/generate_icon.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="14px" height="16px" viewBox="0 0 14 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 52.6 (67491) - http://www.bohemiancoding.com/sketch -->
+    <title>generate_icon</title>
+    <desc>Created with Sketch.</desc>
+    <g id="screenshot" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="generate_icon" transform="translate(-5.000000, -4.000000)">
+            <g id="baseline-publish-24px" transform="translate(12.000000, 12.000000) scale(-1, 1) rotate(-180.000000) translate(-12.000000, -12.000000) ">
+                <polygon id="Path" points="0 0 24 0 24 24 0 24"></polygon>
+                <path d="M5.6,4.6 L5.6,5.4 L18.4,5.4 L18.4,4.6 L5.6,4.6 Z M6.44852814,13.4 L9.6,13.4 L9.6,19.4 L14.4,19.4 L14.4,13.4 L17.5514719,13.4 L12,7.84852814 L6.44852814,13.4 Z" id="Shape" stroke="#2E90E9" stroke-width="1.2" fill-rule="nonzero"></path>
+            </g>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
If the same Bitcoin Core node is used by multiple people (like on the upcoming workshop) there could be name collisions for new wallets - all specters use the same wallet path `specter/walletname` in Bitcoin Core.

This pull request introduces a unique id for Specter generated when you first start the server. 
This `uid` is stored in the `config.json` file. If `config.json` already exists - empty `uid` is used (for backward compatibility).
Wallet path in Bitcoin Core becomes `specter<uid>/walletname`.

Now we should not have name collisions when using the same node with multiple specters.

Also adds a `generate_icon.svg` for mined coins on regtest.