### PR TITLE
UTXO view

### DIFF
--- a/src/cryptoadvance/specter/bitcoind.py
+++ b/src/cryptoadvance/specter/bitcoind.py
@@ -13,7 +13,8 @@ import docker
 
 from .helpers import which
 from .server import DATA_FOLDER
-from .rpc import BitcoinCLI, RpcError
+from .rpc import RpcError
+from .rpc_cache import BitcoinCLICached
 from .helpers import load_jsons
 
 
@@ -40,7 +41,7 @@ class Btcd_conn:
     def get_cli(self):
         ''' returns a BitcoinCLI '''
         # def __init__(self, user, passwd, host="127.0.0.1", port=8332, protocol="http", path="", timeout=30, **kwargs):
-        cli = BitcoinCLI(self.rpcuser, self.rpcpassword, host=self.ipaddress, port=self.rpcport)
+        cli = BitcoinCLICached(self.rpcuser, self.rpcpassword, host=self.ipaddress, port=self.rpcport)
         cli.getblockchaininfo()
         return cli
 

--- a/src/cryptoadvance/specter/bitcoind.py
+++ b/src/cryptoadvance/specter/bitcoind.py
@@ -91,17 +91,17 @@ class BitcoindController:
     def testcoin_faucet(self, address, amount=20, mine_tx=False):
         ''' an easy way to get some testcoins '''
         cli = self.get_cli()
-        test3rdparty_cli = cli.wallet("test3rdparty")
         try:
-            balance = test3rdparty_cli.getbalance()
+            test3rdparty_cli = cli.wallet("test3rdparty")
         except RpcError as rpce:
             # return-codes:
             # https://github.com/bitcoin/bitcoin/blob/v0.15.0.1/src/rpc/protocol.h#L32L87
             if rpce.error_code == -18: # RPC_WALLET_NOT_FOUND
                 cli.createwallet("test3rdparty")
-                balance = test3rdparty_cli.getbalance()
+                test3rdparty_cli = cli.wallet("test3rdparty")
             else:
                 raise rpce
+        balance = test3rdparty_cli.getbalance()
         if balance < amount:
             test3rdparty_address = test3rdparty_cli.getnewaddress("test3rdparty")
             cli.generatetoaddress(102, test3rdparty_address)

--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -359,7 +359,8 @@ def wallet_addresses(wallet_alias):
             label = request.form['label']
             address = request.form['addr']
             wallet.setlabel(address, label)
-    return render_template("wallet_addresses.html", wallet_alias=wallet_alias, wallet=wallet, specter=app.specter, rand=rand)
+    alladdresses = True if request.args.get('all') != 'False' else False
+    return render_template("wallet_addresses.html", wallet_alias=wallet_alias, wallet=wallet, alladdresses=alladdresses, specter=app.specter, rand=rand)
 
 @app.route('/wallets/<wallet_alias>/receive/', methods=['GET', 'POST'])
 @login_required

--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -353,14 +353,20 @@ def wallet_addresses(wallet_alias):
         wallet = app.specter.wallets.get_by_alias(wallet_alias)
     except:
         return render_template("base.html", error="Wallet not found", specter=app.specter, rand=rand)
+    viewtype = 'address' if request.args.get('view') != 'label' else 'label'
     if request.method == "POST":
         action = request.form['action']
         if action == "updatelabel":
             label = request.form['label']
-            address = request.form['addr']
-            wallet.setlabel(address, label)
+            account = request.form['account']
+            if viewtype == 'address':
+                wallet.setlabel(account, label)
+            else:
+                for address in wallet.addressesonlabel(account):
+                    wallet.setlabel(address, label)
+                wallet.getdata()
     alladdresses = True if request.args.get('all') != 'False' else False
-    return render_template("wallet_addresses.html", wallet_alias=wallet_alias, wallet=wallet, alladdresses=alladdresses, specter=app.specter, rand=rand)
+    return render_template("wallet_addresses.html", wallet_alias=wallet_alias, wallet=wallet, alladdresses=alladdresses, viewtype=viewtype, specter=app.specter, rand=rand)
 
 @app.route('/wallets/<wallet_alias>/receive/', methods=['GET', 'POST'])
 @login_required

--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -227,6 +227,7 @@ def new_wallet_simple():
                 return render_template("base.html", error="Key not found", specter=app.specter, rand=rand)
             # create a wallet here
             wallet = app.specter.wallets.create_simple(wallet_name, wallet_type, key, device)
+            wallet.update_cache()
             return redirect("/wallets/%s/" % wallet["alias"])
     return render_template("new_simple.html", wallet_name=wallet_name, device=device, error=err, specter=app.specter, rand=rand)
 
@@ -318,6 +319,7 @@ def new_wallet_multi():
                     error=err, specter=app.specter, rand=rand)
             # create a wallet here
             wallet = app.specter.wallets.create_multi(wallet_name, sigs_required, wallet_type, keys, cosigners)
+            wallet.update_cache()
             return redirect("/wallets/%s/" % wallet["alias"])
     return render_template("new_simple.html", cosigners=cosigners, wallet_type=wallet_type, wallet_name=wallet_name, error=err, sigs_required=sigs_required, sigs_total=sigs_total, specter=app.specter, rand=rand)
 
@@ -329,6 +331,7 @@ def wallet(wallet_alias):
         wallet = app.specter.wallets.get_by_alias(wallet_alias)
     except:
         return render_template("base.html", error="Wallet not found", specter=app.specter, rand=rand)
+    wallet.update_cache()
     if wallet.balance["untrusted_pending"] + wallet.balance["trusted"] == 0:
         return redirect("/wallets/%s/receive/" % wallet_alias)
     else:
@@ -343,6 +346,7 @@ def wallet_tx(wallet_alias):
     except:
         return render_template("base.html", error="Wallet not found", specter=app.specter, rand=rand)
 
+    wallet.update_cache()
     return render_template("wallet_tx.html", wallet_alias=wallet_alias, wallet=wallet, specter=app.specter, rand=rand)
 
 @app.route('/wallets/<wallet_alias>/addresses/', methods=['GET', 'POST'])
@@ -353,6 +357,7 @@ def wallet_addresses(wallet_alias):
         wallet = app.specter.wallets.get_by_alias(wallet_alias)
     except:
         return render_template("base.html", error="Wallet not found", specter=app.specter, rand=rand)
+    wallet.update_cache()
     viewtype = 'address' if request.args.get('view') != 'label' else 'label'
     if request.method == "POST":
         action = request.form['action']
@@ -376,6 +381,7 @@ def wallet_receive(wallet_alias):
         wallet = app.specter.wallets.get_by_alias(wallet_alias)
     except:
         return render_template("base.html", error="Wallet not found", specter=app.specter, rand=rand)
+    wallet.update_cache()
     if request.method == "POST":
         action = request.form['action']
         if action == "newaddress":
@@ -402,6 +408,7 @@ def wallet_send(wallet_alias):
     except Exception as e:
         print(e)
         return render_template("base.html", error="Wallet not found", specter=app.specter, rand=rand)
+    wallet.update_cache()
     psbt = None
     address = ""
     label = ""
@@ -450,6 +457,7 @@ def wallet_settings(wallet_alias):
         wallet = app.specter.wallets.get_by_alias(wallet_alias)
     except:
         return render_template("base.html", error="Wallet not found", specter=app.specter, rand=rand)
+    wallet.update_cache()
     if request.method == "POST":
         action = request.form['action']
         if action == "rescanblockchain":
@@ -472,6 +480,8 @@ def wallet_settings(wallet_alias):
             wallet.keypoolrefill(wallet["keypool"], wallet["keypool"]+delta)
             wallet.keypoolrefill(wallet["change_keypool"], wallet["change_keypool"]+delta, change=True)
             wallet.getdata()
+        elif action == "rebuildcache":
+            wallet.rebuild_cache()
 
     cc_file = None
     qr_text = wallet["name"]+"&"+wallet.descriptor

--- a/src/cryptoadvance/specter/corecache.py
+++ b/src/cryptoadvance/specter/corecache.py
@@ -5,16 +5,15 @@ class CoreCache():
     def __init__(self, cli):
         self.cli = cli
         self.walletname = cli.getwalletinfo()["walletname"]
-        self.wallet_addresses = []
-        self.change_addresses = []
         self.setup_cache()
+
+    @property
+    def change_addresses(self):
+        return self.cache["change_addresses"]
     
-    def cache_addresses(self, full_addresses, change_addresses):
-        """Cache the wallet full addresses list and change only addresses list
-        TODO: Find a better way to retrieve this data without depending on the wallet class
-        """       
-        self.wallet_addresses = full_addresses
-        self.change_addresses = change_addresses
+    @property
+    def wallet_addresses(self):
+        return self.cache["addresses"] + self.change_addresses
 
     def setup_cache(self):
         """Setup cache object for wallet
@@ -26,7 +25,10 @@ class CoreCache():
                 "tx_count": None,
                 "tx_changed": True,
                 "last_block": None,
-                "raw_tx_block_update": {}
+                "raw_tx_block_update": {},
+                "addresses": [],
+                "change_addresses": [],
+                "scan_addresses": True
             }
 
     def cache_raw_txs(self, cli_txs):
@@ -207,6 +209,22 @@ class CoreCache():
         cached_txs = self.cache_txs(raw_txs)
 
         return cached_txs
+
+    def update_addresses(self, addresses, change=False):
+        if change:
+            cache[self.walletname]["change_addresses"] += list(dict.fromkeys(self.cache["change_addresses"] + addresses))
+        else:
+            cache[self.walletname]["addresses"] += list(dict.fromkeys(self.cache["addresses"] + addresses))
+
+    def scanning_started(self):
+        cache[self.walletname]["scan_addresses"] = True
+    
+    def scanning_ended(self):
+        cache[self.walletname]["scan_addresses"] = False
+
+    @property
+    def scan_addresses(self):
+        return self.cache["scan_addresses"]
 
     def rebuild_cache(self):
         del cache[self.walletname]

--- a/src/cryptoadvance/specter/corecache.py
+++ b/src/cryptoadvance/specter/corecache.py
@@ -1,0 +1,217 @@
+
+cache = {}
+
+class CoreCache():
+    def __init__(self, cli):
+        self.cli = cli
+        self.walletname = cli.getwalletinfo()["walletname"]
+        self.wallet_addresses = []
+        self.change_addresses = []
+        self.setup_cache()
+    
+    def cache_addresses(self, full_addresses, change_addresses):
+        """Cache the wallet full addresses list and change only addresses list
+        TODO: Find a better way to retrieve this data without depending on the wallet class
+        """       
+        self.wallet_addresses = full_addresses
+        self.change_addresses = change_addresses
+
+    def setup_cache(self):
+        """Setup cache object for wallet
+        """
+        if self.walletname not in cache: 
+            cache[self.walletname] = {
+                "raw_transactions": {},
+                "transactions": [],
+                "tx_count": None,
+                "tx_changed": True,
+                "last_block": None,
+                "raw_tx_block_update": {}
+            }
+
+    def cache_raw_txs(self, cli_txs):
+        """Cache `raw_transactions` (with full data on all the inputs and outputs of each tx)
+        """        
+        # Get list of all tx ids
+        txids = list(dict.fromkeys(cli_txs.keys()))
+        tx_count = len(txids)
+
+        # If there are new transactions (if the transations count changed)
+        if tx_count != self.cache["tx_count"]:
+            for txid in txids:
+                # Cache each tx, if not already cached.
+                # Data is immutable (unless reorg occurs) and can be saved in a file for permanent caching
+                if txid not in self.cache["raw_transactions"]:
+                    # Call Bitcoin Core to get the "raw" transaction - allows to read detailed inputs and outputs
+                    raw_tx_hex = self.cli.gettransaction(txid)["hex"]
+                    raw_tx = self.cli.decoderawtransaction(raw_tx_hex)
+                    # Some data (like fee and category, and when unconfirmed also time) available from the `listtransactions`
+                    # command is not available in the `getrawtransacion` - so add it "manually" here.
+                    if "fee" in cli_txs[txid]:
+                        raw_tx["fee"] = cli_txs[txid]["fee"]
+                    if "category" in cli_txs[txid]:
+                        raw_tx["category"] = cli_txs[txid]["category"]
+                    if "time" in cli_txs[txid]:
+                        raw_tx["time"] = cli_txs[txid]["time"]
+
+                    if "blockhash" in cli_txs[txid]:
+                        raw_tx["block_height"] = self.cli.getblockheader(cli_txs[txid]["blockhash"])["height"]
+                    else:
+                        raw_tx["block_height"] = -1
+
+                    # Loop on the transaction's inputs
+                    # If not a coinbase transaction:
+                    # Get the the output data corresponding to the input (that is: input_txid[output_index])
+                    tx_ins = []
+                    for vin in raw_tx["vin"]:
+                        # If the tx is a coinbase tx - set `coinbase` to True
+                        if "coinbase" in vin:
+                            raw_tx["coinbase"] = True
+                            break
+                        # If the tx is a coinbase tx - set `coinbase` to True
+                        vin_txid = vin["txid"]
+                        vin_vout = vin["vout"]
+                        try:
+                            raw_tx_hex = self.cli.gettransaction(vin_txid)["hex"]
+                            tx_in = self.cli.decoderawtransaction(raw_tx_hex)["vout"][vin_vout]
+                            tx_in["txid"] = vin["txid"]
+                            tx_ins.append(tx_in)
+                        except:
+                            pass
+                    # For each output in the tx_ins list (the tx inputs in their output "format")
+                    # Create object with the address, amount, and whatever the address belongs to the wallet (`internal=True` if it is).
+                    raw_tx["from"] = [{
+                        "address": out["scriptPubKey"]["addresses"][0],
+                        "amount": out["value"],
+                        "internal": out["scriptPubKey"]["addresses"][0] in self.wallet_addresses
+                    } for out in tx_ins]
+                    # For each output in the tx (`vout`)
+                    # Create object with the address, amount, and whatever the address belongs to the wallet (`internal=True` if it is).
+                    raw_tx["to"] = [({
+                        "address": out["scriptPubKey"]["addresses"][0],
+                        "amount": out["value"],
+                        "internal": out["scriptPubKey"]["addresses"][0] in self.wallet_addresses
+                    }) for out in raw_tx["vout"] if "addresses" in out["scriptPubKey"]]
+                    # Save the raw_transaction to the cache
+                    cache[self.walletname]["raw_transactions"][txid] = raw_tx
+            # Set the tx count to avoid unnecessary indexing
+            cache[self.walletname]["tx_count"] = tx_count
+            # Set the tx changed to indicate the there are new transactions to cache
+            cache[self.walletname]["tx_changed"] = True
+        else:
+            # Set the tx changed to False to avoid unnecessary indexing
+            cache[self.walletname]["tx_changed"] = False
+
+        # If unconfirmed transactions were mined, assign them their block height
+        blocks = self.cli.getblockcount()
+        if blocks != self.cache["last_block"]:
+            for txid in self.cache["raw_transactions"]:
+                if self.cache["raw_transactions"][txid]["block_height"] == -1 and "blockhash" in cli_txs[txid]:
+                    height = self.cli.getblockheader(cli_txs[txid]["blockhash"])["height"]
+                    cache[self.walletname]["raw_transactions"][txid]["block_height"] = height
+                    cache[self.walletname]["raw_tx_block_update"][txid] = height
+            cache[self.walletname]["last_block"] = blocks
+
+        return self.cache["raw_transactions"]
+    
+    def cache_txs(self, raw_txs):
+        """Caches the transactions list.
+            Cache the inputs and outputs which belong to the user's wallet for each `raw_transaction` 
+            This method relies on a few assumptions regarding the txs format to cache data properly:
+                - In `send` transactions, all inputs belong to the wallet.
+                - In `send` transactions, there is only one output not belonging to the wallet (i.e. only one recipient).
+                - In `coinbase` transactions, there is only one input.
+                - Change addresses are derived from the path used by Specter
+        """
+        # Get the cached `raw_transactions` dict (txid -> tx) as a list of txs
+        transactions = list(sorted(raw_txs.values(), key = lambda tx: tx['time'], reverse=True))
+        result = []
+
+        # If unconfirmed transactions were mined, assign them their block height
+        if len(self.cache["raw_tx_block_update"]) > 0:
+            for i in range(0, len(self.cache["transactions"])):
+                if self.cache["transactions"][i]["txid"] in cache[self.walletname]["raw_tx_block_update"]:
+                    cache[self.walletname]["transactions"][i]["block_height"] = cache[self.walletname]["raw_tx_block_update"][cache[self.walletname]["transactions"][i]["txid"]]
+                    del cache[self.walletname]["raw_tx_block_update"][cache[self.walletname]["transactions"][i]["txid"]]
+                    if len(self.cache["raw_tx_block_update"]) == 0:
+                        break
+
+        # If the `raw_transactions` did not change - exit here.
+        if not self.cache["tx_changed"]:
+            return self.cache["transactions"]
+
+        # Loop through the raw_transactions list
+        for i, tx in enumerate(transactions):
+            # If tx is a user generated one (categories: `send`/ `receive`) and not coinbase (categories: `generated`/ `immature`)
+            if tx["category"] == "send" or tx["category"] == "receive":
+                is_send = True
+                is_self = True
+
+                # Check if the transaction is a `send` or not (if all inputs belong to the wallet)
+                if len(tx["from"]) == 0:
+                    is_send = False
+
+                for fromdata in tx["from"]:
+                    if not fromdata["internal"]:
+                        is_send = False
+
+                # Check if the transaction is a `self-transfer` (if all inputs and all outputs belong to the wallet)
+                for to in tx["to"]:
+                    if not is_send or not to["internal"]:
+                        is_self = False
+                        break
+
+                tx["is_self"] = is_self
+
+                if not is_send or is_self:
+                    for to in tx["to"]:
+                        if to["internal"]:
+                            # Cache received outputs
+                            result.append(self.prepare_tx(tx, to, "receive", destination=None, is_change=(to["address"] in self.change_addresses)))
+
+                if is_send or is_self:
+                    destination = None
+                    for to in tx["to"]:
+                        if to["address"] in self.change_addresses and not is_self:
+                            # Cache change output
+                            result.append(self.prepare_tx(tx, to, "receive", destination=destination, is_change=True))
+                        elif not to["internal"] or (is_self and to["address"] not in self.change_addresses):
+                            destination = to
+                    for fromdata in tx["from"]:
+                        # Cache sent inputs
+                        result.append(self.prepare_tx(tx, fromdata, "send", destination=destination))
+            else:
+                tx["is_self"] = False
+                # Cache coinbase output
+                result.append(self.prepare_tx(tx, tx["to"][0], tx["category"]))
+
+        # Save the result to the cache
+        cache[self.walletname]["transactions"] = result
+        return self.cache["transactions"]
+    
+    def prepare_tx(self, tx, output, category, destination=None, is_change=False):
+        tx_clone = tx.copy()
+        tx_clone["destination"] = destination
+        tx_clone["address"] = output["address"]
+        tx_clone["amount"] = output["amount"]
+        tx_clone["category"] = category
+        tx_clone["is_change"] = is_change
+        return tx_clone
+
+    def update_txs(self, txs):
+        """Cache Bitcoin Core `listtransactions` result
+        """
+        # For now avoid caching orphan transactions. We might want to show them somehow in the future.
+        cli_txs = {tx["txid"]: tx for tx in txs if tx["category"] != "orphan"}
+        raw_txs = self.cache_raw_txs(cli_txs)
+        cached_txs = self.cache_txs(raw_txs)
+
+        return cached_txs
+
+    def rebuild_cache(self):
+        del cache[self.walletname]
+        self.setup_cache()
+
+    @property
+    def cache(self):
+        return cache[self.walletname]

--- a/src/cryptoadvance/specter/logic.py
+++ b/src/cryptoadvance/specter/logic.py
@@ -765,7 +765,7 @@ class Wallet(dict):
         return len(txlist)
 
     def balanceonlabel(self, label):
-        balancelist = [utxo["amount"] for utxo in self.utxo if utxo["label"] == label or utxo["address"] == label]
+        balancelist = [utxo["amount"] for utxo in self.utxo if ("label" in utxo and utxo["label"] == label) or utxo["address"] == label]
         return sum(balancelist)
 
     def addressesonlabel(self, label):

--- a/src/cryptoadvance/specter/logic.py
+++ b/src/cryptoadvance/specter/logic.py
@@ -12,6 +12,8 @@ from .helpers import deep_update, load_jsons
 from .rpc import RPC_PORTS, BitcoinCLI, autodetect_cli
 from .serializations import PSBT
 
+cache = {}
+
 # a gap of 20 addresses is what many wallets do
 WALLET_CHUNK = 20
 # we don't need to scan earlier than that 
@@ -583,6 +585,230 @@ class Wallet(dict):
         self._dict["change_address"] = self.get_address(self._dict["change_index"], change=True)
         self._commit()
 
+    def setup_cache(self):
+        """Setup cache if don't exist yet for the wallet
+        """
+        if self["name"] in cache:
+            if "cli_txs" not in cache[self["name"]]:
+                cache[self["name"]]["cli_txs"] = {}
+            if "raw_transactions" not in cache[self["name"]]:
+                cache[self["name"]]["raw_transactions"] = {}
+            if "transactions" not in cache[self["name"]]:
+                cache[self["name"]]["transactions"] = []
+            if "addresses" not in cache[self["name"]]:
+                cache[self["name"]]["addresses"] = []
+            if "tx_count" not in cache[self["name"]]:
+                cache[self["name"]]["tx_count"] = None
+            if "tx_changed" not in cache[self["name"]]:
+                cache[self["name"]]["tx_changed"] = True
+            if "labels" not in cache[self["name"]]:
+                cache[self["name"]]["labels"] = []
+            if "last_block" not in cache[self["name"]]:
+                cache[self["name"]]["last_block"] = None
+        else:
+            cache[self["name"]] = {
+                "cli_txs": {},
+                "raw_transactions": {},
+                "transactions": [],
+                "addresses": [],
+                "tx_count": None,
+                "tx_changed": True,
+                "labels": [],
+                "last_block": None
+            }
+
+    def cache_cli_txs(self):
+        """Cache Bitcoin Core `listtransactions` result
+        """
+        cache[self["name"]]["cli_txs"] = {tx["txid"]: tx for tx in self.cli_transactions}
+
+    def cache_addresses(self):
+        """Cache wallet addresses
+        """
+        cache[self["name"]]["active_addresses"] = list(dict.fromkeys(self.addresses))
+        cache[self["name"]]["addresses"] = list(dict.fromkeys(self.addresses + self.change_addresses))
+
+    def cache_raw_txs(self):
+        """Cache `raw_transactions` (with full data on all the inputs and outputs of each tx)
+        """
+        # Get list of all tx ids
+        txids = list(dict.fromkeys(cache[self["name"]]["cli_txs"].keys()))
+        tx_count = len(txids)
+        # If there are new transactions (if the transations count changed)
+        if tx_count != cache[self["name"]]["tx_count"]:
+            for txid in txids:
+                # Cache each tx, if not already cached.
+                # Data is immutable (unless reorg occurs and except of confirmations) and can be saved in a file for permanent caching
+                if txid not in cache[self["name"]]["raw_transactions"]:
+                    # Call Bitcoin Core to get the "raw" transaction - allows to read detailed inputs and outputs
+                    raw_tx = self.cli.getrawtransaction(txid, 1)
+                    # Some data (like fee and category, and when unconfirmed also time) available from the `listtransactions`
+                    # command is not available in the `getrawtransacion` - so add it "manually" here.
+                    if "fee" in cache[self["name"]]["cli_txs"][txid]:
+                        raw_tx["fee"] = cache[self["name"]]["cli_txs"][txid]["fee"]
+                    if "category" in cache[self["name"]]["cli_txs"][txid]:
+                        raw_tx["category"] = cache[self["name"]]["cli_txs"][txid]["category"]
+                    if "time" in cache[self["name"]]["cli_txs"][txid]:
+                        raw_tx["time"] = cache[self["name"]]["cli_txs"][txid]["time"]
+
+                    # Loop on the transaction's inputs
+                    # If not a coinbase transaction:
+                    # Get the the output data corresponding to the input (that is: input_txid[output_index])
+                    tx_ins = []
+                    for vin in raw_tx["vin"]:
+                        # If the tx is a coinbase tx - set `coinbase` to True
+                        if "coinbase" in vin:
+                            raw_tx["coinbase"] = True
+                            break
+                        # If the tx is a coinbase tx - set `coinbase` to True
+                        vin_txid = vin["txid"]
+                        vin_vout = vin["vout"]
+                        tx_in = self.cli.getrawtransaction(vin_txid, 1)["vout"][vin_vout]
+                        tx_in["txid"] = vin["txid"]
+                        tx_ins.append(tx_in)
+                    # For each output in the tx_ins list (the tx inputs in their output "format")
+                    # Create object with the address, amount, and whatever the address belongs to the wallet (`internal=True` if it is).
+                    raw_tx["from"] = [{"address": out["scriptPubKey"]["addresses"][0], "amount": out["value"], "internal": out["scriptPubKey"]["addresses"][0] in cache[self["name"]]["addresses"]} for out in tx_ins]
+                    # For each output in the tx (`vout`)
+                    # Create object with the address, amount, and whatever the address belongs to the wallet (`internal=True` if it is).
+                    raw_tx["to"] = [({"address": out["scriptPubKey"]["addresses"][0], "amount": out["value"], "internal": out["scriptPubKey"]["addresses"][0] in cache[self["name"]]["addresses"]}) for out in raw_tx["vout"] if "addresses" in out["scriptPubKey"]]
+                    # Save the raw_transaction to the cache
+                    cache[self["name"]]["raw_transactions"][txid] = raw_tx
+            # Set the tx count to avoid unnecessary indexing
+            cache[self["name"]]["tx_count"] = tx_count
+            # Set the tx changed to indicate the there are new transactions to cache
+            cache[self["name"]]["tx_changed"] = True
+        else:
+            # Set the tx changed to False to avoid unnecessary indexing
+            cache[self["name"]]["tx_changed"] = False
+
+    def cache_labels(self):
+        """Cache labels for addresses (if not cached already)
+        """
+        # This list is updated from the `self.setlabel` method
+        if len(cache[self["name"]]["labels"]) == 0:
+            cache[self["name"]]["labels"] = {address: self.getlabel(address) for address in cache[self["name"]]["addresses"]}
+    
+    def cache_confirmations(self):
+        """Update the confirmations count for txs.
+        """
+        # Get the block count from Bitcoin Core
+        blocks = self.cli.getblockcount()
+        # If there are new blocks since the last cache update
+        if blocks != cache[self["name"]]["last_block"] or cache[self["name"]]["tx_changed"]:
+            # Loop through the cached `transactions` and update its confirmations according to the cached `cli_txs` data 
+            for i in range(0, len(cache[self["name"]]["transactions"])):
+                confs = cache[self["name"]]["cli_txs"][cache[self["name"]]["transactions"][i]["txid"]]["confirmations"]
+                cache[self["name"]]["transactions"][i]["confirmations"] = confs
+
+            # Update last block confirmations were cached for
+            cache[self["name"]]["last_block"] = blocks
+
+    def cache_txs(self):
+        """Caches the transactions list.
+            Cache the inputs and outputs which belong to the user's wallet for each `raw_transaction` 
+            This method relies on a few assumptions regarding the txs format to cache data properly:
+                - In `send` transactions, all inputs belong to the wallet.
+                - In `send` transactions, there is only one output not belonging to the wallet (i.e. only one recipient).
+                - In `coinbase` transactions, there is only one input.
+                - Change addresses are derived from the path used by Specter
+        """
+        # Get the cached `raw_transactions` dict (txid -> tx) as a list of txs
+        transactions = list(sorted(cache[self["name"]]["raw_transactions"].values(), key = lambda tx: tx['time'], reverse=True))
+        result = []
+
+        # If the `raw_transactions` did not change - exit here.
+        if not cache[self["name"]]["tx_changed"]:
+            return
+
+        # Loop through the raw_transactions list
+        for i, tx in enumerate(transactions):
+            # If tx is a user generated one (categories: `send`/ `receive`) and not coinbase (categories: `generated`/ `immature`)
+            if tx["category"] == "send" or tx["category"] == "receive":
+                is_send = True
+                is_self = True
+
+                # Check if the transaction is a `send` or not (if all inputs belong to the wallet)
+                for fromdata in tx["from"]:
+                    if not fromdata["internal"]:
+                        is_send = False
+
+                # Check if the transaction is a `self-transfer` (if all inputs and all outputs belong to the wallet)
+                for to in tx["to"]:
+                    if not is_send or not to["internal"]:
+                        is_self = False
+                        break
+
+                tx["is_self"] = is_self
+
+                if not is_send or is_self:
+                    for to in tx["to"]:
+                        if to["internal"]:
+                            # Cache received outputs
+                            result.append(self.prepare_tx(tx, to, "receive", destination=None, is_change=(to["address"] in self.change_addresses)))
+
+                if is_send or is_self:
+                    destination = None
+                    for to in tx["to"]:
+                        if to["address"] in self.change_addresses:
+                            # Cache change output
+                            result.append(self.prepare_tx(tx, to, "receive", destination=destination, is_change=True))
+                        elif not to["internal"] or (is_self and to["address"] not in self.change_addresses):
+                            destination = to
+                    for fromdata in tx["from"]:
+                        # Cache sent inputs
+                        result.append(self.prepare_tx(tx, fromdata, "send", destination=destination))
+            else:
+                tx["is_self"] = False
+                # Cache coinbase output
+                result.append(self.prepare_tx(tx, tx["to"][0], tx["category"]))
+
+        # Save the result to the cache
+        cache[self["name"]]["transactions"] = result
+    
+    def prepare_tx(self, tx, output, category, destination=None, is_change=False):
+        tx_clone = tx.copy()
+        tx_clone["destination"] = destination
+        tx_clone["address"] = output["address"]
+        tx_clone["label"] = self.getlabel(tx_clone["address"])
+        tx_clone["amount"] = output["amount"]
+        tx_clone["category"] = category
+        tx_clone["is_change"] = is_change
+        return tx_clone
+
+    def update_cache(self):
+        self.setup_cache()
+        self.cache_cli_txs()
+        self.cache_addresses()
+        self.cache_labels()
+        self.cache_raw_txs()
+        self.cache_txs()
+        self.cache_confirmations()
+
+    def rebuild_cache(self):
+        del cache[self["name"]]
+        self.update_cache()
+
+    @property
+    def transactions(self):
+        if self["name"] not in cache or "transactions" not in cache[self["name"]] or len(cache[self["name"]]["transactions"]) == 0:
+            return self.cli_transactions
+        return cache[self["name"]]["transactions"]
+    
+    @property
+    def cli_transactions(self):
+        return self.cli.listtransactions("*", 1000, 0, True)[::-1]
+
+    @property
+    def txlist(self):
+        txidlist = []
+        txlist = []
+        for tx in cache[self["name"]]["transactions"]:
+            if tx["is_change"] == False and (tx["is_self"] or tx["txid"] not in txidlist):
+                txidlist.append(tx["txid"])
+                txlist.append(tx)
+        return txlist
+
     def getdata(self):
         try:
             self.balance = self.getbalances()
@@ -593,13 +819,13 @@ class Wallet(dict):
         except:
             self.utxo = None
         try:
-            self.transactions = self.cli.listtransactions("*", 1000, 0, True)[::-1]
-        except:
-            self.transactions = None
-        try:
             self.info = self.cli.getwalletinfo()
         except:
             self.info = None
+
+        if self["name"] not in cache:
+            self.update_cache()
+
         self._check_change()
         return {
             "balance": self.balance,
@@ -778,8 +1004,15 @@ class Wallet(dict):
 
     def setlabel(self, addr, label):
         self.cli.setlabel(addr, label)
+        old_label = cache[self["name"]]["labels"][addr] if addr in cache[self["name"]]["labels"] else addr
+        cache[self["name"]]["labels"][addr] = label
+        for i, tx in enumerate(self.transactions):
+            if tx["label"] == old_label if "label" in tx else tx["address"] == old_label:
+                self.transactions[i]["label"] = label
 
     def getlabel(self, addr):
+        if addr in cache[self["name"]]["labels"]:
+            return cache[self["name"]]["labels"][addr]
         address_info = self.cli.getaddressinfo(addr)
         return address_info["label"] if "label" in address_info and address_info["label"] != "" else addr
     
@@ -821,9 +1054,7 @@ class Wallet(dict):
             utxo["address"] for utxo in 
             sorted(
                 self.utxo,
-                key = lambda utxo: next(
-                    tx for tx in self.transactions if tx["txid"] == utxo["txid"]
-                )["time"]
+                key = lambda utxo: cache[self["name"]]["cli_txs"][utxo["txid"]]["time"]
             )
         ]))
 
@@ -843,6 +1074,10 @@ class Wallet(dict):
     def addresses(self):
         addresses = [self.get_address(idx) for idx in range(0,self._dict["address_index"] + 1)]
         return list(dict.fromkeys(addresses + self.utxoaddresses))
+    
+    @property
+    def change_addresses(self):
+        return [self.get_address(idx, change=True) for idx in range(0,self._dict["change_index"] + 1)]
 
     @property
     def labels(self):

--- a/src/cryptoadvance/specter/logic.py
+++ b/src/cryptoadvance/specter/logic.py
@@ -588,6 +588,9 @@ class Wallet(dict):
 
     @property
     def txlist(self):
+        ''' The last 1000 transactions for that wallet - filtering out change addresses transactions and duplicated transactions (except for self-transfers)
+            This list is used for the wallet `txs` tab to list the wallet transacions.
+        '''
         txidlist = []
         txlist = []
         for tx in self.transactions:
@@ -597,6 +600,9 @@ class Wallet(dict):
         return txlist
 
     def cache_addresses(self):
+        ''' Caches the wallet addresses to the CachedCLI
+            This is needed for caching tranactions inputs and outputs baseed on whetever the wallet owns them or if they are change addresses.
+        '''
         self.cli.cache.cache_addresses(self.full_addresses, self.change_addresses)
 
     def getdata(self):

--- a/src/cryptoadvance/specter/logic.py
+++ b/src/cryptoadvance/specter/logic.py
@@ -816,14 +816,6 @@ class Wallet(dict):
         return self.txonaddr(addr)
 
     @property
-    def addresses(self):
-        return [self.get_address(idx) for idx in range(0,self._dict["address_index"] + 1)]
-
-    @property
-    def labels(self):
-        return list(dict.fromkeys([self.getlabel(addr) for addr in self.addresses]))
-
-    @property
     def utxoaddresses(self):
         return list(dict.fromkeys([
             utxo["address"] for utxo in 
@@ -846,6 +838,15 @@ class Wallet(dict):
                 )["time"]
             )
         ]))
+
+    @property
+    def addresses(self):
+        addresses = [self.get_address(idx) for idx in range(0,self._dict["address_index"] + 1)]
+        return list(dict.fromkeys(addresses + self.utxoaddresses))
+
+    @property
+    def labels(self):
+        return list(dict.fromkeys([self.getlabel(addr) for addr in self.addresses]))
 
     def createpsbt(self, address:str, amount:float, subtract:bool=False, fee_rate:float=0.0, fee_unit="SAT_B"):
         """

--- a/src/cryptoadvance/specter/logic.py
+++ b/src/cryptoadvance/specter/logic.py
@@ -9,7 +9,7 @@ from collections import OrderedDict
 from . import helpers
 from .descriptor import AddChecksum
 from .helpers import deep_update, load_jsons, get_xpub_fingerprint
-from .rpc import RPC_PORTS, autodetect_cli
+from .rpc import RPC_PORTS, autodetect_cli_confs
 from .rpc_cache import BitcoinCLICached
 from .serializations import PSBT
 
@@ -48,11 +48,11 @@ def get_cli(conf):
         conf["autodetect"] = True
     if conf["autodetect"]:
         if "port" in conf:
-            cli_arr = autodetect_cli(port=conf["port"])
+            cli_conf_arr = autodetect_cli_confs(port=conf["port"])
         else:
-            cli_arr = autodetect_cli()
-        if len(cli_arr) > 0:
-            cli = cli_arr[0]
+            cli_conf_arr = autodetect_cli_confs()
+        if len(cli_conf_arr) > 0:
+            cli = BitcoinCLICached(**cli_conf_arr[0])
         else:
             return None
     else:

--- a/src/cryptoadvance/specter/logic.py
+++ b/src/cryptoadvance/specter/logic.py
@@ -589,7 +589,7 @@ class Wallet(dict):
         except:
             self.balance = None
         try:
-            self.utxo = {utxo["txid"]: utxo for utxo in self.cli.listunspent(0)}
+            self.utxo = self.cli.listunspent(0)
         except:
             self.utxo = None
         try:
@@ -757,7 +757,7 @@ class Wallet(dict):
         return len(txlist)
 
     def balanceonaddr(self, addr):
-        balancelist = [utxo["amount"] for _, utxo in list(self.utxo.items()) if utxo["address"] == addr]
+        balancelist = [utxo["amount"] for utxo in self.utxo if utxo["address"] == addr]
         return sum(balancelist)
 
     def txonlabel(self, label):
@@ -765,7 +765,7 @@ class Wallet(dict):
         return len(txlist)
 
     def balanceonlabel(self, label):
-        balancelist = [utxo["amount"] for _, utxo in list(self.utxo.items()) if utxo["label"] == label or utxo["address"] == label]
+        balancelist = [utxo["amount"] for utxo in self.utxo if utxo["label"] == label or utxo["address"] == label]
         return sum(balancelist)
 
     def addressesonlabel(self, label):
@@ -774,7 +774,7 @@ class Wallet(dict):
         ))
 
     def istxspent(self, txid):
-        return txid in self.utxo.keys()
+        return txid in [utxo["txid"] for utxo in self.utxo]
 
     def setlabel(self, addr, label):
         self.cli.setlabel(addr, label)
@@ -826,11 +826,11 @@ class Wallet(dict):
     @property
     def utxoaddresses(self):
         return list(dict.fromkeys([
-            utxo["address"] for _,utxo in 
+            utxo["address"] for utxo in 
             sorted(
-                list(self.utxo.items()),
+                self.utxo,
                 key = lambda utxo: next(
-                    tx for tx in self.transactions if tx["txid"] == utxo[0]
+                    tx for tx in self.transactions if tx["txid"] == utxo["txid"]
                 )["time"]
             )
         ]))
@@ -838,11 +838,11 @@ class Wallet(dict):
     @property
     def utxolabels(self):
         return list(dict.fromkeys([
-            utxo["label"] if "label" in utxo and utxo["label"] != "" else utxo["address"] for _,utxo in 
+            utxo["label"] if "label" in utxo and utxo["label"] != "" else utxo["address"] for utxo in 
             sorted(
-                list(self.utxo.items()),
+                self.utxo,
                 key = lambda utxo: next(
-                    tx for tx in self.transactions if tx["txid"] == utxo[0]
+                    tx for tx in self.transactions if tx["txid"] == utxo["txid"]
                 )["time"]
             )
         ]))

--- a/src/cryptoadvance/specter/logic.py
+++ b/src/cryptoadvance/specter/logic.py
@@ -530,6 +530,7 @@ class Wallet(dict):
         self.cli_path = manager.cli_path
         self.cli = manager.cli.wallet(self.cli_path+self["alias"])
         self._dict = d
+        self.setup_cache()
         # check if address is known and derive if not
         # address derivation will also refill the keypool if necessary
         if self._dict["address"] is None:
@@ -602,7 +603,7 @@ class Wallet(dict):
             if "tx_changed" not in cache[self["name"]]:
                 cache[self["name"]]["tx_changed"] = True
             if "labels" not in cache[self["name"]]:
-                cache[self["name"]]["labels"] = []
+                cache[self["name"]]["labels"] = {}
             if "last_block" not in cache[self["name"]]:
                 cache[self["name"]]["last_block"] = None
         else:
@@ -613,7 +614,7 @@ class Wallet(dict):
                 "addresses": [],
                 "tx_count": None,
                 "tx_changed": True,
-                "labels": [],
+                "labels": {},
                 "last_block": None
             }
 
@@ -1012,6 +1013,8 @@ class Wallet(dict):
 
     def setlabel(self, addr, label):
         self.cli.setlabel(addr, label)
+        if self["name"] not in cache:
+            return
         old_label = cache[self["name"]]["labels"][addr] if addr in cache[self["name"]]["labels"] else addr
         cache[self["name"]]["labels"][addr] = label
         for i, tx in enumerate(self.transactions):

--- a/src/cryptoadvance/specter/rpc.py
+++ b/src/cryptoadvance/specter/rpc.py
@@ -90,39 +90,40 @@ def get_configs(config=None):
         confs.append(o)
     return confs
 
-def detect_cli(config=None):
+def detect_cli_confs(config=None):
     if config is None:
         config = get_rpcconfig()
     rpcconfs = get_configs(config)
     cli_arr = []
     for conf in rpcconfs:
-        cli_arr.append(BitcoinCLI(**conf))
+        cli_arr.append(conf)
     return cli_arr
 
-def autodetect_cli(port=None):
+def autodetect_cli_confs(port=None):
     if port == "":
         port = None
     if port is not None:
         port = int(port)
-    cli_arr = detect_cli()
-    available_cli_arr = []
-    if len(cli_arr) > 0:
-        print("trying %d different configs" % len(cli_arr))
-        for cli in cli_arr:
+    conf_arr = detect_cli_confs()
+    available_conf_arr = []
+    if len(conf_arr) > 0:
+        print("trying %d different configs" % len(conf_arr))
+        for conf in conf_arr:
+            cli = BitcoinCLI(**conf)
             if port is not None:
                 if int(cli.port) != port:
                     continue
             try:
                 cli.getmininginfo()
-                available_cli_arr.append(cli)
+                available_conf_arr.append(conf)
             except requests.exceptions.RequestException:
                 pass
             except Exception as e:
                 pass
     else:
         print("Bitcoin-cli not found :(")
-    print("Detected %d bitcoin daemons" % len(available_cli_arr))
-    return available_cli_arr
+    print("Detected %d bitcoin daemons" % len(available_conf_arr))
+    return available_conf_arr
 
 class RpcError(Exception):
     ''' Specifically created for error-handling of the BitcoiCore-API

--- a/src/cryptoadvance/specter/rpc_cache.py
+++ b/src/cryptoadvance/specter/rpc_cache.py
@@ -1,0 +1,34 @@
+from .rpc import BitcoinCLI
+from .corecache import CoreCache
+
+class BitcoinCLICached:
+    def __init__(self, user="", passwd="", host="127.0.0.1", port=8332, protocol="http", path="", timeout=30, cli=None, **kwargs):
+        if cli:
+            self.cli = cli
+            self.cache = CoreCache(cli)
+        else:
+            self.cli = BitcoinCLI(user, passwd, host, port, protocol, path, timeout)
+            self.cache = None
+
+    @property
+    def url(self):
+        return self.cli.url
+
+    def test_connection(self):
+        return self.cli.test_connection()
+
+    def clone(self):
+        ''' returns a clone of self. Usefull if you want to mess with the properties '''
+        return BitcoinCLICached(cli=self.cli)
+    
+    def wallet(self, name=""):
+            return BitcoinCLICached(cli=self.cli.wallet(name))
+    
+    def listtransactions(self, *args, **kwargs):
+        cli_transactions = self.cli.listtransactions(*args, **kwargs)
+        if self.cache:
+            return self.cache.update_txs(cli_transactions)
+        return cli_transactions
+
+    def __getattr__(self, method):
+        return self.cli.__getattr__(method)

--- a/src/cryptoadvance/specter/rpc_cache.py
+++ b/src/cryptoadvance/specter/rpc_cache.py
@@ -1,4 +1,4 @@
-from .rpc import BitcoinCLI
+from .rpc import BitcoinCLI, RpcError
 from .corecache import CoreCache
 
 class BitcoinCLICached:
@@ -48,7 +48,12 @@ class BitcoinCLICached:
         return BitcoinCLICached(self.cli.user, self.cli.passwd, self.cli.host, self.cli.port, self.cli.protocol, self.cli.path, self.cli.timeout)
     
     def wallet(self, name=""):
-        return BitcoinCLICached.from_wallet_cli(cli=self.cli.wallet(name))
+        try:
+            return BitcoinCLICached.from_wallet_cli(cli=self.cli.wallet(name))
+        except RpcError as rpce:
+            raise rpce
+        except Exception as e:
+                raise e
     
     def listtransactions(self, *args, **kwargs):
         cli_transactions = self.cli.listtransactions(*args, **kwargs)
@@ -70,4 +75,9 @@ class BitcoinCLICached:
         return self.cli.rescanblockchain(*args, **kwargs)
 
     def __getattr__(self, method):
-        return self.cli.__getattr__(method)
+        try:
+            return self.cli.__getattr__(method)
+        except RpcError as rpce:
+            raise rpce
+        except Exception as e:
+                raise e

--- a/src/cryptoadvance/specter/rpc_cache.py
+++ b/src/cryptoadvance/specter/rpc_cache.py
@@ -19,10 +19,12 @@ class BitcoinCLICached:
 
     def clone(self):
         ''' returns a clone of self. Usefull if you want to mess with the properties '''
-        return BitcoinCLICached(cli=self.cli)
+        if self.cache:
+            return BitcoinCLICached(cli=self.cli)
+        return BitcoinCLICached(self.cli.user, self.cli.passwd, self.cli.host, self.cli.port, self.cli.protocol, self.cli.path, self.cli.timeout)
     
     def wallet(self, name=""):
-            return BitcoinCLICached(cli=self.cli.wallet(name))
+        return BitcoinCLICached(cli=self.cli.wallet(name))
     
     def listtransactions(self, *args, **kwargs):
         cli_transactions = self.cli.listtransactions(*args, **kwargs)

--- a/src/cryptoadvance/specter/rpc_cache.py
+++ b/src/cryptoadvance/specter/rpc_cache.py
@@ -4,11 +4,21 @@ from .corecache import CoreCache
 class BitcoinCLICached:
     def __init__(self, user="", passwd="", host="127.0.0.1", port=8332, protocol="http", path="", timeout=30, cli=None, **kwargs):
         if cli:
+            # If cli argument is not empty it should contain a wallet settting in it
+            # Only CLI with a wallet configured should have caching
             self.cli = cli
             self.cache = CoreCache(cli)
         else:
             self.cli = BitcoinCLI(user, passwd, host, port, protocol, path, timeout)
             self.cache = None
+
+    @classmethod
+    def from_wallet_cli(cls, cli):
+        """ Initialize BitcoinCLICached from a CLI with wallet configured.
+            This call is internally used when the `wallet` method is called and configures the CLI wallet.
+        """
+        return cls(cli=cli)
+ 
 
     @property
     def url(self):
@@ -20,11 +30,11 @@ class BitcoinCLICached:
     def clone(self):
         ''' returns a clone of self. Usefull if you want to mess with the properties '''
         if self.cache:
-            return BitcoinCLICached(cli=self.cli)
+            return BitcoinCLICached.from_wallet_cli(cli=self.cli)
         return BitcoinCLICached(self.cli.user, self.cli.passwd, self.cli.host, self.cli.port, self.cli.protocol, self.cli.path, self.cli.timeout)
     
     def wallet(self, name=""):
-        return BitcoinCLICached(cli=self.cli.wallet(name))
+        return BitcoinCLICached.from_wallet_cli(cli=self.cli.wallet(name))
     
     def listtransactions(self, *args, **kwargs):
         cli_transactions = self.cli.listtransactions(*args, **kwargs)

--- a/src/cryptoadvance/specter/rpctest.py
+++ b/src/cryptoadvance/specter/rpctest.py
@@ -3,19 +3,20 @@ from rpc import *
 import requests
 
 if __name__ == '__main__':
-    cli_arr = detect_cli()
-    available_cli_arr = []
-    if len(cli_arr) > 0:
-        print("trying %d different configs" % len(cli_arr))
-        for cli in cli_arr:
+    conf_arr = detect_cli_confs()
+    available_conf_arr = []
+    if len(conf_arr) > 0:
+        print("trying %d different configs" % len(conf_arr))
+        for conf in conf_arr:
+            cli = BitcoinCLI(**conf)
             try:
                 print(cli.getmininginfo(timeout=1))
                 print("Yey! Bitcoin-cli found!")
-                available_cli_arr.append(cli)
+                available_conf_arr.append(cli)
             except requests.exceptions.RequestException:
                 print("can't connect")
             except Exception as e:
                 print("fail...", e)
     else:
         print("Bitcoin-cli not found :(")
-    print("\nDetected %d bitcoin daemons\n" % len(available_cli_arr))
+    print("\nDetected %d bitcoin daemons\n" % len(available_conf_arr))

--- a/src/cryptoadvance/specter/static/styles.css
+++ b/src/cryptoadvance/specter/static/styles.css
@@ -645,3 +645,39 @@ table tr:hover .btn.hovering{
 .hidden {
     display: none;
 }
+.dropbtn {
+    background: var(--cmap-border);
+    color: white;
+    padding: 10px;
+    font-size: 0.8em;
+    border: none;
+}
+.dropdown {
+    position: relative;
+    display: inline-block;
+}
+.dropdown-content {
+    display: none;
+    position: absolute;
+    background-color: #f1f1f1;
+    min-width: 160px;
+    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+    z-index: 1;
+    width: 100%;
+}
+.dropdown-content a {
+    color: black;
+    padding: 12px 16px;
+    text-decoration: none;
+    display: block;
+    font-size: 0.9em;
+}
+.dropdown-content a:hover {
+    background-color: #ddd;
+}
+.dropdown:hover .dropdown-content {
+    display: block;
+}
+.dropdown:hover .dropbtn {
+    background: (--cmap-border-darker);
+}

--- a/src/cryptoadvance/specter/templates/wallet_addresses.html
+++ b/src/cryptoadvance/specter/templates/wallet_addresses.html
@@ -117,8 +117,9 @@
 						{% endif %}
 					{% endif %}
 				</td>
+				{% set display_address = (tx["destination"]["address"] if ("destination" in tx and tx["destination"] != None) else tx["address"])%}
 				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}tx/{{tx['txid']}}">{{tx["txid"]}}</a></td>
-				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}address/{{tx['address']}}">{{accountlabel}}</a></td>
+				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}address/{{display_address}}">{{wallet.getaddressname(display_address, -1)}}</a></td>
 				<td>{{tx["amount"]}}</td><td>
 				{%if tx["confirmations"] == 0 %}
 					Pending

--- a/src/cryptoadvance/specter/templates/wallet_addresses.html
+++ b/src/cryptoadvance/specter/templates/wallet_addresses.html
@@ -99,8 +99,8 @@
 		<tbody>
 			{% if (wallet.txonaddr(account) if isaddrview else wallet.txonlabel(account) > 0) %}
 			{% for tx in wallet.transactions %}
-			{% if (tx["address"] == account or (tx["label"] == account and not isaddrview)) and (alladdresses or (wallet.istxspent(tx["txid"]) and tx["category"] != "send")) %}
-				{% if tx["confirmations"] == 0 %}
+			{% if (tx["address"] == account or (wallet.getlabel(tx["address"]) == account and not isaddrview)) and (alladdresses or (wallet.istxspent(tx["txid"]) and tx["category"] != "send")) %}
+				{% if tx["block_height"] == -1 %}
 					<tr class="unconfirmed">
 				{%else%}
 					<tr>
@@ -110,7 +110,7 @@
 					{% if tx['category'] == 'immature' %}
 						<img src="/static/img/unconfirmed_receive_icon.svg"/>
 					{% else %}
-						{% if tx["confirmations"] == 0 %}
+						{% if tx["block_height"] == -1 %}
 						<img src="/static/img/unconfirmed_{{tx['category']}}_icon.svg"/>
 						{% else %}
 						<img src="/static/img/{{tx['category']}}_icon.svg"/>
@@ -121,10 +121,10 @@
 				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}tx/{{tx['txid']}}">{{tx["txid"]}}</a></td>
 				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}address/{{display_address}}">{{wallet.getaddressname(display_address, -1)}}</a></td>
 				<td>{{tx["amount"]}}</td><td>
-				{%if tx["confirmations"] == 0 %}
+				{%if tx["block_height"] == -1 %}
 					Pending
 				{% else %}
-					{{tx["confirmations"]}}
+					{{specter.info.blocks - tx["block_height"] + 1}}
 				{% endif %}
 				</td>
 				<td>{{tx["time"] | datetime}}</td></tr>

--- a/src/cryptoadvance/specter/templates/wallet_addresses.html
+++ b/src/cryptoadvance/specter/templates/wallet_addresses.html
@@ -51,27 +51,43 @@
 	( {{ "%0.8f" % wallet.balance["trusted"] | float }} confirmed, {{"%0.8f" % wallet.balance["untrusted_pending"] | float}} pending )
 	{% endif %}
 </small></h1>
-<div class="row padded">
-	<a href="/wallets/{{wallet['alias']}}/addresses?all=True" class="btn radio left {% if alladdresses %}checked{% endif %}">History</a>
-	<a href="/wallets/{{wallet['alias']}}/addresses?all=False" class="btn radio right {% if alladdresses != True %}checked{% endif %}">UTXO</a>
+
+<div style="padding: 0 30px; width: 100%;">
+	<div class="row padded" style="width: intrinsic; margin: auto;">
+		<a href="./?all=True&view={{viewtype}}" class="btn radio left {% if alladdresses %}checked{% endif %}">History</a>
+		<a href="./?all=False&view={{viewtype}}" class="btn radio right {% if alladdresses != True %}checked{% endif %}">UTXO</a>
+	</div>
+	<span>View Type: </span><br>
+	<div class="dropdown" style="margin-top: 5px;">
+		<button class="btn radio dropbtn">{{viewtype|title}} View &#9660;</button>
+		<div class="dropdown-content">
+			<a href="./?all={{alladdresses}}&view=address">Address View</a>
+			<a href="./?all={{alladdresses}}&view=label">Labels View</a>
+		</div>
+	</div>
 </div>
-{% for address in (wallet.addresses if alladdresses else wallet.utxoaddresses) | reverse %}
-{% if alladdresses or wallet.balanceonaddr(address) > 0 %}
-{% set addrlabel = wallet.getaddressname(address, (wallet.addresses | length - loop.index0 - 1) if alladdresses else -1) %}
+{% set isaddrview = viewtype == "address" %}
+{% set accounts = (wallet.addresses if isaddrview else wallet.labels) if alladdresses else (wallet.utxoaddresses if isaddrview else wallet.utxolabels)  %}
+{% for account in accounts | reverse %}
+{% if alladdresses or (wallet.balanceonaddr(account) > 0 if isaddrview else wallet.balanceonlabel(account) > 0) %}
+{% set accountlabel = wallet.getaddressname(account, (wallet.addresses | length - loop.index0 - 1) if alladdresses else -1) if isaddrview else account %}
 <div class="table-holder">
 	<br>
-	<form action="./?all={{alladdresses}}" method="POST">
+	<form action="./?all={{alladdresses}}&view={{viewtype}}" method="POST">
 		<br>
-		<input type="text" class="label" autocomplete="off" spellcheck="false" id="{{"label" ~ loop.index0}}" name="label" value="{{addrlabel}}" style="border: none; font-size: 1.5em;" disabled />
-		<input type="hidden" name="addr" value="{{address}}"/>
+		<input type="text" class="label" autocomplete="off" spellcheck="false" id="{{"label" ~ loop.index0}}" name="label" value="{{accountlabel}}" style="border: none; font-size: 1.5em;" disabled />
+		<input type="hidden" name="account" value="{{account}}"/>
 		<button type="submit" class="btn update" id="{{"save" ~ loop.index0}}" name="action" value="updatelabel">Update</button>
-		<button type="button" class="btn cancel" id="{{"cancel" ~ loop.index0}}" onclick="toggleEdit('{{ loop.index0 }}', '{{ addrlabel }}')">Cancel</button>
-		<button type="button" class="btn edit" id="{{"edit" ~ loop.index0}}" onclick="toggleEdit('{{ loop.index0 }}', '{{ addrlabel }}')">Edit Label</button>
+		<button type="button" class="btn cancel" id="{{"cancel" ~ loop.index0}}" onclick="toggleEdit('{{ loop.index0 }}', '{{ accountlabel }}')">Cancel</button>
+		<button type="button" class="btn edit" id="{{"edit" ~ loop.index0}}" onclick="toggleEdit('{{ loop.index0 }}', '{{ accountlabel }}')">Edit Label</button>
 		<br>
 	</form><br><br>
-	<a target="blank" class="address" href="{{specter.explorer}}address/{{address}}">{{address}}</a>
+	{% if isaddrview %}
+	<a target="blank" class="address" href="{{specter.explorer}}address/{{account}}">{{account}}</a>
+	{% endif %}
 	<p class="balance">Balance: 
-		{{wallet.balanceonaddr(address)}} {% if specter.chain !='main' %}t{%endif%}BTC
+		{{"%0.8f" % (wallet.balanceonaddr(account) if isaddrview else wallet.balanceonlabel(account)) | float}} 
+		{% if specter.chain !='main' %}t{%endif%}BTC
 	</p>
 	<br><br>
 	<table>
@@ -81,14 +97,14 @@
 		</tr>
 		</thead>
 		<tbody>
-			{% if wallet.txonaddr(address) > 0 %}
+			{% if (wallet.txonaddr(account) if isaddrview else wallet.txonlabel(account) > 0) %}
 			{% for tx in wallet.transactions %}
-			{% if tx["address"] == address and (alladdresses or (wallet.istxspent(tx["txid"]) and tx["category"] != "send")) %}
-			{%if tx["confirmations"] == 0 %}
-			<tr class="unconfirmed">
-			{%else%}
-			<tr>
-			{%endif%}
+			{% if (tx["address"] == account or (tx["label"] == account and not isaddrview)) and (alladdresses or (wallet.istxspent(tx["txid"]) and tx["category"] != "send")) %}
+				{% if tx["confirmations"] == 0 %}
+					<tr class="unconfirmed">
+				{%else%}
+					<tr>
+				{%endif%}
 				<td>
 					{# coinbase txs are 'immature' until 100 confs #}
 					{% if tx['category'] == 'immature' %}
@@ -102,7 +118,7 @@
 					{% endif %}
 				</td>
 				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}tx/{{tx['txid']}}">{{tx["txid"]}}</a></td>
-				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}address/{{tx['address']}}">{{addrlabel}}</a></td>
+				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}address/{{tx['address']}}">{{accountlabel}}</a></td>
 				<td>{{tx["amount"]}}</td><td>
 				{%if tx["confirmations"] == 0 %}
 					Pending
@@ -123,14 +139,14 @@
 {% endfor %}
 {% endif %}
 <script>
-	function toggleEdit(id, addrlabel) {
+	function toggleEdit(id, accountlabel) {
 		var edit_button_display = document.getElementById("edit"+id).style.display
 		if (edit_button_display === 'none'){
 			document.getElementById("label" +id).disabled = 'true'
 			document.getElementById("label" +id).style.border = 'none'
 			document.getElementById("label" + id).style.textAlign = 'left';
 			document.getElementById("label" + id).style.fontSize = '1.5em';
-			document.getElementById("label" +id).value = addrlabel
+			document.getElementById("label" +id).value = accountlabel
 			document.getElementById("edit" +id).style.display = 'block'
 			document.getElementById("cancel" +id).style.display = 'none'
 			document.getElementById("save" +id).style.display = 'none'

--- a/src/cryptoadvance/specter/templates/wallet_addresses.html
+++ b/src/cryptoadvance/specter/templates/wallet_addresses.html
@@ -67,10 +67,10 @@
 	</div>
 </div>
 {% set isaddrview = viewtype == "address" %}
-{% set accounts = (wallet.addresses if isaddrview else wallet.labels) if alladdresses else (wallet.utxoaddresses if isaddrview else wallet.utxolabels)  %}
+{% set accounts = (wallet.active_addresses if isaddrview else wallet.labels) if alladdresses else (wallet.utxoaddresses if isaddrview else wallet.utxolabels)  %}
 {% for account in accounts | reverse %}
 {% if alladdresses or (wallet.balanceonaddr(account) > 0 if isaddrview else wallet.balanceonlabel(account) > 0) %}
-{% set accountlabel = wallet.getaddressname(account, (wallet.addresses | length - loop.index0 - 1) if alladdresses else -1) if isaddrview else account %}
+{% set accountlabel = wallet.getaddressname(account, (wallet.active_addresses | length - loop.index0 - 1) if alladdresses else -1) if isaddrview else account %}
 <div class="table-holder">
 	<br>
 	<form action="./?all={{alladdresses}}&view={{viewtype}}" method="POST">

--- a/src/cryptoadvance/specter/templates/wallet_addresses.html
+++ b/src/cryptoadvance/specter/templates/wallet_addresses.html
@@ -11,6 +11,9 @@
 		color: #fff;
 		text-decoration: underline;
 	}
+	.table-holder .balance {
+		display: inline;
+	}
 	.label {
 		text-align: left;
 		padding-left: 0;
@@ -28,7 +31,7 @@
 		float: left;
 	}
 	.edit {
-		float: left;
+		float: right;
 		margin-top: 8px;
 	}
 </style>
@@ -48,21 +51,29 @@
 	( {{ "%0.8f" % wallet.balance["trusted"] | float }} confirmed, {{"%0.8f" % wallet.balance["untrusted_pending"] | float}} pending )
 	{% endif %}
 </small></h1>
-<br>
-<h1>Address History</h1>
-{% for address in wallet.addresses | reverse %}
-{% set addrlabel = wallet.getaddressname(address, wallet.addresses | length - loop.index0 - 1) %}
+<div class="row padded">
+	<a href="/wallets/{{wallet['alias']}}/addresses?all=True" class="btn radio left {% if alladdresses %}checked{% endif %}">History</a>
+	<a href="/wallets/{{wallet['alias']}}/addresses?all=False" class="btn radio right {% if alladdresses != True %}checked{% endif %}">UTXO</a>
+</div>
+{% for address in (wallet.addresses if alladdresses else wallet.utxoaddresses) | reverse %}
+{% if alladdresses or wallet.balanceonaddr(address) > 0 %}
+{% set addrlabel = wallet.getaddressname(address, (wallet.addresses | length - loop.index0 - 1) if alladdresses else -1) %}
 <div class="table-holder">
 	<br>
-	<form action="./" method="POST">
+	<form action="./?all={{alladdresses}}" method="POST">
+		<br>
 		<input type="text" class="label" autocomplete="off" spellcheck="false" id="{{"label" ~ loop.index0}}" name="label" value="{{addrlabel}}" style="border: none; font-size: 1.5em;" disabled />
 		<input type="hidden" name="addr" value="{{address}}"/>
 		<button type="submit" class="btn update" id="{{"save" ~ loop.index0}}" name="action" value="updatelabel">Update</button>
 		<button type="button" class="btn cancel" id="{{"cancel" ~ loop.index0}}" onclick="toggleEdit('{{ loop.index0 }}', '{{ addrlabel }}')">Cancel</button>
 		<button type="button" class="btn edit" id="{{"edit" ~ loop.index0}}" onclick="toggleEdit('{{ loop.index0 }}', '{{ addrlabel }}')">Edit Label</button>
 		<br>
-		<a target="blank" class="address" href="{{specter.explorer}}address/{{address}}">{{address}}</a>
 	</form><br><br>
+	<a target="blank" class="address" href="{{specter.explorer}}address/{{address}}">{{address}}</a>
+	<p class="balance">Balance: 
+		{{wallet.balanceonaddr(address)}} {% if specter.chain !='main' %}t{%endif%}BTC
+	</p>
+	<br><br>
 	<table>
 		<thead>
 		<tr>
@@ -72,18 +83,23 @@
 		<tbody>
 			{% if wallet.txonaddr(address) > 0 %}
 			{% for tx in wallet.transactions %}
-			{% if tx['address'] == address %}
+			{% if tx["address"] == address and (alladdresses or (wallet.istxspent(tx["txid"]) and tx["category"] != "send")) %}
 			{%if tx["confirmations"] == 0 %}
 			<tr class="unconfirmed">
 			{%else%}
 			<tr>
 			{%endif%}
 				<td>
-					{%if tx["confirmations"] == 0 %}
-					<img src="/static/img/unconfirmed_{{tx['category']}}_icon.svg"/>
+					{# coinbase txs are 'immature' until 100 confs #}
+					{% if tx['category'] == 'immature' %}
+						<img src="/static/img/unconfirmed_receive_icon.svg"/>
 					{% else %}
-					<img src="/static/img/{{tx['category']}}_icon.svg"/>
-					{%endif%}
+						{% if tx["confirmations"] == 0 %}
+						<img src="/static/img/unconfirmed_{{tx['category']}}_icon.svg"/>
+						{% else %}
+						<img src="/static/img/{{tx['category']}}_icon.svg"/>
+						{% endif %}
+					{% endif %}
 				</td>
 				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}tx/{{tx['txid']}}">{{tx["txid"]}}</a></td>
 				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}address/{{tx['address']}}">{{addrlabel}}</a></td>
@@ -103,6 +119,7 @@
 		</tbody>
 	</table>
 </div>
+{% endif %}
 {% endfor %}
 {% endif %}
 <script>

--- a/src/cryptoadvance/specter/templates/wallet_settings.html
+++ b/src/cryptoadvance/specter/templates/wallet_settings.html
@@ -39,6 +39,13 @@
 	{% endif %}
 </form>
 
+<h1>Cahce</h1>
+<form action="." method="POST" class="padded" style="width: 500px">
+	<div class="row center">
+		<button type="submit" name="action" value="rebuildcache" class="btn" style="max-width: 160px;">Rebuild Cache</button>
+	</div>
+</form>
+
 <h1>Import / Export</h1>
 
 <div class="note center">

--- a/src/cryptoadvance/specter/templates/wallet_tx.html
+++ b/src/cryptoadvance/specter/templates/wallet_tx.html
@@ -28,7 +28,7 @@
 		<tbody>
 			{% if wallet.txlist != [] %}
 			{% for tx in wallet.txlist %}
-			{%if tx["confirmations"] == 0 %}
+			{%if tx["block_height"] == -1 %}
 			<tr class="unconfirmed">
 			{%else%}
 			<tr>
@@ -38,7 +38,7 @@
 					{% if tx['category'] == 'immature' %}
 						<img src="/static/img/unconfirmed_receive_icon.svg"/>
 					{% else %}
-						{% if tx["confirmations"] == 0 %}
+						{% if tx["block_height"] == -1 %}
 						<img src="/static/img/unconfirmed_{{tx['category']}}_icon.svg"/>
 						{% else %}
 						<img src="/static/img/{{tx['category']}}_icon.svg"/>
@@ -50,10 +50,10 @@
 					{{wallet.getaddressname(tx["address"] if tx["category"] != "send" or tx["destination"] == None else tx["destination"]["address"], -1)}}
 				</a></td>
 				<td>{{tx["amount"] if tx["category"] != "send" or tx["destination"] == None else tx["destination"]["amount"]}}</td><td>
-				{%if tx["confirmations"] == 0 %}
+				{%if tx["block_height"] == -1 %}
 					Pending
 				{% else %}
-					{{tx["confirmations"]}}
+					{{specter.info.blocks - tx["block_height"] + 1}}
 				{% endif %}
 				</td>
 				<td>{{tx["time"] | datetime}}</td></tr>

--- a/src/cryptoadvance/specter/templates/wallet_tx.html
+++ b/src/cryptoadvance/specter/templates/wallet_tx.html
@@ -26,8 +26,8 @@
 		</tr>
 		</thead>
 		<tbody>
-			{% if wallet.transactions != [] %}
-			{% for tx in wallet.transactions %}
+			{% if wallet.txlist != [] %}
+			{% for tx in wallet.txlist %}
 			{%if tx["confirmations"] == 0 %}
 			<tr class="unconfirmed">
 			{%else%}
@@ -46,8 +46,10 @@
 					{% endif %}
 				</td>
 				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}tx/{{tx['txid']}}">{{tx["txid"]}}</a></td>
-				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}address/{{tx['address']}}">{{wallet.getaddressname(tx["address"], -1)}}</a></td>
-				<td>{{tx["amount"]}}</td><td>
+				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}address/{{tx['address']}}">
+					{{wallet.getaddressname(tx["address"] if tx["category"] != "send" or tx["destination"] == None else tx["destination"]["address"], -1)}}
+				</a></td>
+				<td>{{tx["amount"] if tx["category"] != "send" or tx["destination"] == None else tx["destination"]["amount"]}}</td><td>
 				{%if tx["confirmations"] == 0 %}
 					Pending
 				{% else %}

--- a/tests/test_specter.py
+++ b/tests/test_specter.py
@@ -7,7 +7,7 @@ import pytest
 from cryptoadvance.specter.rpc import RpcError
 from cryptoadvance.specter.logic import (get_cli, Device, DeviceManager, Specter, Wallet, WalletManager,
                      alias)
-from cryptoadvance.specter.rpc import BitcoinCLI
+from cryptoadvance.specter.rpc_cache import BitcoinCLICached
 
 
 def test_alias():
@@ -29,7 +29,7 @@ def test_get_cli(specter_regtest_configured):
     print("rpc_config_data: {}".format(rpc_config_data))
     cli = get_cli(rpc_config_data)
     assert cli.getblockchaininfo() 
-    assert isinstance(cli, BitcoinCLI)
+    assert isinstance(cli, BitcoinCLICached)
     # ToDo test autodetection-features
 
 def test_specter(specter_regtest_configured,caplog): 


### PR DESCRIPTION
- Cache transactions details.
- Update the tx and addresses tabs to utilize the new data to better display txs data
- New UTXO view in the Addresses tab (includes change outputs).
- Added "Label view" to the Addresses tab (groups addresses with the same label, essentially allows having separate "accounts" withing the same wallet).
- Show total balance per address in the Address tab.
- Fix `immature` tx icon on the Address tab.
- Move the `Edit Label` button to the right on the Addresses tab.
- Change address auto-labeling on the Send tab.
- Add "Rebuild Cache" button to the Wallet Settings tab.