### PR TITLE
Upgrade HWI to version 1.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==1.1.1
 Flask-Login==0.5.0
 Flask-QRcode==3.0.0
 hidapi==0.7.99.post21
-hwi==1.0.3
+hwi==1.1.0
 idna==2.8
 itsdangerous==1.1.0
 Jinja2==2.10.3

--- a/src/cryptoadvance/specter/views/hwi.py
+++ b/src/cryptoadvance/specter/views/hwi.py
@@ -75,8 +75,7 @@ def hwi_extract_xpubs():
         client.is_testnet = False
         xpubs = ""
 
-        master_xpub = client.get_pubkey_at_path('m/0')['xpub']
-        master_fpr = hwilib_commands.get_xpub_fingerprint_hex(master_xpub)
+        master_fpr = client.get_master_fingerprint_hex()
 
         # HWI calls to client.get_pubkey_at_path() return "xpub"-prefixed xpubs
         # regardless of derivation path. Update to match SLIP-0132 prefixes.


### PR DESCRIPTION
The most notable change in this release is the support for the latest Trezor firmware, which currently doesn't work well with Specter. The full change list is available [here](https://github.com/bitcoin-core/HWI/releases/tag/1.1.0).