### PR TITLE
Sorting wallet and devices and some style fixes

### DIFF
--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -338,9 +338,8 @@ def wallet(wallet_alias):
 @login_required
 def wallet_tx(wallet_alias):
     app.specter.check()
-    try:
-        wallet = app.specter.wallets.get_by_alias(wallet_alias)
-    except:
+    wallet = app.specter.wallets.get_by_alias(wallet_alias)
+    if wallet is None:
         return render_template("base.html", error="Wallet not found", specter=app.specter, rand=rand)
 
     return render_template("wallet_tx.html", wallet_alias=wallet_alias, wallet=wallet, specter=app.specter, rand=rand)

--- a/src/cryptoadvance/specter/logic.py
+++ b/src/cryptoadvance/specter/logic.py
@@ -301,7 +301,7 @@ class DeviceManager:
         return self
 
     def __next__(self):
-        arr = list(self._devices.keys())
+        arr = sorted(list(self._devices.keys()))
         if self._n < len(arr):
             v = self._devices[arr[self._n]]
             self._n += 1
@@ -390,10 +390,10 @@ class WalletManager:
                 print("loading", self._wallets[k]["alias"])
                 self.cli.loadwallet(self.cli_path+self._wallets[k]["alias"])
 
-    def get_by_alias(self, fname):
-        for dev in self:
-            if dev["alias"] == fname:
-                return dev
+    def get_by_alias(self, alias):
+        for w in self:
+            if w["alias"] == alias:
+                return w
 
     def names(self):
         return list(self._wallets.keys())
@@ -510,7 +510,7 @@ class WalletManager:
         return self
 
     def __next__(self):
-        arr = list(self._wallets.keys())
+        arr = sorted(list(self._wallets.keys()))
         if self._n < len(arr):
             v = self._wallets[arr[self._n]]
             self._n += 1

--- a/src/cryptoadvance/specter/static/styles.css
+++ b/src/cryptoadvance/specter/static/styles.css
@@ -34,6 +34,9 @@ body{
 *{
     box-sizing: border-box;
 }
+.output_option{
+    margin: 5px;
+}
 .logout{
     position: absolute;
     right: 0px;

--- a/src/cryptoadvance/specter/templates/wallet_send.html
+++ b/src/cryptoadvance/specter/templates/wallet_send.html
@@ -143,7 +143,8 @@
 		{% endif %}
 
 		{% if wallet.uses_sdcard_device %}
-			<br><a class="btn centered" download='to{{address}}{{amount}}.psbt' href="data:application/octet-stream;base64,{{psbt['coldcard']}}">Download transaction</a>
+			<div><a class="btn centered" download='to{{address}}{{amount}}.psbt' href="data:application/octet-stream;base64,{{psbt['coldcard']}}">Download transaction</a>
+			</div>
 			<br>
 		{% endif %}
 


### PR DESCRIPTION
Paddy reported a bug when sending transactions from the wallet - after broadcasting specter was not able to render `/tx/` page.
It was happening because of a weird bug in the `__next__` implementation of the WalletManager - order of keys in the dictionary can change during the runtime, sorting them helps to fix the issue :)

Sorting also helps to avoid reordering of the wallets in the sidebar - they stay in place now.

This pull request also fixes a download button style issue - it was huge...