### PR TITLE
Addresses tab + address labelling and avoid address reuse

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -130,7 +130,7 @@ As a quite young project, we don't have many dependencies yet and as a quite sec
 
 ## Some words specific to the frontend
 Also for that reason, we're avoiding npm and manage javascript dependencies by hand or do stuff manually. Feel free to use plain javascript in pages.
-However, we're planning (or even have started) to use vue.js without using vue.js-components (that would require a build). So feel free to use vue.js but either make a thoughtfull proposal on how to manage the vue.js build or don't use vue.js-components. Also, specter-desktop is not a one-page-app and also doesn't want to become one.
+However, we're planning (or even have started) to use vue.js without using vue.js-components (that would require a build). So feel free to use vue.js but either make a thoughtful proposal on how to manage the vue.js build or don't use vue.js-components. Also, specter-desktop is not a one-page-app and also doesn't want to become one.
 This [security-link](https://vuejs.org/v2/guide/security.html) might be interesting when developing vue.js.
 
 We're aware that currently the app is not very compatible on different browsers and there is no clear strategy yet on how (and whether at all) to fix that. High level consultancy help on that would be appreciated even so (or especially when) you take the above security/dependency requirements into account.

--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -397,6 +397,7 @@ def wallet_send(wallet_alias):
         return render_template("base.html", error="Wallet not found", specter=app.specter, rand=rand)
     psbt = None
     address = ""
+    label = ""
     amount = 0
     fee_rate = 0.0
     err = None
@@ -404,8 +405,9 @@ def wallet_send(wallet_alias):
         action = request.form['action']
         if action == "createpsbt":
             address = request.form['address']
-            if "label" in request.form and request.form['label'] != "":
-                wallet.setlabel(address, request.form["label"])
+            label = request.form['label']
+            if request.form['label'] != "":
+                wallet.setlabel(address, label)
             amount = float(request.form['amount'])
             subtract = bool(request.form.get("subtract", False))
             fee_unit = request.form.get('fee_unit')
@@ -428,7 +430,7 @@ def wallet_send(wallet_alias):
                                 amount = v["value"]
             except Exception as e:
                 err = "%r" % e
-    return render_template("wallet_send.html", psbt=psbt, address=address, amount=amount, 
+    return render_template("wallet_send.html", psbt=psbt, address=address, label=label, amount=amount, 
                                                 wallet_alias=wallet_alias, wallet=wallet, 
                                                 specter=app.specter, rand=rand, error=err)
 

--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -112,7 +112,6 @@ def settings():
     protocol = 'http'
     explorer = app.specter.explorer
     auth = app.specter.config["auth"]
-    avoidreuse = app.specter.config['avoidreuse']
     if "protocol" in rpc:
         protocol = rpc["protocol"]
     test = None
@@ -123,7 +122,6 @@ def settings():
         host = request.form['host']
         explorer = request.form["explorer"]
         auth = request.form['auth']
-        avoidreuse = 'avoidreuse' in request.form.keys()
         action = request.form['action']
         # protocol://host
         if "://" in host:
@@ -153,7 +151,6 @@ def settings():
                 app.config['LOGIN_DISABLED'] = False
             else:
                 app.config['LOGIN_DISABLED'] = True
-            app.specter.update_avoidreuse(avoidreuse)
             app.specter.check()
             return redirect("/")
     else:
@@ -167,7 +164,6 @@ def settings():
                             protocol=protocol,
                             explorer=explorer,
                             auth=auth,
-                            avoidreuse=avoidreuse,
                             specter=app.specter,
                             rand=rand)
 
@@ -349,6 +345,17 @@ def wallet_tx(wallet_alias):
 
     return render_template("wallet_tx.html", wallet_alias=wallet_alias, wallet=wallet, specter=app.specter, rand=rand)
 
+@app.route('/wallets/<wallet_alias>/addresses/')
+@login_required
+def wallet_addresses(wallet_alias):
+    app.specter.check()
+    try:
+        wallet = app.specter.wallets.get_by_alias(wallet_alias)
+    except:
+        return render_template("base.html", error="Wallet not found", specter=app.specter, rand=rand)
+
+    return render_template("wallet_addresses.html", wallet_alias=wallet_alias, wallet=wallet, specter=app.specter, rand=rand)
+
 @app.route('/wallets/<wallet_alias>/receive/', methods=['GET', 'POST'])
 @login_required
 def wallet_receive(wallet_alias):
@@ -361,7 +368,7 @@ def wallet_receive(wallet_alias):
         action = request.form['action']
         if action == "newaddress":
             wallet.getnewaddress()
-    if wallet.txonaddr > 0 and app.specter.config['avoidreuse']:
+    if wallet.txoncurrentaddr > 0:
         wallet.getnewaddress()
     return render_template("wallet_receive.html", wallet_alias=wallet_alias, wallet=wallet, specter=app.specter, rand=rand)
 

--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -404,6 +404,8 @@ def wallet_send(wallet_alias):
         action = request.form['action']
         if action == "createpsbt":
             address = request.form['address']
+            if "label" in request.form and request.form['label'] != "":
+                wallet.setlabel(address, request.form["label"])
             amount = float(request.form['amount'])
             subtract = bool(request.form.get("subtract", False))
             fee_unit = request.form.get('fee_unit')

--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -345,7 +345,7 @@ def wallet_tx(wallet_alias):
 
     return render_template("wallet_tx.html", wallet_alias=wallet_alias, wallet=wallet, specter=app.specter, rand=rand)
 
-@app.route('/wallets/<wallet_alias>/addresses/')
+@app.route('/wallets/<wallet_alias>/addresses/', methods=['GET', 'POST'])
 @login_required
 def wallet_addresses(wallet_alias):
     app.specter.check()
@@ -353,7 +353,12 @@ def wallet_addresses(wallet_alias):
         wallet = app.specter.wallets.get_by_alias(wallet_alias)
     except:
         return render_template("base.html", error="Wallet not found", specter=app.specter, rand=rand)
-
+    if request.method == "POST":
+        action = request.form['action']
+        if action == "updatelabel":
+            label = request.form['label']
+            address = request.form['addr']
+            wallet.setlabel(address, label)
     return render_template("wallet_addresses.html", wallet_alias=wallet_alias, wallet=wallet, specter=app.specter, rand=rand)
 
 @app.route('/wallets/<wallet_alias>/receive/', methods=['GET', 'POST'])
@@ -368,6 +373,9 @@ def wallet_receive(wallet_alias):
         action = request.form['action']
         if action == "newaddress":
             wallet.getnewaddress()
+        elif action == "updatelabel":
+            label = request.form['label']
+            wallet.setlabel(wallet['address'], label)
     if wallet.txoncurrentaddr > 0:
         wallet.getnewaddress()
     return render_template("wallet_receive.html", wallet_alias=wallet_alias, wallet=wallet, specter=app.specter, rand=rand)

--- a/src/cryptoadvance/specter/logic.py
+++ b/src/cryptoadvance/specter/logic.py
@@ -756,7 +756,7 @@ class Wallet(dict):
     
     def getaddressname(self, addr, addr_idx):
         address_info = self.cli.getaddressinfo(addr)
-        if "label" not in address_info or address_info["label"] == "" and addr_idx > -1:
+        if ("label" not in address_info or address_info["label"] == "") and addr_idx > -1:
             self.setlabel(addr, "Address #{}".format(addr_idx))
             address_info["label"] = "Address #{}".format(addr_idx)
         return addr if ("label" not in address_info or address_info["label"] == "") else address_info["label"]

--- a/src/cryptoadvance/specter/logic.py
+++ b/src/cryptoadvance/specter/logic.py
@@ -777,10 +777,6 @@ class Wallet(dict):
     @property
     def addresses(self):
         return [self.get_address(idx) for idx in range(0,self._dict["address_index"] + 1)]
-    
-    @property
-    def change_addresses(self):
-        return [self.get_address(idx, change=True) for idx in range(0,self._dict["change_index"] + 1)]
 
     def createpsbt(self, address:str, amount:float, subtract:bool=False, fee_rate:float=0.0, fee_unit="SAT_B"):
         """

--- a/src/cryptoadvance/specter/logic.py
+++ b/src/cryptoadvance/specter/logic.py
@@ -754,8 +754,11 @@ class Wallet(dict):
     def setlabel(self, addr, label):
         self.cli.setlabel(addr, label)
     
-    def getaddressname(self, addr):
+    def getaddressname(self, addr, addr_idx):
         address_info = self.cli.getaddressinfo(addr)
+        if "label" not in address_info or address_info["label"] == "" and addr_idx > -1:
+            self.setlabel(addr, "Address #{}".format(addr_idx))
+            address_info["label"] = "Address #{}".format(addr_idx)
         return addr if ("label" not in address_info or address_info["label"] == "") else address_info["label"]
 
     @property    

--- a/src/cryptoadvance/specter/logic.py
+++ b/src/cryptoadvance/specter/logic.py
@@ -756,7 +756,7 @@ class Wallet(dict):
     
     def getaddressname(self, addr):
         address_info = self.cli.getaddressinfo(addr)
-        return addr if address_info["label"] == "" else address_info["label"]
+        return addr if ("label" not in address_info or address_info["label"] == "") else address_info["label"]
 
     @property    
     def fullbalance(self):

--- a/src/cryptoadvance/specter/logic.py
+++ b/src/cryptoadvance/specter/logic.py
@@ -93,6 +93,7 @@ class Specter:
                 "regtest": None,
                 "signet": "https://explorer.bc-2.jp/"
             },
+            "avoidreuse": True,
             # unique id that will be used in wallets path in Bitcoin Core
             # empty by default for backward-compatibility
             "uid": "",
@@ -209,6 +210,11 @@ class Specter:
         # update the urls in the app config
         if self.config["explorers"][self.chain] != explorer:
             self.config["explorers"][self.chain] = explorer
+
+    def update_avoidreuse(self, avoidreuse):
+        ''' update avoid reuse if changed '''
+        if self.config["avoidreuse"] != avoidreuse:
+            self.config["avoidreuse"] = avoidreuse
         self._save()
             
 
@@ -766,6 +772,12 @@ class Wallet(dict):
         h256 = hashlib.sha256(self.descriptor.encode()).digest()
         h160 = hashlib.new('ripemd160', h256).digest()
         return h160[:4]
+
+    @property
+    def txonaddr(self):
+        addr = self["address"]
+        txlist = [tx for tx in self.transactions if tx["address"] == addr]
+        return len(txlist)
 
     def createpsbt(self, address:str, amount:float, subtract:bool=False, fee_rate:float=0.0, fee_unit="SAT_B"):
         """

--- a/src/cryptoadvance/specter/logic.py
+++ b/src/cryptoadvance/specter/logic.py
@@ -532,6 +532,7 @@ class Wallet(dict):
         # address derivation will also refill the keypool if necessary
         if self._dict["address"] is None:
             self._dict["address"] = self.get_address(0)
+            self.setlabel(self._dict["address"], "Address #0")
         if self._dict["change_address"] is None:
             self._dict["change_address"] = self.get_address(0, change=True)
         self.getdata()
@@ -614,6 +615,7 @@ class Wallet(dict):
     def getnewaddress(self):
         self._dict["address_index"] += 1
         addr = self.get_address(self._dict["address_index"])
+        self.setlabel(addr, "Address #{}".format(self._dict["address_index"]))
         self._dict["address"] = addr
         self._commit()
         return addr
@@ -748,6 +750,13 @@ class Wallet(dict):
     def txonaddr(self, addr):
         txlist = [tx for tx in self.transactions if tx["address"] == addr]
         return len(txlist)
+
+    def setlabel(self, addr, label):
+        self.cli.setlabel(addr, label)
+    
+    def getaddressname(self, addr):
+        address_info = self.cli.getaddressinfo(addr)
+        return addr if address_info["label"] == "" else address_info["label"]
 
     @property    
     def fullbalance(self):

--- a/src/cryptoadvance/specter/templates/settings.html
+++ b/src/cryptoadvance/specter/templates/settings.html
@@ -27,9 +27,6 @@
 		Block explorer URL ({{specter.chain}}):<br>
 		<input type="url" name="explorer" value="{{explorer}}">
 		<br><br>
-		Generate new address per transaction (recommended):
-		<input style="width: auto;" type="checkbox" name="avoidreuse" {% if avoidreuse %} checked {% endif %}>
-		<br><br>
 		<div class="row">
 			<button type="submit" class="btn" name="action" value="test">
 				Test

--- a/src/cryptoadvance/specter/templates/settings.html
+++ b/src/cryptoadvance/specter/templates/settings.html
@@ -27,6 +27,9 @@
 		Block explorer URL ({{specter.chain}}):<br>
 		<input type="url" name="explorer" value="{{explorer}}">
 		<br><br>
+		Generate new address per transaction (recommended):
+		<input style="width: auto;" type="checkbox" name="avoidreuse" {% if avoidreuse %} checked {% endif %}>
+		<br><br>
 		<div class="row">
 			<button type="submit" class="btn" name="action" value="test">
 				Test

--- a/src/cryptoadvance/specter/templates/wallet_addresses.html
+++ b/src/cryptoadvance/specter/templates/wallet_addresses.html
@@ -51,7 +51,7 @@
 <br>
 <h1>Address History</h1>
 {% for address in wallet.addresses | reverse %}
-{% set addrlabel = wallet.getaddressname(address) %}
+{% set addrlabel = wallet.getaddressname(address, wallet.addresses | length - loop.index0 - 1) %}
 <div class="table-holder">
 	<br>
 	<form action="./" method="POST">

--- a/src/cryptoadvance/specter/templates/wallet_addresses.html
+++ b/src/cryptoadvance/specter/templates/wallet_addresses.html
@@ -1,5 +1,37 @@
 {% extends "base.html" %}
 {% block main %}
+<style>
+	.address {
+		text-decoration: none;
+		color: inherit;
+		float: right;
+		margin-left: 10px;
+	}
+	.address:hover {
+		color: #fff;
+		text-decoration: underline;
+	}
+	.label {
+		text-align: left;
+		padding-left: 0;
+		float: left;
+		width: auto;
+	}
+	.update {
+		display: none;
+		float: left;
+		margin-right: 5px;
+		margin-left: 5px;
+	}
+	.cancel {
+		display: none;
+		float: left;
+	}
+	.edit {
+		float: left;
+		margin-top: 8px;
+	}
+</style>
 <h1>{{wallet.name}}</h1>
 <div class="row padded">
 	<a href="/wallets/{{wallet['alias']}}/tx/" class="btn radio left">Transactions</a>
@@ -19,10 +51,18 @@
 <br>
 <h1>Address History</h1>
 {% for address in wallet.addresses | reverse %}
+{% set addrlabel = wallet.getaddressname(address) %}
 <div class="table-holder">
 	<br>
-	<h2> Address {{ wallet.addresses | length - loop.index0 }}: <a style="color: inherit; text-decoration: none;" target="blank" class="tx" href="{{specter.explorer}}address/{{address}}">{{address}}</a></h2>
-	<br>
+	<form action="./" method="POST">
+		<input type="text" class="label" autocomplete="off" spellcheck="false" id="{{"label" ~ loop.index0}}" name="label" value="{{addrlabel}}" style="border: none; font-size: 1.5em;" disabled />
+		<input type="hidden" name="addr" value="{{address}}"/>
+		<button type="submit" class="btn update" id="{{"save" ~ loop.index0}}" name="action" value="updatelabel">Update</button>
+		<button type="button" class="btn cancel" id="{{"cancel" ~ loop.index0}}" onclick="toggleEdit('{{ loop.index0 }}', '{{ addrlabel }}')">Cancel</button>
+		<button type="button" class="btn edit" id="{{"edit" ~ loop.index0}}" onclick="toggleEdit('{{ loop.index0 }}', '{{ addrlabel }}')">Edit Label</button>
+		<br>
+		<a target="blank" class="address" href="{{specter.explorer}}address/{{address}}">{{address}}</a>
+	</form><br><br>
 	<table>
 		<thead>
 		<tr>
@@ -46,7 +86,7 @@
 					{%endif%}
 				</td>
 				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}tx/{{tx['txid']}}">{{tx["txid"]}}</a></td>
-				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}address/{{tx['address']}}">{{tx["address"]}}</a></td>
+				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}address/{{tx['address']}}">{{addrlabel}}</a></td>
 				<td>{{tx["amount"]}}</td><td>
 				{%if tx["confirmations"] == 0 %}
 					Pending
@@ -65,4 +105,27 @@
 </div>
 {% endfor %}
 {% endif %}
+<script>
+	function toggleEdit(id, addrlabel) {
+		var edit_button_display = document.getElementById("edit"+id).style.display
+		if (edit_button_display === 'none'){
+			document.getElementById("label" +id).disabled = 'true'
+			document.getElementById("label" +id).style.border = 'none'
+			document.getElementById("label" + id).style.textAlign = 'left';
+			document.getElementById("label" + id).style.fontSize = '1.5em';
+			document.getElementById("label" +id).value = addrlabel
+			document.getElementById("edit" +id).style.display = 'block'
+			document.getElementById("cancel" +id).style.display = 'none'
+			document.getElementById("save" +id).style.display = 'none'
+		} else{
+			document.getElementById("label" + id).disabled = ''
+			document.getElementById("label" + id).style.removeProperty('border');
+			document.getElementById("label" + id).style.textAlign = 'center';
+			document.getElementById("label" + id).style.removeProperty('font-size');
+			document.getElementById("edit" + id).style.display = 'none'
+			document.getElementById("cancel" + id).style.display = 'block'
+			document.getElementById("save" + id).style.display = 'block'
+		}
+	}
+</script>
 {% endblock %}

--- a/src/cryptoadvance/specter/templates/wallet_addresses.html
+++ b/src/cryptoadvance/specter/templates/wallet_addresses.html
@@ -18,59 +18,10 @@
 </small></h1>
 <br>
 <h1>Address History</h1>
-{% for address in wallet.addresses %}
+{% for address in wallet.addresses | reverse %}
 <div class="table-holder">
 	<br>
-	<h2> Address: <a style="color: inherit; text-decoration: none;" target="blank" class="tx" href="{{specter.explorer}}address/{{address}}">{{address}}</a></h2>
-	<br>
-	<table>
-		<thead>
-		<tr>
-			<th></th><th>TxID</th><th>Address</th><th>Amount</th><th>Confirmations</th><th>Time</th>
-		</tr>
-		</thead>
-		<tbody>
-			{% if wallet.txonaddr(address) > 0 %}
-			{% for tx in wallet.transactions %}
-			{% if tx['address'] == address %}
-			{%if tx["confirmations"] == 0 %}
-			<tr class="unconfirmed">
-			{%else%}
-			<tr>
-			{%endif%}
-				<td>
-					{%if tx["confirmations"] == 0 %}
-					<img src="/static/img/unconfirmed_{{tx['category']}}_icon.svg"/>
-					{% else %}
-					<img src="/static/img/{{tx['category']}}_icon.svg"/>
-					{%endif%}
-				</td>
-				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}tx/{{tx['txid']}}">{{tx["txid"]}}</a></td>
-				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}address/{{tx['address']}}">{{tx["address"]}}</a></td>
-				<td>{{tx["amount"]}}</td><td>
-				{%if tx["confirmations"] == 0 %}
-					Pending
-				{% else %}
-					{{tx["confirmations"]}}
-				{% endif %}
-				</td>
-				<td>{{tx["time"] | datetime}}</td></tr>
-			{% endif %}
-			{% endfor %}
-			{% else %}
-			<td></td><td>No transactions yet.</td><td></td><td></td><td></td><td></td>
-			{% endif %}
-		</tbody>
-	</table>
-</div>
-{% endfor %}
-<br>
-<br>
-<h1>Change Address History</h1>
-{% for address in wallet.change_addresses %}
-<div class="table-holder">
-	<br>
-	<h2> Address: <a style="color: inherit; text-decoration: none;" target="blank" class="tx" href="{{specter.explorer}}address/{{address}}">{{address}}</a></h2>
+	<h2> Address {{ wallet.addresses | length - loop.index0 }}: <a style="color: inherit; text-decoration: none;" target="blank" class="tx" href="{{specter.explorer}}address/{{address}}">{{address}}</a></h2>
 	<br>
 	<table>
 		<thead>

--- a/src/cryptoadvance/specter/templates/wallet_addresses.html
+++ b/src/cryptoadvance/specter/templates/wallet_addresses.html
@@ -1,0 +1,117 @@
+{% extends "base.html" %}
+{% block main %}
+<h1>{{wallet.name}}</h1>
+<div class="row padded">
+	<a href="/wallets/{{wallet['alias']}}/tx/" class="btn radio left">Transactions</a>
+	<a href="/wallets/{{wallet['alias']}}/addresses/" class="btn radio checked">Addresses</a>
+	<a href="/wallets/{{wallet['alias']}}/receive/" class="btn radio">Receive</a>
+	<a href="/wallets/{{wallet['alias']}}/send/" class="btn radio">Send</a>
+	<a href="/wallets/{{wallet['alias']}}/settings/" class="btn radio right">Settings</a>
+</div>
+{% if ( wallet.fullbalance ) is not none %}
+<h1><small style="line-height:30px">Total balance:<br></small><span style="color: #fff">
+	{{ "%0.8f" % ( wallet.fullbalance ) | float }}
+	{% if specter.chain !='main' %}t{%endif%}BTC
+	{% if wallet.balance["untrusted_pending"] > 0 %}</span><br><small>
+	( {{ "%0.8f" % wallet.balance["trusted"] | float }} confirmed, {{"%0.8f" % wallet.balance["untrusted_pending"] | float}} pending )
+	{% endif %}
+</small></h1>
+<br>
+<h1>Address History</h1>
+{% for address in wallet.addresses %}
+<div class="table-holder">
+	<br>
+	<h2> Address: <a style="color: inherit; text-decoration: none;" target="blank" class="tx" href="{{specter.explorer}}address/{{address}}">{{address}}</a></h2>
+	<br>
+	<table>
+		<thead>
+		<tr>
+			<th></th><th>TxID</th><th>Address</th><th>Amount</th><th>Confirmations</th><th>Time</th>
+		</tr>
+		</thead>
+		<tbody>
+			{% if wallet.txonaddr(address) > 0 %}
+			{% for tx in wallet.transactions %}
+			{% if tx['address'] == address %}
+			{%if tx["confirmations"] == 0 %}
+			<tr class="unconfirmed">
+			{%else%}
+			<tr>
+			{%endif%}
+				<td>
+					{%if tx["confirmations"] == 0 %}
+					<img src="/static/img/unconfirmed_{{tx['category']}}_icon.svg"/>
+					{% else %}
+					<img src="/static/img/{{tx['category']}}_icon.svg"/>
+					{%endif%}
+				</td>
+				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}tx/{{tx['txid']}}">{{tx["txid"]}}</a></td>
+				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}address/{{tx['address']}}">{{tx["address"]}}</a></td>
+				<td>{{tx["amount"]}}</td><td>
+				{%if tx["confirmations"] == 0 %}
+					Pending
+				{% else %}
+					{{tx["confirmations"]}}
+				{% endif %}
+				</td>
+				<td>{{tx["time"] | datetime}}</td></tr>
+			{% endif %}
+			{% endfor %}
+			{% else %}
+			<td></td><td>No transactions yet.</td><td></td><td></td><td></td><td></td>
+			{% endif %}
+		</tbody>
+	</table>
+</div>
+{% endfor %}
+<br>
+<br>
+<h1>Change Address History</h1>
+{% for address in wallet.change_addresses %}
+<div class="table-holder">
+	<br>
+	<h2> Address: <a style="color: inherit; text-decoration: none;" target="blank" class="tx" href="{{specter.explorer}}address/{{address}}">{{address}}</a></h2>
+	<br>
+	<table>
+		<thead>
+		<tr>
+			<th></th><th>TxID</th><th>Address</th><th>Amount</th><th>Confirmations</th><th>Time</th>
+		</tr>
+		</thead>
+		<tbody>
+			{% if wallet.txonaddr(address) > 0 %}
+			{% for tx in wallet.transactions %}
+			{% if tx['address'] == address %}
+			{%if tx["confirmations"] == 0 %}
+			<tr class="unconfirmed">
+			{%else%}
+			<tr>
+			{%endif%}
+				<td>
+					{%if tx["confirmations"] == 0 %}
+					<img src="/static/img/unconfirmed_{{tx['category']}}_icon.svg"/>
+					{% else %}
+					<img src="/static/img/{{tx['category']}}_icon.svg"/>
+					{%endif%}
+				</td>
+				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}tx/{{tx['txid']}}">{{tx["txid"]}}</a></td>
+				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}address/{{tx['address']}}">{{tx["address"]}}</a></td>
+				<td>{{tx["amount"]}}</td><td>
+				{%if tx["confirmations"] == 0 %}
+					Pending
+				{% else %}
+					{{tx["confirmations"]}}
+				{% endif %}
+				</td>
+				<td>{{tx["time"] | datetime}}</td></tr>
+			{% endif %}
+			{% endfor %}
+			{% else %}
+			<td></td><td>No transactions yet.</td><td></td><td></td><td></td><td></td>
+			{% endif %}
+		</tbody>
+	</table>
+</div>
+{% endfor %}
+{% endif %}
+{% endblock %}

--- a/src/cryptoadvance/specter/templates/wallet_receive.html
+++ b/src/cryptoadvance/specter/templates/wallet_receive.html
@@ -10,7 +10,7 @@
 </div>
 <div class="center">
 <form action="./" method="POST">
-	{% set addrlabel = wallet.getaddressname(wallet['address']) %}
+	{% set addrlabel = wallet.getaddressname(wallet['address'], wallet['address_index']) %}
 	<input type="text" autocomplete="off" spellcheck="false" id="label" name="label" value="{{addrlabel}}" style="text-align: center; border: none; font-size: 1.5em;" disabled>
 	<button type="submit" id="save" name="action" value="updatelabel" class="btn centered" style="display: none;">Update</button>
 	<button type="button" id="cancel" onclick="toggleEdit()" class="btn centered" style="display: none;">Cancel</button>

--- a/src/cryptoadvance/specter/templates/wallet_receive.html
+++ b/src/cryptoadvance/specter/templates/wallet_receive.html
@@ -9,12 +9,16 @@
 	<a href="/wallets/{{wallet['alias']}}/settings/" class="btn radio right">Settings</a>
 </div>
 <div class="center">
-<span>
-	Address #{{wallet['address_index']+1}}<br>
-	<small>( scan to verify )</small>
-</span><br><br>
+<form action="./" method="POST">
+	{% set addrlabel = wallet.getaddressname(wallet['address']) %}
+	<input type="text" autocomplete="off" spellcheck="false" id="label" name="label" value="{{addrlabel}}" style="text-align: center; border: none; font-size: 1.5em;" disabled>
+	<button type="submit" id="save" name="action" value="updatelabel" class="btn centered" style="display: none;">Update</button>
+	<button type="button" id="cancel" onclick="toggleEdit()" class="btn centered" style="display: none;">Cancel</button>
+	<button type="button" id="edit" onclick="toggleEdit()" name="action" value="updatelabel" class="btn centered">Edit Label</button>
+</form><br><br>
 <img src="{{ qrcode( 'bitcoin:'+wallet['address']+'?index='+(wallet['address_index']|string) ) }}" class="qr alt-qr" width="300px" />
 <br>
+<small>( scan to verify )</small>
 <div class="padded">{{wallet['address']}}</div>
 </div>
 <form action="./" method="POST">
@@ -24,4 +28,26 @@
 
 <div class="note"><center>Specter can verify this address if you scan it.<br>
 It has an address index included in the QR code.</center></div>
+
+<script>
+	function toggleEdit() {
+		var edit_button_display = document.getElementById("edit").style.display
+		if (edit_button_display === 'none'){
+			document.getElementById("label").disabled = 'true'
+			document.getElementById("label").style.border = 'none'
+			document.getElementById("label").style.fontSize = '1.5em';
+			document.getElementById("label").value = "{{ addrlabel }}"
+			document.getElementById("edit").style.display = 'block'
+			document.getElementById("cancel").style.display = 'none'
+			document.getElementById("save").style.display = 'none'
+		} else{
+			document.getElementById("label").disabled = ''
+			document.getElementById("label").style.removeProperty('border');
+			document.getElementById("label").style.removeProperty('font-size');
+			document.getElementById("edit").style.display = 'none'
+			document.getElementById("cancel").style.display = 'block'
+			document.getElementById("save").style.display = 'block'
+		}
+	}
+</script>
 {% endblock %}

--- a/src/cryptoadvance/specter/templates/wallet_receive.html
+++ b/src/cryptoadvance/specter/templates/wallet_receive.html
@@ -24,9 +24,9 @@
 <div class="note"><center>Specter can verify this address if you scan it.<br>
 It has an address index included in the QR code.</center></div>
 
-{% if (wallet | txonaddr) > 0 %}
+{% if (wallet.txonaddr) > 0 %}
 <div class="padded">
-<h1>Transactions on this address ( {{wallet | txonaddr}} )</h1>
+<h1>Transactions on this address ( {{wallet.txonaddr}} )</h1>
 <div class="table-holder">
 	<table>
 		<thead>

--- a/src/cryptoadvance/specter/templates/wallet_receive.html
+++ b/src/cryptoadvance/specter/templates/wallet_receive.html
@@ -22,7 +22,7 @@
 </form>
 
 <div class="note"><center>Specter can verify this address if you scan it.<br>
-It has an address index inluded in the QR code.</center></div>
+It has an address index included in the QR code.</center></div>
 
 {% if (wallet | txonaddr) > 0 %}
 <div class="padded">

--- a/src/cryptoadvance/specter/templates/wallet_receive.html
+++ b/src/cryptoadvance/specter/templates/wallet_receive.html
@@ -3,6 +3,7 @@
 <h1>{{wallet.name}}</h1>
 <div class="row padded">
 	<a href="/wallets/{{wallet['alias']}}/tx/" class="btn radio left">Transactions</a>
+	<a href="/wallets/{{wallet['alias']}}/addresses/" class="btn radio">Addresses</a>
 	<a href="/wallets/{{wallet['alias']}}/receive/" class="btn radio checked">Receive</a>
 	<a href="/wallets/{{wallet['alias']}}/send/" class="btn radio">Send</a>
 	<a href="/wallets/{{wallet['alias']}}/settings/" class="btn radio right">Settings</a>
@@ -23,46 +24,4 @@
 
 <div class="note"><center>Specter can verify this address if you scan it.<br>
 It has an address index included in the QR code.</center></div>
-
-{% if (wallet.txonaddr) > 0 %}
-<div class="padded">
-<h1>Transactions on this address ( {{wallet.txonaddr}} )</h1>
-<div class="table-holder">
-	<table>
-		<thead>
-		<tr>
-			<th></th><th>TxID</th><th>Address</th><th>Amount</th><th>Confirmations</th><th>Time</th>
-		</tr>
-		</thead>
-		<tbody>
-			{% for tx in wallet.transactions %}
-			{% if tx['address'] == wallet['address'] %}
-			{%if tx["confirmations"] == 0 %}
-			<tr class="unconfirmed">
-			{%else%}
-			<tr>
-			{%endif%}
-				<td>
-					{%if tx["confirmations"] == 0 %}
-					<img src="/static/img/unconfirmed_{{tx['category']}}_icon.svg"/>
-					{% else %}
-					<img src="/static/img/{{tx['category']}}_icon.svg"/>
-					{%endif%}
-				</td>
-				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}tx/{{tx['txid']}}">{{tx["txid"]}}</a></td>
-				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}address/{{tx['address']}}">{{tx["address"]}}</a></td>
-				<td>{{tx["amount"]}}</td><td>
-				{%if tx["confirmations"] == 0 %}
-					Pending
-				{% else %}
-					{{tx["confirmations"]}}
-				{% endif %}
-				</td>
-				<td>{{tx["time"] | datetime}}</td></tr>
-			{% endif %}
-			{% endfor %}
-		</tbody>
-	</table>
-</div>
-{% endif %}
 {% endblock %}

--- a/src/cryptoadvance/specter/templates/wallet_send.html
+++ b/src/cryptoadvance/specter/templates/wallet_send.html
@@ -29,8 +29,8 @@
 <h1>{{wallet.name}}</h1>
 <div class="row padded">
 	<a href="/wallets/{{wallet['alias']}}/tx/" class="btn radio left">Transactions</a>
-	<a href="/wallets/{{wallet['alias']}}/receive/" class="btn radio">Receive</a>
 	<a href="/wallets/{{wallet['alias']}}/addresses/" class="btn radio">Addresses</a>
+	<a href="/wallets/{{wallet['alias']}}/receive/" class="btn radio">Receive</a>
 	<a href="/wallets/{{wallet['alias']}}/send/" class="btn radio checked">Send</a>
 	<a href="/wallets/{{wallet['alias']}}/settings/" class="btn radio right">Settings</a>
 </div>
@@ -46,7 +46,7 @@
 			</div>
 			<br><br>
 			Amount:<br>
-			<input type="number" name="amount" value="{{amount}}" id="amount" max="{{wallet.fullbalance}}" min=0 step="1e-8">
+			<input type="number" name="amount" value="{{amount}}" id="amount" max="{{wallet.fullbalance}}" min=0 step="1e-8" autocomplete="off">
 			<div class="note">Available: {{"%.8f" % wallet.fullbalance}}</div>
 			<div><label><input type="checkbox" class="inline" name="subtract" value="1"> Subtract from amount</label></div>
 			<br><br>
@@ -58,7 +58,7 @@
 			<input type="hidden" id="fee_unit" name="fee_unit" value="">
 			<div id = "fee_manual" style="display:none">
 			Fee rate:<br>
-			<input type="number" class="fee_rate" name="fee_rate" id="fee_rate" max="100" min=0 step="0.25"> sat/B
+			<input type="number" class="fee_rate" name="fee_rate" id="fee_rate" max="100" min=0 step="0.25" autocomplete="off"> sat/B
 			<div class="note">leave blank to set automatically</div>
 			<br><br>
 			</div>

--- a/src/cryptoadvance/specter/templates/wallet_send.html
+++ b/src/cryptoadvance/specter/templates/wallet_send.html
@@ -44,6 +44,9 @@
 				<input type="text" id="address" name="address" value="{{address}}"> &nbsp;
 				<a class="btn" id="scanme"><img src="/static/img/qr_tiny.svg"/> Scan</a>
 			</div>
+			<br>
+			Address label (optional):<br>
+			<input type="text" id="label" name="label" value="{{label}}">
 			<br><br>
 			Amount:<br>
 			<input type="number" name="amount" value="{{amount}}" id="amount" max="{{wallet.fullbalance}}" min=0 step="1e-8" autocomplete="off">

--- a/src/cryptoadvance/specter/templates/wallet_send.html
+++ b/src/cryptoadvance/specter/templates/wallet_send.html
@@ -30,6 +30,7 @@
 <div class="row padded">
 	<a href="/wallets/{{wallet['alias']}}/tx/" class="btn radio left">Transactions</a>
 	<a href="/wallets/{{wallet['alias']}}/receive/" class="btn radio">Receive</a>
+	<a href="/wallets/{{wallet['alias']}}/addresses/" class="btn radio">Addresses</a>
 	<a href="/wallets/{{wallet['alias']}}/send/" class="btn radio checked">Send</a>
 	<a href="/wallets/{{wallet['alias']}}/settings/" class="btn radio right">Settings</a>
 </div>

--- a/src/cryptoadvance/specter/templates/wallet_settings.html
+++ b/src/cryptoadvance/specter/templates/wallet_settings.html
@@ -3,6 +3,7 @@
 <h1>{{wallet.name}}</h1>
 <div class="row padded">
 	<a href="/wallets/{{wallet['alias']}}/tx/" class="btn radio left">Transactions</a>
+	<a href="/wallets/{{wallet['alias']}}/addresses/" class="btn radio">Addresses</a>
 	<a href="/wallets/{{wallet['alias']}}/receive/" class="btn radio">Receive</a>
 	<a href="/wallets/{{wallet['alias']}}/send/" class="btn radio">Send</a>
 	<a href="/wallets/{{wallet['alias']}}/settings/" class="btn radio right checked">Settings</a>

--- a/src/cryptoadvance/specter/templates/wallet_tx.html
+++ b/src/cryptoadvance/specter/templates/wallet_tx.html
@@ -46,7 +46,7 @@
 					{% endif %}
 				</td>
 				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}tx/{{tx['txid']}}">{{tx["txid"]}}</a></td>
-				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}address/{{tx['address']}}">{{wallet.getaddressname(tx["address"])}}</a></td>
+				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}address/{{tx['address']}}">{{wallet.getaddressname(tx["address"], -1)}}</a></td>
 				<td>{{tx["amount"]}}</td><td>
 				{%if tx["confirmations"] == 0 %}
 					Pending

--- a/src/cryptoadvance/specter/templates/wallet_tx.html
+++ b/src/cryptoadvance/specter/templates/wallet_tx.html
@@ -3,6 +3,7 @@
 <h1>{{wallet.name}}</h1>
 <div class="row padded">
 	<a href="/wallets/{{wallet['alias']}}/tx/" class="btn radio left checked">Transactions</a>
+	<a href="/wallets/{{wallet['alias']}}/addresses/" class="btn radio">Addresses</a>
 	<a href="/wallets/{{wallet['alias']}}/receive/" class="btn radio">Receive</a>
 	<a href="/wallets/{{wallet['alias']}}/send/" class="btn radio">Send</a>
 	<a href="/wallets/{{wallet['alias']}}/settings/" class="btn radio right">Settings</a>
@@ -25,6 +26,7 @@
 		</tr>
 		</thead>
 		<tbody>
+			{% if wallet.transactions != [] %}
 			{% for tx in wallet.transactions %}
 			{%if tx["confirmations"] == 0 %}
 			<tr class="unconfirmed">
@@ -54,6 +56,9 @@
 				</td>
 				<td>{{tx["time"] | datetime}}</td></tr>
 			{% endfor %}
+			{% else %}
+			<td></td><td>No transactions yet.</td><td></td><td></td><td></td><td></td>
+			{% endif %}
 		</tbody>
 	</table>
 </div>

--- a/src/cryptoadvance/specter/templates/wallet_tx.html
+++ b/src/cryptoadvance/specter/templates/wallet_tx.html
@@ -46,7 +46,7 @@
 					{% endif %}
 				</td>
 				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}tx/{{tx['txid']}}">{{tx["txid"]}}</a></td>
-				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}address/{{tx['address']}}">{{tx["address"]}}</a></td>
+				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}address/{{tx['address']}}">{{wallet.getaddressname(tx["address"])}}</a></td>
 				<td>{{tx["amount"]}}</td><td>
 				{%if tx["confirmations"] == 0 %}
 					Pending


### PR DESCRIPTION
- New Addresses tab: Show all addresses of the wallet.
- Support Bitcoin Core address labeling.
- Avoid address reuse: when entering the `Receive` tab of a wallet, if the current address is used, Specter will automatically generate a new address to prevent address reuse.
- Remove address history from the `Receive` tab.
- Add empty tx view to the `Transactions` tab