### PR TITLE
support for compressed psbt in QR codes

### DIFF
--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -298,7 +298,6 @@ def new_wallet_multi():
                             break
                 except:
                     pass
-            print(keys, cosigners)
             if len(keys) != sigs_total or len(cosigners) != sigs_total:
                 prefix = "tpub"
                 if app.specter.chain == "main":
@@ -420,7 +419,6 @@ def wallet_settings(wallet_alias):
             startblock = int(request.form['startblock'])
             try:
                 res = wallet.cli.rescanblockchain(startblock, timeout=1)
-                print(res)
             except requests.exceptions.ReadTimeout:
                 pass
             except Exception as e:
@@ -439,7 +437,7 @@ def wallet_settings(wallet_alias):
             wallet.getdata()
 
     cc_file = None
-    qr_text = wallet["name"]+"&"+descr(wallet)
+    qr_text = wallet["name"]+"&"+wallet.descriptor
     if wallet.is_multisig:
         CC_TYPES = {
         'legacy': 'BIP45',
@@ -580,11 +578,6 @@ def txonaddr(wallet):
 @app.template_filter('prettyjson')
 def txonaddr(obj):
     return json.dumps(obj, indent=4)
-
-@app.template_filter('descriptor')
-def descr(wallet):
-    # we always use sortedmulti even though it is not in Bitcoin Core yet
-    return wallet['recv_descriptor'].split("#")[0].replace("/0/*", "").replace("multi", "sortedmulti")
 
 
     

--- a/src/cryptoadvance/specter/templates/wallet_send.html
+++ b/src/cryptoadvance/specter/templates/wallet_send.html
@@ -97,6 +97,17 @@
 		{% endif %}
 
 		{% if wallet.uses_qrcode_device %}
+			<div class="row padded">
+				<label>
+					<input type="radio" name="psbt_type" value="compressed_psbt" class="hidden" checked>
+					<div class="btn radio left">Compressed PSBT</div>
+				</label>
+				<label>
+					<input type="radio" name="psbt_type" value="full_psbt" class="hidden">
+					<div class="btn radio right">Full PSBT</div>
+				</label>
+			</div>
+
 			<div class="row" style="min-height: 400px;">
 			<!-- 	{% set chunk = 700 %}
 				{%for i in range( (psbt["base64"] | length)//chunk+1)%}
@@ -104,8 +115,25 @@
 				{%endfor%}
 			 -->
 
-				<img src="{{qrcode(psbt['base64'])}}" class="qr broad" width="400px" height="400px"/>
+				<img id="compressed_psbt" src="{{qrcode(psbt['specter'])}}" class="qr broad" width="400px" height="400px"/>
+				<img id="full_psbt" src="{{qrcode(psbt['base64'])}}" class="qr broad" width="400px" height="400px" style="display: none"/>
 			 </div>
+			 <script>
+			 	document.addEventListener("DOMContentLoaded", function(){
+				 	document.forms[0].elements.psbt_type.forEach((o)=>{
+				 		o.addEventListener('change', e=>{
+				 			["compressed_psbt","full_psbt"].forEach(id=>{
+					 			let el = document.getElementById(id);
+					 			if(id==document.forms[0].elements.psbt_type.value){
+					 				el.style.display = "flex";
+					 			}else{
+					 				el.style.display = "none";
+					 			}
+				 			});
+				 		})
+				 	});
+			 	});
+			 </script>
 			<!-- because coldcard psbt is the most complete (includes xpubs) -->
 			<div class="log"><code><pre>{{psbt['coldcard']}}</pre></code></div>
 		{% endif %}


### PR DESCRIPTION
In multisig full-psbt QR codes are large. Specter knows about the wallet and doesn't allow signing from wallets that are unknown, so there is no need in witness script, redeem script and only two last indexes of the derivation path are used.
If we use proprietary fields we can significantly reduce the size of the QR code, the wallet still will be able to sign and verify.
Also, the size of the compressed-psbt QR code doesn't depend on number of signers.
For compatibility with other projects that use QR codes we keep full psbt available - there is a radio button now.

Just compare the sizes:
<img width="1440" alt="Screenshot 2020-02-28 at 16 45 45" src="https://user-images.githubusercontent.com/1706012/75563040-eb004f80-5a49-11ea-8a6e-fdbfc1347c98.png">
<img width="1440" alt="Screenshot 2020-02-28 at 16 45 48" src="https://user-images.githubusercontent.com/1706012/75563123-18e59400-5a4a-11ea-9d09-26b385d568c8.png">
