### PR TITLE
Make RPC password input use type password

### DIFF
--- a/src/cryptoadvance/specter/templates/settings.html
+++ b/src/cryptoadvance/specter/templates/settings.html
@@ -7,7 +7,7 @@
 		<br>
 		Username:<br><input type="text" name="username" value="{{username}}">
 		<br><br>
-		Password:<br><input type="text" name="password" value="{{password}}">
+		Password:<br><input type="password" name="password" value="{{password}}">
 		<br><br>
 		Host:<br>
 		<input type="text" name="host" type="text" value="{{protocol}}://{{host}}">


### PR DESCRIPTION
Make RPC password input use type `password` so that users password is not displayed in clear text.