### PR TITLE
Support Rename and Delete wallet

### DIFF
--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -488,6 +488,16 @@ def wallet_settings(wallet_alias):
             wallet.getdata()
         elif action == "rebuildcache":
             wallet.cli.cache.rebuild_cache()
+        elif action == "deletewallet":
+            app.specter.wallets.delete_wallet(wallet)
+            response = redirect(url_for('index'))
+            return response
+        elif action == "renamewallet":
+            wallet_name = request.form['walletname']
+            if wallet_name in app.specter.wallets.names():
+                error = "Wallet already exists"
+            else:
+                app.specter.wallets.rename_wallet(wallet, wallet_name)
 
     cc_file = None
     qr_text = wallet["name"]+"&"+wallet.descriptor

--- a/src/cryptoadvance/specter/templates/wallet_settings.html
+++ b/src/cryptoadvance/specter/templates/wallet_settings.html
@@ -4,9 +4,11 @@
 <form action="./" method="POST">
 	<h1 id="nametitle">{{wallet.name}}</h1>
 	<input type="text" class="label" autocomplete="off" spellcheck="false" id="walletname" name="walletname" value="{{wallet.name}}" style="font-size: 1.5em; text-align: center; display: none;" />
-	<button type="submit" class="btn update" id="savename" name="action" value="renamewallet" style="display: none; width: 49.2%;">Update</button>
-	<button type="button" class="btn cancel" id="cancelname" onclick="toggleEdit()" style="display: none; width: 49.2%;">Cancel</button>
-	<button type="button" class="btn edit" id="editname" onclick="toggleEdit()">Edit Wallet Name</button>
+	<div class="row">
+		<button type="submit" class="btn update" id="savename" name="action" value="renamewallet" style="display: none; width: 49.2%; margin: 3px;">Update</button>
+		<button type="button" class="btn cancel" id="cancelname" onclick="toggleEdit()" style="display: none; width: 49.2%; margin: 3px;">Cancel</button>
+		<button type="button" class="btn edit" id="editname" onclick="toggleEdit()">Edit Wallet Name</button>
+	</div>
 </form>
 <div class="row padded">
 	<a href="/wallets/{{wallet['alias']}}/tx/" class="btn radio left">Transactions</a>

--- a/src/cryptoadvance/specter/templates/wallet_settings.html
+++ b/src/cryptoadvance/specter/templates/wallet_settings.html
@@ -7,8 +7,6 @@
 	<button type="submit" class="btn update" id="savename" name="action" value="renamewallet" style="display: none; width: 49.2%;">Update</button>
 	<button type="button" class="btn cancel" id="cancelname" onclick="toggleEdit()" style="display: none; width: 49.2%;">Cancel</button>
 	<button type="button" class="btn edit" id="editname" onclick="toggleEdit()">Edit Wallet Name</button>
-	<br>
-	<a target="blank" class="address" href="{{specter.explorer}}address/{{address}}">{{address}}</a>
 </form>
 <div class="row padded">
 	<a href="/wallets/{{wallet['alias']}}/tx/" class="btn radio left">Transactions</a>

--- a/src/cryptoadvance/specter/templates/wallet_settings.html
+++ b/src/cryptoadvance/specter/templates/wallet_settings.html
@@ -1,6 +1,15 @@
 {% extends "base.html" %}
 {% block main %}
-<h1>{{wallet.name}}</h1>
+
+<form action="./" method="POST">
+	<h1 id="nametitle">{{wallet.name}}</h1>
+	<input type="text" class="label" autocomplete="off" spellcheck="false" id="walletname" name="walletname" value="{{wallet.name}}" style="font-size: 1.5em; text-align: center; display: none;" />
+	<button type="submit" class="btn update" id="savename" name="action" value="renamewallet" style="display: none; width: 49.2%;">Update</button>
+	<button type="button" class="btn cancel" id="cancelname" onclick="toggleEdit()" style="display: none; width: 49.2%;">Cancel</button>
+	<button type="button" class="btn edit" id="editname" onclick="toggleEdit()">Edit Wallet Name</button>
+	<br>
+	<a target="blank" class="address" href="{{specter.explorer}}address/{{address}}">{{address}}</a>
+</form>
 <div class="row padded">
 	<a href="/wallets/{{wallet['alias']}}/tx/" class="btn radio left">Transactions</a>
 	<a href="/wallets/{{wallet['alias']}}/addresses/" class="btn radio">Addresses</a>
@@ -66,4 +75,30 @@
 <div>
 	<code style="max-width: 700px; word-wrap: break-all; overflow-x: scroll; display: block; padding: 20px 0;">{{qr_text}}</code>
 </div>
+<h1>Delete Wallet</h1>
+<form action="." method="POST" class="padded" style="width: 500px">
+	<div class="row center">
+		<button type="submit" name="action" value="deletewallet" class="btn danger" style="max-width: 160px;">Delete Wallet</button>
+	</div>
+</form>
+<script>
+	function toggleEdit() {
+		var edit_button_display = document.getElementById("editname").style.display
+		if (edit_button_display === 'none'){
+			document.getElementById("editname").style.display = 'block'
+			document.getElementById("cancelname").style.display = 'none'
+			document.getElementById("savename").style.display = 'none'
+			document.getElementById("nametitle").style.display = 'block'
+			document.getElementById("walletname").style.display = "none"
+		} else {
+			document.getElementById("walletname").style.fontSize = '1.5em';
+			document.getElementById("walletname").value = "{{ wallet.name }}"
+			document.getElementById("walletname").style.display = "block"
+			document.getElementById("editname").style.display = 'none'
+			document.getElementById("cancelname").style.display = 'inline-block'
+			document.getElementById("savename").style.display = 'inline-block'
+			document.getElementById("nametitle").style.display = 'none'
+		}
+	}
+</script>
 {% endblock %}


### PR DESCRIPTION
Add the ability to delete and rename wallets from the wallet Settings tab. This is very handy mostly when creating many test wallets, but also a nice feature for real use.

This PR also makes sure the create wallet will not unexpectedly import an existing old wallet with the same name.