### PR TITLE
Add custom block explorer URL settings

### DIFF
--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -110,6 +110,8 @@ def settings():
     port = rpc['port']
     host = rpc['host']
     protocol = 'http'
+    mainnet_explorer = app.specter.config["mainnet_explorer"]
+    testnet_explorer = app.specter.config["testnet_explorer"]
     auth = app.specter.config["auth"]
     if "protocol" in rpc:
         protocol = rpc["protocol"]
@@ -119,6 +121,8 @@ def settings():
         passwd = request.form['password']
         port = request.form['port']
         host = request.form['host']
+        mainnet_explorer = request.form["mainnet_explorer"]
+        testnet_explorer = request.form["testnet_explorer"]
         auth = request.form['auth']
         action = request.form['action']
         # protocol://host
@@ -143,6 +147,7 @@ def settings():
                                     protocol=protocol,
                                     autodetect=False
                                     )
+            app.specter.update_explorers(mainnet_explorer, testnet_explorer)
             app.specter.update_auth(auth)
             if auth == "rpcpasswordaspin":
                 app.config['LOGIN_DISABLED'] = False
@@ -159,6 +164,8 @@ def settings():
                             port=port,
                             host=host,
                             protocol=protocol,
+                            mainnet_explorer=mainnet_explorer,
+                            testnet_explorer=testnet_explorer,
                             auth=auth,
                             specter=app.specter,
                             rand=rand)
@@ -338,7 +345,11 @@ def wallet_tx(wallet_alias):
         wallet = app.specter.wallets.get_by_alias(wallet_alias)
     except:
         return render_template("base.html", error="Wallet not found", specter=app.specter, rand=rand)
-    return render_template("wallet_tx.html", wallet_alias=wallet_alias, wallet=wallet, specter=app.specter, rand=rand)
+
+    explorer = app.specter.config["mainnet_explorer"]
+    if app.specter.chain == "test":
+        explorer = app.specter.config["testnet_explorer"]
+    return render_template("wallet_tx.html", wallet_alias=wallet_alias, wallet=wallet, explorer=explorer, specter=app.specter, rand=rand)
 
 @app.route('/wallets/<wallet_alias>/receive/', methods=['GET', 'POST'])
 @login_required
@@ -352,7 +363,10 @@ def wallet_receive(wallet_alias):
         action = request.form['action']
         if action == "newaddress":
             wallet.getnewaddress()
-    return render_template("wallet_receive.html", wallet_alias=wallet_alias, wallet=wallet, specter=app.specter, rand=rand)
+    explorer = app.specter.config["mainnet_explorer"]
+    if app.specter.chain == "test":
+        explorer = app.specter.config["testnet_explorer"]
+    return render_template("wallet_receive.html", wallet_alias=wallet_alias, wallet=wallet, explorer=explorer, specter=app.specter, rand=rand)
 
 @app.route('/get_fee/<blocks>')
 @login_required

--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -110,8 +110,7 @@ def settings():
     port = rpc['port']
     host = rpc['host']
     protocol = 'http'
-    mainnet_explorer = app.specter.config["mainnet_explorer"]
-    testnet_explorer = app.specter.config["testnet_explorer"]
+    explorer = app.specter.explorer
     auth = app.specter.config["auth"]
     if "protocol" in rpc:
         protocol = rpc["protocol"]
@@ -121,8 +120,7 @@ def settings():
         passwd = request.form['password']
         port = request.form['port']
         host = request.form['host']
-        mainnet_explorer = request.form["mainnet_explorer"]
-        testnet_explorer = request.form["testnet_explorer"]
+        explorer = request.form["explorer"]
         auth = request.form['auth']
         action = request.form['action']
         # protocol://host
@@ -147,7 +145,7 @@ def settings():
                                     protocol=protocol,
                                     autodetect=False
                                     )
-            app.specter.update_explorers(mainnet_explorer, testnet_explorer)
+            app.specter.update_explorer(explorer)
             app.specter.update_auth(auth)
             if auth == "rpcpasswordaspin":
                 app.config['LOGIN_DISABLED'] = False
@@ -164,8 +162,7 @@ def settings():
                             port=port,
                             host=host,
                             protocol=protocol,
-                            mainnet_explorer=mainnet_explorer,
-                            testnet_explorer=testnet_explorer,
+                            explorer=explorer,
                             auth=auth,
                             specter=app.specter,
                             rand=rand)
@@ -346,10 +343,7 @@ def wallet_tx(wallet_alias):
     except:
         return render_template("base.html", error="Wallet not found", specter=app.specter, rand=rand)
 
-    explorer = app.specter.config["mainnet_explorer"]
-    if app.specter.chain == "test":
-        explorer = app.specter.config["testnet_explorer"]
-    return render_template("wallet_tx.html", wallet_alias=wallet_alias, wallet=wallet, explorer=explorer, specter=app.specter, rand=rand)
+    return render_template("wallet_tx.html", wallet_alias=wallet_alias, wallet=wallet, specter=app.specter, rand=rand)
 
 @app.route('/wallets/<wallet_alias>/receive/', methods=['GET', 'POST'])
 @login_required
@@ -363,10 +357,7 @@ def wallet_receive(wallet_alias):
         action = request.form['action']
         if action == "newaddress":
             wallet.getnewaddress()
-    explorer = app.specter.config["mainnet_explorer"]
-    if app.specter.chain == "test":
-        explorer = app.specter.config["testnet_explorer"]
-    return render_template("wallet_receive.html", wallet_alias=wallet_alias, wallet=wallet, explorer=explorer, specter=app.specter, rand=rand)
+    return render_template("wallet_receive.html", wallet_alias=wallet_alias, wallet=wallet, specter=app.specter, rand=rand)
 
 @app.route('/get_fee/<blocks>')
 @login_required

--- a/src/cryptoadvance/specter/logic.py
+++ b/src/cryptoadvance/specter/logic.py
@@ -87,6 +87,8 @@ class Specter:
                 "protocol": "http"          # https for the future
             },
             "auth": "none",
+            "mainnet_explorer": "https://blockstream.info/",
+            "testnet_explorer": "https://blockstream.info/testnet/",
             # unique id that will be used in wallets path in Bitcoin Core
             # empty by default for backward-compatibility
             "uid": "",
@@ -191,6 +193,22 @@ class Specter:
         ''' simply persisting the current auth-choice '''
         if self.config["auth"] != auth:
             self.config["auth"] = auth
+        self._save()
+    
+    def update_explorers(self, mainnet_explorer, testnet_explorer):
+        ''' update the block explorers urls '''
+
+        # make sure the urls end with a "/"
+        if not mainnet_explorer.endswith("/"):
+            mainnet_explorer += "/"
+        if not testnet_explorer.endswith("/"):
+            testnet_explorer += "/"
+
+        # update the urls in the app config
+        if self.config["mainnet_explorer"] != mainnet_explorer:
+            self.config["mainnet_explorer"] = mainnet_explorer
+        if self.config["testnet_explorer"] != testnet_explorer:
+            self.config["testnet_explorer"] = testnet_explorer
         self._save()
             
 

--- a/src/cryptoadvance/specter/logic.py
+++ b/src/cryptoadvance/specter/logic.py
@@ -87,8 +87,12 @@ class Specter:
                 "protocol": "http"          # https for the future
             },
             "auth": "none",
-            "mainnet_explorer": "https://blockstream.info/",
-            "testnet_explorer": "https://blockstream.info/testnet/",
+            "explorers": {
+                "main": "https://blockstream.info/",
+                "test": "https://blockstream.info/testnet/",
+                "regtest": None,
+                "signet": "https://explorer.bc-2.jp/"
+            },
             # unique id that will be used in wallets path in Bitcoin Core
             # empty by default for backward-compatibility
             "uid": "",
@@ -195,20 +199,16 @@ class Specter:
             self.config["auth"] = auth
         self._save()
     
-    def update_explorers(self, mainnet_explorer, testnet_explorer):
+    def update_explorer(self, explorer):
         ''' update the block explorers urls '''
 
         # make sure the urls end with a "/"
-        if not mainnet_explorer.endswith("/"):
-            mainnet_explorer += "/"
-        if not testnet_explorer.endswith("/"):
-            testnet_explorer += "/"
+        if not explorer.endswith("/"):
+            explorer += "/"
 
         # update the urls in the app config
-        if self.config["mainnet_explorer"] != mainnet_explorer:
-            self.config["mainnet_explorer"] = mainnet_explorer
-        if self.config["testnet_explorer"] != testnet_explorer:
-            self.config["testnet_explorer"] = testnet_explorer
+        if self.config["explorers"][self.chain] != explorer:
+            self.config["explorers"][self.chain] = explorer
         self._save()
             
 
@@ -234,6 +234,13 @@ class Specter:
     @property
     def chain(self):
         return self._info["chain"]
+
+    @property
+    def explorer(self):
+        if "explorers" in self.config and self.chain in self.config["explorers"]:
+            return self.config["explorers"][self.chain]
+        else:
+            return None
     
     
 class DeviceManager:

--- a/src/cryptoadvance/specter/templates/settings.html
+++ b/src/cryptoadvance/specter/templates/settings.html
@@ -24,11 +24,8 @@
   			<option value="rpcpasswordaspin" {% if auth=="rpcpasswordaspin" %} selected="selected"{% endif %}>RPC password as Pin</option>
 		</select>
 		<br><br>
-		Block explorer URL (mainnet):<br>
-		<input type="url" name="mainnet_explorer" value="{{mainnet_explorer}}">
-		<br><br>
-		Block explorer URL (testnet):<br>
-		<input type="url" name="testnet_explorer" value="{{testnet_explorer}}">
+		Block explorer URL ({{specter.chain}}):<br>
+		<input type="url" name="explorer" value="{{explorer}}">
 		<br><br>
 		<div class="row">
 			<button type="submit" class="btn" name="action" value="test">

--- a/src/cryptoadvance/specter/templates/settings.html
+++ b/src/cryptoadvance/specter/templates/settings.html
@@ -24,6 +24,12 @@
   			<option value="rpcpasswordaspin" {% if auth=="rpcpasswordaspin" %} selected="selected"{% endif %}>RPC password as Pin</option>
 		</select>
 		<br><br>
+		Block explorer URL (mainnet):<br>
+		<input type="url" name="mainnet_explorer" value="{{mainnet_explorer}}">
+		<br><br>
+		Block explorer URL (testnet):<br>
+		<input type="url" name="testnet_explorer" value="{{testnet_explorer}}">
+		<br><br>
 		<div class="row">
 			<button type="submit" class="btn" name="action" value="test">
 				Test

--- a/src/cryptoadvance/specter/templates/wallet_receive.html
+++ b/src/cryptoadvance/specter/templates/wallet_receive.html
@@ -7,10 +7,7 @@
 	<a href="/wallets/{{wallet['alias']}}/send/" class="btn radio">Send</a>
 	<a href="/wallets/{{wallet['alias']}}/settings/" class="btn radio right">Settings</a>
 </div>
-{% set url="https://blockstream.info/" %}
-{% if specter.chain == "test" %}
-{% set url="https://blockstream.info/testnet/" %}
-{% endif %}
+{% set url=explorer %}
 {% if specter.chain == "regtest" %}
 {% set url="#" %}
 {% endif %}

--- a/src/cryptoadvance/specter/templates/wallet_receive.html
+++ b/src/cryptoadvance/specter/templates/wallet_receive.html
@@ -7,10 +7,6 @@
 	<a href="/wallets/{{wallet['alias']}}/send/" class="btn radio">Send</a>
 	<a href="/wallets/{{wallet['alias']}}/settings/" class="btn radio right">Settings</a>
 </div>
-{% set url=explorer %}
-{% if specter.chain == "regtest" %}
-{% set url="#" %}
-{% endif %}
 <div class="center">
 <span>
 	Address #{{wallet['address_index']+1}}<br>
@@ -53,8 +49,8 @@ It has an address index inluded in the QR code.</center></div>
 					<img src="/static/img/{{tx['category']}}_icon.svg"/>
 					{%endif%}
 				</td>
-				<td class="tx scroll"><a target="blank" href="{{url}}tx/{{tx['txid']}}">{{tx["txid"]}}</a></td>
-				<td class="tx scroll"><a target="blank" href="{{url}}address/{{tx['address']}}">{{tx["address"]}}</a></td>
+				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}tx/{{tx['txid']}}">{{tx["txid"]}}</a></td>
+				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}address/{{tx['address']}}">{{tx["address"]}}</a></td>
 				<td>{{tx["amount"]}}</td><td>
 				{%if tx["confirmations"] == 0 %}
 					Pending

--- a/src/cryptoadvance/specter/templates/wallet_tx.html
+++ b/src/cryptoadvance/specter/templates/wallet_tx.html
@@ -7,13 +7,6 @@
 	<a href="/wallets/{{wallet['alias']}}/send/" class="btn radio">Send</a>
 	<a href="/wallets/{{wallet['alias']}}/settings/" class="btn radio right">Settings</a>
 </div>
-{% set url=explorer %}
-{% if specter.chain == "regtest" %}
-{% set url="#" %}
-{% endif %}
-{% if specter.chain == "signet" %}
-{% set url="https://explorer.bc-2.jp/" %}
-{% endif %}
 {% if ( wallet.fullbalance ) is not none %}
 <h1><small style="line-height:30px">Total balance:<br></small><span style="color: #fff">
 	{{ "%0.8f" % ( wallet.fullbalance ) | float }}
@@ -50,8 +43,8 @@
 						{% endif %}
 					{% endif %}
 				</td>
-				<td class="tx scroll"><a target="blank" href="{{url}}tx/{{tx['txid']}}">{{tx["txid"]}}</a></td>
-				<td class="tx scroll"><a target="blank" href="{{url}}address/{{tx['address']}}">{{tx["address"]}}</a></td>
+				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}tx/{{tx['txid']}}">{{tx["txid"]}}</a></td>
+				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}address/{{tx['address']}}">{{tx["address"]}}</a></td>
 				<td>{{tx["amount"]}}</td><td>
 				{%if tx["confirmations"] == 0 %}
 					Pending

--- a/src/cryptoadvance/specter/templates/wallet_tx.html
+++ b/src/cryptoadvance/specter/templates/wallet_tx.html
@@ -7,10 +7,7 @@
 	<a href="/wallets/{{wallet['alias']}}/send/" class="btn radio">Send</a>
 	<a href="/wallets/{{wallet['alias']}}/settings/" class="btn radio right">Settings</a>
 </div>
-{% set url="https://blockstream.info/" %}
-{% if specter.chain == "test" %}
-{% set url="https://blockstream.info/testnet/" %}
-{% endif %}
+{% set url=explorer %}
 {% if specter.chain == "regtest" %}
 {% set url="#" %}
 {% endif %}


### PR DESCRIPTION
Support customizing the block explorer URLs for `mainnet` and `testnet` from the settings page.
This gives both a new customization option for the user and enables using a local block explorer like [btc-rpc-explorer](https://github.com/janoside/btc-rpc-explorer/) which connects directly to the user's full node (instead of relying on 3rd party data). This update keeps [blockstream.info](https://blockstream.info) as the default block explorer.

<img width="711" alt="Specter Settings" src="https://user-images.githubusercontent.com/10667901/76882021-b6322c00-6882-11ea-80ff-c37255cca721.png">
