### PR TITLE
Support Device Passphrase

### DIFF
--- a/src/cryptoadvance/specter/templates/hwi_new_device_xpubs.html
+++ b/src/cryptoadvance/specter/templates/hwi_new_device_xpubs.html
@@ -77,6 +77,7 @@
 		formData.append("device_name", document.getElementById('device_name_id').value);
 		formData.append("type", hwiCurrentWallet.type);
 		formData.append("path", hwiCurrentWallet.path);
+		formData.append("passphrase", hwiWalletPassphrase);
 
 		const response = await fetch(
 			'/hwi/extract_xpubs/',

--- a/src/cryptoadvance/specter/templates/includes/hwi.html
+++ b/src/cryptoadvance/specter/templates/includes/hwi.html
@@ -233,7 +233,7 @@
         var formData = new FormData();
         formData.append("type", hwiCurrentWallet.type);
         formData.append("path", hwiCurrentWallet.path);
-        formData.append("hwiWalletPassphrase", hwiWalletPassphrase);
+        formData.append("passphrase", hwiWalletPassphrase);
         formData.append("psbt", psbt);
 
         try {

--- a/src/cryptoadvance/specter/templates/includes/hwi.html
+++ b/src/cryptoadvance/specter/templates/includes/hwi.html
@@ -170,6 +170,10 @@
                 }
             });
 
+        } else if (hwiCurrentWallet.code == -18) {
+            // TODO: Support wallet initializing if possible
+            hidePageOverlay("hwi_include__select_device");
+            alert("Could not load device - device is not initialized.")
         } else {
             // Already unlocked
             hidePageOverlay("hwi_include__select_device");

--- a/src/cryptoadvance/specter/templates/includes/hwi.html
+++ b/src/cryptoadvance/specter/templates/includes/hwi.html
@@ -50,6 +50,20 @@
     </div>
 </div>
 
+<div id="hwi_include__enter_passphrase" class="hidden">
+    <h2>Enter Passphrase</h2>
+    <form autocomplete="off">
+        <div id="hwi_include__enter_passphrase__content" class="flex-center flex-column">
+            <br/>
+            <div>
+                <input name="passphrase" type="password" id="hwi_include__enter_passphrase__passphrase" />
+            </div>
+            <br/>
+            <br/>
+            <button id="hwi_include__enter_passphrase__submit" class="btn">submit</button>
+        </div>
+    </form>
+</div>
 
 <div id="hwi_include__unlocked" class="hidden">
     <h2>USB Wallet Unlocked</h2>
@@ -76,6 +90,7 @@
 
     var hwiCurrentWallet;
     var hwiWalletPIN = "";
+    var hwiWalletPassphrase = ""
 
 
     function hwiSelectHWIDevice() {
@@ -93,6 +108,7 @@
         **/
         var formData = new FormData();
         formData.append("type", type);
+        formData.append("passphrase", hwiWalletPassphrase);
 
         try {
             const response = await fetch(
@@ -134,6 +150,7 @@
         var formData = new FormData();
         formData.append("type", hwiCurrentWallet.type);
         formData.append("path", hwiCurrentWallet.path);
+        formData.append("passphrase", hwiWalletPassphrase);
 
         const response = await fetch(
             '/hwi/prompt_pin/',
@@ -160,7 +177,10 @@
         hwiCurrentWallet.typeDisplay = hwiTypeToDisplayName(hwiCurrentWallet.type);
         console.log(hwiCurrentWallet);
 
-        if (hwiCurrentWallet.needs_pin_sent) {
+        if (hwiCurrentWallet.needs_passphrase_sent) {
+            hidePageOverlay("hwi_include__select_device");
+            showPageOverlay("hwi_include__enter_passphrase");
+        } else if (hwiCurrentWallet.needs_pin_sent) {
             hwiPromptPin().then(async function(promptResult) {
                 if (promptResult.success) {
                     hidePageOverlay("hwi_include__select_device");
@@ -191,6 +211,7 @@
         formData.append("type", hwiCurrentWallet.type);
         formData.append("path", hwiCurrentWallet.path);
         formData.append("pin", hwiWalletPIN);
+        formData.append("passphrase", hwiWalletPassphrase);
 
         const response = await fetch(
             '/hwi/send_pin/',
@@ -212,6 +233,7 @@
         var formData = new FormData();
         formData.append("type", hwiCurrentWallet.type);
         formData.append("path", hwiCurrentWallet.path);
+        formData.append("hwiWalletPassphrase", hwiWalletPassphrase);
         formData.append("psbt", psbt);
 
         try {
@@ -286,6 +308,7 @@
     document.addEventListener("DOMContentLoaded", function(){
         // Handler when the DOM is fully loaded
         initPageOverlay("hwi_include__select_device");
+        initPageOverlay("hwi_include__enter_passphrase");
         initPageOverlay("hwi_include__enter_pin");
         initPageOverlay("hwi_include__unlocked");
 
@@ -337,6 +360,32 @@
                 hwiShowUnlocked();
             } else {
                 // pin failed...
+            }
+        });
+
+        document.getElementById("hwi_include__enter_passphrase__submit").addEventListener("click", async function(e) {
+            e.preventDefault();
+
+            var loader = document.getElementById("hwi_include__loading");
+            var content = document.getElementById("hwi_include__enter_passphrase__content");
+            content.style.display = "none";
+
+            loader.style.display = "flex";
+            document.getElementById("hwi_include__enter_passphrase").appendChild(loader);
+
+            hwiWalletPassphrase = document.getElementById("hwi_include__enter_passphrase__passphrase").value;
+
+            hidePageOverlay("hwi_include__enter_passphrase");
+            if (hwiCurrentWallet.needs_pin_sent){
+                hwiPromptPin().then(async function(promptResult) {
+                    if (promptResult.success) {
+                        showPageOverlay("hwi_include__enter_pin");
+                    } else {
+                        console.log(promptResult);
+                    }
+                });
+            } else {
+                hwiShowUnlocked();
             }
         });
 

--- a/src/cryptoadvance/specter/views/hwi.py
+++ b/src/cryptoadvance/specter/views/hwi.py
@@ -16,13 +16,13 @@ rand = random.randint(0, 1e32) # to force style refresh
 
 hwi_views = Blueprint('hwi', __name__, template_folder='templates')
 
-def get_spector_instance():
+def get_specter_instance():
     # specter instance is injected into app in server.py's __main__()
     return current_app.specter
 
 
 def get_hwi_client(type, path):
-    is_test = 'test' in get_spector_instance().chain
+    is_test = 'test' in get_specter_instance().chain
     if type == "specter":
         client = SpecterClient(path)
     else:
@@ -56,7 +56,7 @@ def _enumerate():
 
 @hwi_views.route('/extract_xpubs/', methods=['POST'])
 def hwi_extract_xpubs():
-    specter = get_spector_instance()
+    specter = get_specter_instance()
 
     device_name = request.form['device_name']
     if device_name in specter.devices.names():
@@ -151,7 +151,7 @@ def hwi_extract_xpubs():
 @hwi_views.route('/new_device/', methods=['GET'])
 def hwi_new_device_xpubs():
     err = None
-    specter = get_spector_instance()
+    specter = get_specter_instance()
     specter.check()
 
     return render_template(

--- a/src/cryptoadvance/specter/views/hwi.py
+++ b/src/cryptoadvance/specter/views/hwi.py
@@ -21,12 +21,12 @@ def get_specter_instance():
     return current_app.specter
 
 
-def get_hwi_client(type, path):
+def get_hwi_client(type, path, passphrase=''):
     is_test = 'test' in get_specter_instance().chain
     if type == "specter":
         client = SpecterClient(path)
     else:
-        client = hwilib_commands.get_client(type, path)
+        client = hwilib_commands.get_client(type, path, passphrase)
     client.is_testnet = is_test
     return client
 
@@ -64,9 +64,11 @@ def hwi_extract_xpubs():
     
     type = request.form.get("type")
     path = request.form.get("path")
+    passphrase = request.form.get("passphrase")
+    print(passphrase)
 
     try:
-        client = get_hwi_client(type, path)
+        client = get_hwi_client(type, path, passphrase=passphrase)
 
         # Client will be configured for testnet if our Specter instance is
         #   currently connected to testnet. This will prevent us from
@@ -201,6 +203,8 @@ def hwi_prompt_pin():
     print(request.form)
     type = request.form.get("type")
     path = request.form.get("path")
+    passphrase = request.form.get("passphrase")
+    print('passphrase: {}'.format(passphrase))
 
     try:
         if type == "keepkey" or type == "trezor":
@@ -210,7 +214,7 @@ def hwi_prompt_pin():
             #       7 8 9
             #       4 5 6
             #       1 2 3
-            client = get_hwi_client(type, path)
+            client = get_hwi_client(type, path, passphrase=passphrase)
             status = hwilib_commands.prompt_pin(client)
             return jsonify(success=True, status=status)
         else:
@@ -224,10 +228,11 @@ def hwi_prompt_pin():
 def hwi_send_pin():
     type = request.form.get("type")
     path = request.form.get("path")
+    passphrase = request.form.get("passphrase")
     pin = request.form.get("pin")
 
     try:
-        client = get_hwi_client(type, path)
+        client = get_hwi_client(type, path, passphrase=passphrase)
         status = hwilib_commands.send_pin(client, pin)
         return jsonify(status)
     except Exception as e:
@@ -239,10 +244,11 @@ def hwi_send_pin():
 def hwi_sign_tx():
     type = request.form.get("type")
     path = request.form.get("path")
+    passphrase = request.form.get("passphrase")
     psbt = request.form.get("psbt")
 
     try:
-        client = get_hwi_client(type, path)
+        client = get_hwi_client(type, path, passphrase=passphrase)
         status = hwilib_commands.signtx(client, psbt)
         print(status)
 


### PR DESCRIPTION
Support using devices that have passphrase protection enabled - when passphrase protection is on, the user will be prompted to enter the passphrase for wallet interactions.
Also, notify users when the wallet they use is not initialized (instead of stuck UI as there is no).