### PR TITLE
Fix fullbalance wrong condition

### DIFF
--- a/src/cryptoadvance/specter/views/hwi.py
+++ b/src/cryptoadvance/specter/views/hwi.py
@@ -65,7 +65,6 @@ def hwi_extract_xpubs():
     type = request.form.get("type")
     path = request.form.get("path")
     passphrase = request.form.get("passphrase")
-    print(passphrase)
 
     try:
         client = get_hwi_client(type, path, passphrase=passphrase)


### PR DESCRIPTION
- Fixed wrong condition in getting the full balance
- Moved locked UTXO get balance code to `getbalances` (so it imitates the `getbalances` behavior correctly for unconfirmed locked UTXO).
- Delete a `print` left by mistake.