### PR TITLE
Wallet bugfix

### DIFF
--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -439,25 +439,11 @@ def wallet_settings(wallet_alias):
     cc_file = None
     qr_text = wallet["name"]+"&"+wallet.descriptor
     if wallet.is_multisig:
-        CC_TYPES = {
-        'legacy': 'BIP45',
-        'p2sh-segwit': 'P2WSH-P2SH',
-        'bech32': 'P2WSH'
-        }
-        cc_file = """# Coldcard Multisig setup file (created on Specter Desktop)
-#
-Name: {}
-Policy: {} of {}
-Derivation: {}
-Format: {}
-""".format(wallet['name'], wallet['sigs_required'], 
-            len(wallet['keys']), wallet['keys'][0]["derivation"].replace("h","'"),
-            CC_TYPES[wallet['address_type']]
-            )
-        for k in wallet['keys']:
-            cc_file += "{}: {}\n".format(k['fingerprint'].upper(), k['xpub'])
+        cc_file = wallet.get_cc_file()
+        if cc_file is not None:
+            cc_file = urllib.parse.quote(cc_file)
         return render_template("wallet_settings.html", 
-                            cc_file=urllib.parse.quote(cc_file), 
+                            cc_file=cc_file, 
                             wallet_alias=wallet_alias, wallet=wallet, 
                             specter=app.specter, rand=rand, 
                             error=error,

--- a/src/cryptoadvance/specter/logic.py
+++ b/src/cryptoadvance/specter/logic.py
@@ -348,14 +348,12 @@ class WalletManager:
         if cli is not None:
             self.cli = cli
         if self.working_folder is not None:
-            self._wallets = load_jsons(self.working_folder, key="name")
-            try:
-                existing_wallets = [w["name"] for w in self.cli.listwalletdir()["wallets"]]
-                for k in self._wallets:
-                    if self.path+k not in existing_wallets:
-                        self._wallets.pop(w["name"])
-            except:
-                pass
+            self._wallets = {}
+            wallets = load_jsons(self.working_folder, key="name")
+            existing_wallets = [w["name"] for w in self.cli.listwalletdir()["wallets"]]
+            for k in wallets:
+                if self.cli_path+wallets[k]["alias"] in existing_wallets:
+                    self._wallets[k] = wallets[k]
         else:
             self._wallets = {}
 

--- a/src/cryptoadvance/specter/static/styles.css
+++ b/src/cryptoadvance/specter/static/styles.css
@@ -533,6 +533,7 @@ input[type="radio"]:checked + .btn.hovering,
 input[type="checkbox"]:checked + .btn.hovering
 {
     visibility: visible;
+    opacity: 1 !important;
 }
 .btn.radio.left{
     border-radius: 10px 0 0 10px;

--- a/src/cryptoadvance/specter/templates/wallet_settings.html
+++ b/src/cryptoadvance/specter/templates/wallet_settings.html
@@ -48,7 +48,11 @@
 </div>
 {% if wallet.is_multisig %}
 <div>
+{% if cc_file %}
 <a download="{{wallet['name']}}" href="data:text/plain;charset=US-ASCII,{{cc_file}}" class="btn centered padded">Download ColdCard file</a>
+{% else %}
+<div class="note">Coldcard file is unavailable - we don't have enough information to generate it</div>
+{% endif %}
 </div>
 {% endif %}
 <div>


### PR DESCRIPTION
Closes https://github.com/cryptoadvance/specter-desktop/issues/86

- when switching to another node that doesn't have wallets known to specter - hide the wallets instead of crashing
- if derivation path or fingerprint are not known to specter - hide "Download ColdCard file" instead of crashing
- css improvement for key selection - selected key radio button has now opacity of 1