### PR TITLE
Tidyup wallet_send

### DIFF
--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -402,7 +402,7 @@ def fees(blocks):
     res = app.specter.estimatesmartfee(int(blocks))
     return res
 
-@app.route('/wallets/<wallet_alias>/send/', methods=['GET', 'POST'])
+@app.route('/wallets/<wallet_alias>/send/new', methods=['GET', 'POST'])
 @login_required
 def wallet_send(wallet_alias):
     app.specter.check()
@@ -452,7 +452,7 @@ def wallet_send(wallet_alias):
                                                 wallet_alias=wallet_alias, wallet=wallet, 
                                                 specter=app.specter, rand=rand)
 
-@app.route('/wallets/<wallet_alias>/sendpending/', methods=['GET', 'POST'])
+@app.route('/wallets/<wallet_alias>/send/pending/', methods=['GET', 'POST'])
 @login_required
 def wallet_sendpending(wallet_alias):
     app.specter.check()

--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -416,8 +416,6 @@ def wallet_send(wallet_alias):
     label = ""
     amount = 0
     fee_rate = 0.0
-    err = None
-    pending_psbts = None
     if request.method == "POST":
         action = request.form['action']
         if action == "createpsbt":
@@ -447,19 +445,32 @@ def wallet_send(wallet_alias):
                             if address in v["scriptPubKey"]["addresses"]:
                                 amount = v["value"]
             except Exception as e:
-                err = "%r" % e
+                flash(e, "error")
         elif action == "openpsbt":
             psbt = ast.literal_eval(request.form["pending_psbt"])
-        elif action == "deletepsbt":
-            wallet.delete_pending_psbt(ast.literal_eval(request.form["pending_psbt"])["tx"]["txid"])
-
-    list_psbts = True if request.args.get('pending') == 'True' else False
-    if list_psbts:
-        pending_psbts = wallet.pending_psbts
-
-    return render_template("wallet_send.html", list_psbts=list_psbts, pending_psbts=pending_psbts, psbt=psbt, label=label, 
+    return render_template("wallet_send.html", psbt=psbt, label=label, 
                                                 wallet_alias=wallet_alias, wallet=wallet, 
-                                                specter=app.specter, rand=rand, error=err)
+                                                specter=app.specter, rand=rand)
+
+@app.route('/wallets/<wallet_alias>/sendpending/', methods=['GET', 'POST'])
+@login_required
+def wallet_sendpending(wallet_alias):
+    app.specter.check()
+    try:
+        wallet = app.specter.wallets.get_by_alias(wallet_alias)
+    except Exception as e:
+        print(e)
+        return render_template("base.html", error="Wallet not found", specter=app.specter, rand=rand)
+    if request.method == "POST":
+        try:
+            wallet.delete_pending_psbt(ast.literal_eval(request.form["pending_psbt"])["tx"]["txid"])
+        except Exception as e:
+            flash("Could not delete Pending PSBT!")
+    pending_psbts = wallet.pending_psbts
+    return render_template("wallet_sendpending.html", pending_psbts=pending_psbts,
+                                                wallet_alias=wallet_alias, wallet=wallet, 
+                                                specter=app.specter) 
+
 
 @app.route('/wallets/<wallet_alias>/settings/', methods=['GET','POST'])
 @login_required

--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -446,8 +446,14 @@ def wallet_send(wallet_alias):
                                 amount = v["value"]
             except Exception as e:
                 flash(e, "error")
+            return render_template("wallet_send_sign_psbt.html", psbt=psbt, label=label, 
+                                                wallet_alias=wallet_alias, wallet=wallet, 
+                                                specter=app.specter, rand=rand)
         elif action == "openpsbt":
             psbt = ast.literal_eval(request.form["pending_psbt"])
+            return render_template("wallet_send_sign_psbt.html", psbt=psbt, label=label, 
+                                                wallet_alias=wallet_alias, wallet=wallet, 
+                                                specter=app.specter, rand=rand)
     return render_template("wallet_send.html", psbt=psbt, label=label, 
                                                 wallet_alias=wallet_alias, wallet=wallet, 
                                                 specter=app.specter, rand=rand)

--- a/src/cryptoadvance/specter/templates/includes/wallet_menu.html
+++ b/src/cryptoadvance/specter/templates/includes/wallet_menu.html
@@ -1,7 +1,7 @@
 <div class="row padded">
-	<a href="{{ url_for('wallet_tx',wallet_alias=wallet_alias)}}" class="btn radio left {% if active_menu_item == 'transactions' %}checked{% endif %}">Transactions</a>
-	<a href="{{ url_for('wallet_addresses',wallet_alias=wallet_alias)}}" class="btn radio {% if active_menu_item == 'addresses' %}checked{% endif %}">Addresses</a>
-	<a href="{{ url_for('wallet_receive',wallet_alias=wallet_alias)}}" class="btn radio {% if active_menu_item == 'receive' %}checked{% endif %}">Receive</a>
-	<a href="{{ url_for('wallet_send',wallet_alias=wallet_alias)}}" class="btn radio {% if active_menu_item == 'send' %}checked{% endif %}">Send</a>
-	<a href="{{ url_for('wallet_settings',wallet_alias=wallet_alias)}}" class="btn radio right {% if active_menu_item == 'settings' %}checked{% endif %}">Settings</a>
+	<a href="{{ url_for('wallet_tx',wallet_alias=wallet_alias)}}" class="btn radio left {% if active_menuitem == 'transactions' %}checked{% endif %}">Transactions</a>
+	<a href="{{ url_for('wallet_addresses',wallet_alias=wallet_alias)}}" class="btn radio {% if active_menuitem == 'addresses' %}checked{% endif %}">Addresses</a>
+	<a href="{{ url_for('wallet_receive',wallet_alias=wallet_alias)}}" class="btn radio {% if active_menuitem == 'receive' %}checked{% endif %}">Receive</a>
+	<a href="{{ url_for('wallet_send',wallet_alias=wallet_alias)}}" class="btn radio {% if active_menuitem == 'send' %}checked{% endif %}">Send</a>
+	<a href="{{ url_for('wallet_settings',wallet_alias=wallet_alias)}}" class="btn radio right {% if active_menuitem == 'settings' %}checked{% endif %}">Settings</a>
 </div>

--- a/src/cryptoadvance/specter/templates/includes/wallet_menu.html
+++ b/src/cryptoadvance/specter/templates/includes/wallet_menu.html
@@ -1,0 +1,7 @@
+<div class="row padded">
+	<a href="{{ url_for('wallet_tx',wallet_alias=wallet_alias)}}" class="btn radio left {% if active_menu_item == 'transactions' %}checked{% endif %}">Transactions</a>
+	<a href="{{ url_for('wallet_addresses',wallet_alias=wallet_alias)}}" class="btn radio {% if active_menu_item == 'addresses' %}checked{% endif %}">Addresses</a>
+	<a href="{{ url_for('wallet_receive',wallet_alias=wallet_alias)}}" class="btn radio {% if active_menu_item == 'receive' %}checked{% endif %}">Receive</a>
+	<a href="{{ url_for('wallet_send',wallet_alias=wallet_alias)}}" class="btn radio {% if active_menu_item == 'send' %}checked{% endif %}">Send</a>
+	<a href="{{ url_for('wallet_settings',wallet_alias=wallet_alias)}}" class="btn radio right {% if active_menu_item == 'settings' %}checked{% endif %}">Settings</a>
+</div>

--- a/src/cryptoadvance/specter/templates/wallet_addresses.html
+++ b/src/cryptoadvance/specter/templates/wallet_addresses.html
@@ -36,13 +36,8 @@
 	}
 </style>
 <h1>{{wallet.name}}</h1>
-<div class="row padded">
-	<a href="/wallets/{{wallet['alias']}}/tx/" class="btn radio left">Transactions</a>
-	<a href="/wallets/{{wallet['alias']}}/addresses/" class="btn radio checked">Addresses</a>
-	<a href="/wallets/{{wallet['alias']}}/receive/" class="btn radio">Receive</a>
-	<a href="/wallets/{{wallet['alias']}}/send/" class="btn radio">Send</a>
-	<a href="/wallets/{{wallet['alias']}}/settings/" class="btn radio right">Settings</a>
-</div>
+{% set active_menuitem = "receive" %}
+{% include "includes/wallet_menu.html" %}
 {% if ( wallet.fullbalance ) is not none %}
 <h1><small style="line-height:30px">Total balance:<br></small><span style="color: #fff">
 	{{ "%0.8f" % ( wallet.fullbalance ) | float }}

--- a/src/cryptoadvance/specter/templates/wallet_receive.html
+++ b/src/cryptoadvance/specter/templates/wallet_receive.html
@@ -1,13 +1,8 @@
 {% extends "base.html" %}
 {% block main %}
 <h1>{{wallet.name}}</h1>
-<div class="row padded">
-	<a href="/wallets/{{wallet['alias']}}/tx/" class="btn radio left">Transactions</a>
-	<a href="/wallets/{{wallet['alias']}}/addresses/" class="btn radio">Addresses</a>
-	<a href="/wallets/{{wallet['alias']}}/receive/" class="btn radio checked">Receive</a>
-	<a href="/wallets/{{wallet['alias']}}/send/" class="btn radio">Send</a>
-	<a href="/wallets/{{wallet['alias']}}/settings/" class="btn radio right">Settings</a>
-</div>
+{% set active_menuitem = "receive" %}
+{% include "includes/wallet_menu.html" %}
 <div class="center">
 <form action="./" method="POST">
 	{% set addrlabel = wallet.getaddressname(wallet['address'], wallet['address_index']) %}

--- a/src/cryptoadvance/specter/templates/wallet_send.html
+++ b/src/cryptoadvance/specter/templates/wallet_send.html
@@ -192,7 +192,6 @@ document.getElementById("slider_confTime").value = 6
 				} else {
 					return Math.min(this.selected_coins_sum, this.wallet_availablebalance)
 				}
-				
 			},
 			needs_more_selected_coins: function() {
 				return this.amount > this.selected_coins_sum && this.coinselectionActive

--- a/src/cryptoadvance/specter/templates/wallet_send.html
+++ b/src/cryptoadvance/specter/templates/wallet_send.html
@@ -164,6 +164,51 @@ document.getElementById("fee_unit").value = "BTC_KB"
 document.getElementById("slider_confTime").value = 6
 </script>
 
+
+<script type="module">
+
+import QrScanner from "/static/qr/qr-scanner.min.js";
+QrScanner.WORKER_PATH = '/static/qr/qr-scanner-worker.min.js';
+
+const video = document.getElementById('qr-video');
+
+const scanner = new QrScanner(video, result => {
+	scanner.stop();
+	document.getElementById("popup").style.display = 'none';
+		let addr = result;
+		if(addr.indexOf("bitcoin:") >= 0){
+			addr = addr.substr(addr.indexOf("bitcoin:")+8);
+		}
+		let arr = addr.split("?");
+		addr = arr[0]
+		document.getElementById("address").value = addr;
+		let evt = new Event('input');
+		document.getElementById("address").dispatchEvent(evt);
+		if(arr.length > 1){
+			arr = arr[1].split("&");
+			arr.forEach((e)=>{
+				if(e.startsWith("amount=")){
+					document.getElementById("amount").value = parseFloat(e.substr(7));
+					let evt = new Event('input');
+					document.getElementById("amount").dispatchEvent(evt);
+				}
+			});
+		}
+});
+document.getElementById("scanme").addEventListener("click", function(){
+	try{
+		scanner.start();
+		document.getElementById("popup").style.display = 'flex';
+	}catch(e){
+		alert("Can't start the QR scanner!\n\n" + e);
+	}
+});
+document.getElementById("popup").addEventListener("click", function(){
+	document.getElementById("popup").style.display = 'none';
+	scanner.stop();
+});
+</script>
+
 <script>
 	var spend_coins = new Vue({
 		el: '#spend_coins',

--- a/src/cryptoadvance/specter/templates/wallet_send.html
+++ b/src/cryptoadvance/specter/templates/wallet_send.html
@@ -4,25 +4,12 @@
 {% include "includes/hwi.html" %}
 
 <style>
-	.tx_info {
-		padding: 1em;
-		border: 1px solid #506072;
-		border-radius: 4px;
-		text-align: center;
-		margin-bottom: 2em;
-	}
 	.fee_container {
 		height: 11em;
 	}
 	.fee_rate {
 		width: 6em;
 		min-width: 6em;
-	}
-	.hwi_container{
-		margin-bottom: 2em;
-	}
-	.hwi-column-btn {
-		margin: 0.75em;
 	}
 	#coinselection-table .tx {
 		width: 100%;
@@ -38,267 +25,88 @@
 	}
 </style>
 <h1>{{wallet.name}}</h1>
-<div class="row padded">
-	<a href="/wallets/{{wallet['alias']}}/tx/" class="btn radio left">Transactions</a>
-	<a href="/wallets/{{wallet['alias']}}/addresses/" class="btn radio">Addresses</a>
-	<a href="/wallets/{{wallet['alias']}}/receive/" class="btn radio">Receive</a>
-	<a href="/wallets/{{wallet['alias']}}/send/" class="btn radio checked">Send</a>
-	<a href="/wallets/{{wallet['alias']}}/settings/" class="btn radio right">Settings</a>
-</div>
+{% set active_menuitem = "send" %}
+{% include "includes/wallet_menu.html" %}
 <br>
-<form action="./" method="POST" class="full-width">
-	{% if not psbt %}
+<form action="{{ url_for('wallet_send',wallet_alias=wallet_alias)}}" method="POST" class="full-width">
+	<div class="row">
+		<a href="{{ url_for('wallet_send',wallet_alias=wallet_alias)}}" class="btn radio left checked">New</a>
+		<a href="{{ url_for('wallet_sendpending',wallet_alias=wallet_alias)}}" class="btn radio right">Pending</a>
+	</div>
+	<h1 class="padded">Sending to:</h1>
+	<div class="card"  id="spend_coins">
+		Recipient address:<br>
 		<div class="row">
-			<a href="./?pending=False" class="btn radio left {% if not list_psbts %}checked{% endif %}">New</a>
-			<a href="./?pending=True" class="btn radio right {% if list_psbts %}checked{% endif %}">Pending</a>
+			<input type="text" id="address" name="address" v-model="address"> &nbsp;
+			<a class="btn" id="scanme"><img src="/static/img/qr_tiny.svg"/> Scan</a>
 		</div>
-		{% if not list_psbts %}
-			<h1 class="padded">Sending to:</h1>
-			<div class="card"  id="spend_coins">
-				Recipient address:<br>
-				<div class="row">
-					<input type="text" id="address" name="address" v-model="address"> &nbsp;
-					<a class="btn" id="scanme"><img src="/static/img/qr_tiny.svg"/> Scan</a>
-				</div>
-				<br>
-				Address label (optional):<br>
-				<input type="text" id="label" name="label" value="{{label}}">
-				<br><br>
-				Amount:<br>
-				<input type="number" name="amount" v-model="amount" id="amount" v-bind:max="max_amount_sendable" min=0 step="1e-8" autocomplete="off">
-				<div class="notification error" v-if="above_wallet_amount || needs_more_selected_coins">
-					<ul>
-						<li v-if="needs_more_selected_coins"> You need to select more coins to match your amount!</li>
-						<li v-if="above_wallet_amount"> You cannot send more than [[wallet_availablebalance]] !</li>
-					</ul>
-				</div>
-				<div class="note">
-					Available: {{"%.8f" % wallet.availablebalance}}{% if wallet.locked_amount > 0 %};
-					&nbsp;Locked in pending transactions: {{"%.8f" % wallet.locked_amount}}
-					{% endif %}
-				</div>
-				<div><label><input type="checkbox" class="inline" name="subtract" value="1"> Subtract from amount</label></div>
-				<br><br>
-			
-				<div class="fee_container">
-					<div>
-						Fees: <label><input type="radio" class="inline" style="margin: 0 10px 0 20px;" id="fee_option_dynamic"  name="fee_options" value="dynamic" onclick="showFeeOption(this)" checked>dynamic</label>
-						<label><input type="radio" class="inline" style="margin: 0 10px 0 20px" name="fee_options" value="manual" onclick="showFeeOption(this);">manual</label>
-					</div>
-					<br><br>
-					<input type="hidden" id="fee_unit" name="fee_unit" value="">
-					<div id = "fee_manual" style="display:none">
-						Fee rate:<br>
-						<input type="number" class="fee_rate" name="fee_rate" id="fee_rate" max="100" min=0 step="0.25" autocomplete="off"> sat/B
-						<div class="note">leave blank to set automatically</div>
-						<br><br>
-					</div>
-					<div id ="fee_dynamic" style="display:block">
-						<div id="blocks"></div>
-						<input type="range" style="width: 12em" min="1" max="25" value="6" step="1" id="slider_confTime" oninput="loadDynamicFees(this.value)">
-						<input type="hidden" id="fee_rate_dynamic" name="fee_rate_dynamic" value="0">
-						<div> Fee rate: <span id="fee_rate_dynamic_text"></span></div>
-						<br><br>
-					</div>
-				</div>
-				<div>
-					<button id="coinselect" v-on:click="toggleExpand" type="button" class="btn" v-if="unspents.length>0">Select coins</button>
-					<table style="table-layout:fixed; display: block;" v-if="coinselectionActive" id="coinselection-table">
-						<thead>
-						<tr>
-							<th></th><th>TxID</th><th>Address</th><th>Amount</th>
-						</tr>
-						</thead>
-						<tbody>
-							<tr v-for="tx in unspents" v-bind:key="tx.txid">
-								<td>
-									<input class="checkbox" type="checkbox" v-model="tx.selected" name="coinselect" v-bind:value="[tx.txid, tx.vout, tx.amount]">
-								</td>
-								<td class="tx scroll"><a :href="block_explorer+'tx/'+tx.txid" target="blank">[[ tx.txid ]]</a></td>
-								<td class="tx scroll">
-									<a :href="block_explorer+'address/'+tx.address" target="blank">
-										[[ tx.label != '' && tx.label != undefined ? tx.label : tx.address ]]
-									</a>
-								</td>
-								<td>[[ tx.amount ]]</td>
-							</tr>
-						</tbody>
-					</table>
-				</div>
-				<button type="submit" v-bind:disabled="above_wallet_amount || needs_more_selected_coins || amount == '' || address == ''" name="action" value="createpsbt" class="btn centered" style="margin-top: 20px;">Create unsigned transaction</button>
-			</div>
-		{% else %}
-			<h1 class="padded">Pending Transactions:</h1>
-			<div class="table-holder">
-				<table>
-					<thead>
-					<tr>
-						<th></th><th>Address</th><th>Amount</th><th>Time</th><th>Sigs</th><th>Actions</th>
-					</tr>
-					</thead>
-					<tbody>
-						{% if pending_psbts %}
-							{% for txid in pending_psbts %}
-								{% set pending_psbt = pending_psbts[txid] %}
-								<tr>
-									<td></td>
-									<td class="tx scroll">
-										<a target="blank" href="{{specter.explorer}}address/{{ pending_psbt['address'] }}">
-											{{wallet.getaddressname(pending_psbt["address"], -1)}}
-										</a>
-									</td>
-									<td>
-										{{ pending_psbt["amount"] }}
-									</td>
-									<td>
-										{{ pending_psbt["time"] | datetime }}
-									</td>
-									<td>
-										{{ "{}/{}".format(pending_psbt["sigs_count"], wallet.sigs_required) }}
-									</td>
-									<td width="170px">
-										<form action="./?pending={{list_psbts}}" method="POST">
-											<input type="hidden" name="pending_psbt" value="{{pending_psbt}}">
-											<div class="row">
-												<button type="submit" name="action" value="openpsbt" class="btn" style="margin-right: 5px;">Open</button>
-												<button type="submit" name="action" value="deletepsbt" class="btn danger" style="margin-left: 5px;" onclick="javascript: form.action='./?pending=True';">Delete</button>
-											</div>
-										</form>
-									</td>
-								</tr>
-							{% endfor %}
-						{% else %}
-							<td></td><td>No transactions yet.</td><td></td><td></td><td></td><td></td>
-						{% endif %}
-					</tbody>
-				</table>
-			</div>
-		{% endif %}
-	{% else %}
-		<div class="tx_info">
-			
-			<div>Sending <b>{{psbt["amount"]}}</b> BTC to<b>
-				<a class="address-link" target="blank" href="{{specter.explorer}}address/{{ psbt['address'] }}">
-				{{wallet.getaddressname(psbt["address"], -1)}}
-				</a></b><br><br>
-			</div>
-
-			{% if wallet.is_multisig %}
-				<div class="log"><b id="sigscount">{{psbt["sigs_count"]}}</b> signatures acquired</div>
+		<br>
+		Address label (optional):<br>
+		<input type="text" id="label" name="label" value="{{label}}">
+		<br><br>
+		Amount:<br>
+		<input type="number" name="amount" v-model="amount" id="amount" v-bind:max="max_amount_sendable" min=0 step="1e-8" autocomplete="off">
+		<div class="notification error" v-if="above_wallet_amount || needs_more_selected_coins">
+			<ul>
+				<li v-if="needs_more_selected_coins"> You need to select more coins to match your amount!</li>
+				<li v-if="above_wallet_amount"> You cannot send more than [[wallet_availablebalance]] !</li>
+			</ul>
+		</div>
+		<div class="note">
+			Available: {{"%.8f" % wallet.availablebalance}}{% if wallet.locked_amount > 0 %};
+			&nbsp;Locked in pending transactions: {{"%.8f" % wallet.locked_amount}}
 			{% endif %}
 		</div>
-
-		{# ====================== Possible tx signers' inputs ====================== #}
-		{% if wallet.uses_hwi_device %}
-			<div class="hwi_container flex-center flex-column">
-				Sign transaction with your:<br/>
-				{% if not wallet.is_multisig %}
-					<button class="btn hwi-column-btn" id="hwi_sign_btn">{{ wallet.device }}</button>
-				{% else %}
-					{% for device in wallet.devices %}
-						{% if device.type in ['coldcard', 'keepkey', 'ledger', 'trezor', 'specter'] %}
-							<button class="btn hwi-column-btn" id="hwi_sign_btn_{{ loop.index }}" {{'disabled style=background-color:#303c49;' if device.name in psbt['devices_signed'] else ''}}>
-								{{ device.name }} {% if device.name in psbt['devices_signed'] %} (&#10004;) {% endif %}
-							</button>
-						{% endif %}
-					{% endfor %}
-				{% endif %}
-			</div>
-		{% endif %}
-
-		{% if wallet.uses_qrcode_device %}
-			<div class="row padded">
-				<label>
-					<input autocomplete="off" type="radio" name="psbt_type" value="compressed_psbt" class="hidden" checked>
-					<div class="btn radio left">Compressed PSBT</div>
-				</label>
-				<label>
-					<input autocomplete="off" type="radio" name="psbt_type" value="full_psbt" class="hidden">
-					<div class="btn radio right">Full PSBT</div>
-				</label>
-			</div>
-
-			<div class="row" style="min-height: 400px;">
-				<span id="compressed_psbt">
-				<qrencode class = 'center' text="{{psbt['specter']}}" width=400></qrencode>
-				</span>
-				<span id="full_psbt" style="display: none">
-				<qrencode class = 'center' text="{{psbt['base64']}}" width=400></qrencode>
-				</span>
-			</div>
-			<script src="/static/qr/vue-qrcode.min.js"></script>
-			<script type="text/javascript" src="/static/vue_qr.js"></script>
-			<script>
-				Vue.component(VueQrcode.name, VueQrcode);
-				var vmc = new Vue({ el: '#compressed_psbt'});
-				var vmf = new Vue({ el: '#full_psbt'});
-			</script>
-			 <script>
-			 	document.addEventListener("DOMContentLoaded", function(){
-				 	document.forms[0].elements.psbt_type.forEach((o)=>{
-				 		o.addEventListener('change', e=>{
-				 			["compressed_psbt","full_psbt"].forEach(id=>{
-					 			let el = document.getElementById(id);
-					 			if(id==document.forms[0].elements.psbt_type.value){
-					 				el.style.display = "flex";
-					 			}else{
-					 				el.style.display = "none";
-					 			}
-				 			});
-				 		})
-				 	});
-			 	});
-			 </script>
-			<!-- because coldcard psbt is the most complete (includes xpubs) -->
-			<div class="log"><code><pre>{{psbt['coldcard']}}</pre></code></div>
-		{% endif %}
-
-		{% if wallet.uses_sdcard_device %}
+		<div><label><input type="checkbox" class="inline" name="subtract" value="1"> Subtract from amount</label></div>
+		<br><br>
+	
+		<div class="fee_container">
 			<div>
-        <a class="btn centered" download="to{{psbt['address']}}{{psbt['amount']}}.psbt" href="data:application/octet-stream;base64,{{psbt['coldcard']}}">Download transaction</a>
+				Fees: <label><input type="radio" class="inline" style="margin: 0 10px 0 20px;" id="fee_option_dynamic"  name="fee_options" value="dynamic" onclick="showFeeOption(this)" checked>dynamic</label>
+				<label><input type="radio" class="inline" style="margin: 0 10px 0 20px" name="fee_options" value="manual" onclick="showFeeOption(this);">manual</label>
 			</div>
-			<br>
-		{% endif %}
-
-
-		{# ===================== Possible tx signers' outputs ===================== #}
-		{% if wallet.uses_hwi_device %}
-			<div id="hwi_sign_container" class="flex-center flex-column hidden">
-				<h2>Sign Transaction</h2>
-				<div>
-					Please confirm transaction on your <span id="hwi_device_name">device</span>
-				</div>
-				<div class="flex-center">
-					<img src="/static/img/loader_boxes.svg"/>
-				</div>
+			<br><br>
+			<input type="hidden" id="fee_unit" name="fee_unit" value="">
+			<div id = "fee_manual" style="display:none">
+				Fee rate:<br>
+				<input type="number" class="fee_rate" name="fee_rate" id="fee_rate" max="100" min=0 step="0.25" autocomplete="off"> sat/B
+				<div class="note">leave blank to set automatically</div>
+				<br><br>
 			</div>
-		{% endif %}
-
-		{% if wallet.uses_qrcode_device %}
-			<div class="output_option">
-				<a class="btn centered" id="scanme">Scan signed transaction</a>
+			<div id ="fee_dynamic" style="display:block">
+				<div id="blocks"></div>
+				<input type="range" style="width: 12em" min="1" max="25" value="6" step="1" id="slider_confTime" oninput="loadDynamicFees(this.value)">
+				<input type="hidden" id="fee_rate_dynamic" name="fee_rate_dynamic" value="0">
+				<div> Fee rate: <span id="fee_rate_dynamic_text"></span></div>
+				<br><br>
 			</div>
-		{% endif %}
-			<div class="output_option" style="margin-top:20px">
-				<a href="#" class="btn centered" id="pastetx">Paste signed transaction</a>
-			</div>
-
-
-		{% if wallet.uses_sdcard_device %}
-			<div class="row">
-				<input type="file" id="file" class="inputfile"/>
-				<label for="file" class="btn centered">Upload signed transaction</label>
-			</div>
-		{% endif %}
-
-		<div class="row padded">
-			<form action="./" method="POST">
-				<input type="hidden" name="pending_psbt" value="{{psbt}}">
-				<button type="submit" name="action" value="deletepsbt" class="btn danger centered" style="margin-left: 5px;">Delete Transaction</button>
-			</form>
 		</div>
-
-	{% endif %}
+		<div>
+			<button id="coinselect" v-on:click="toggleExpand" type="button" class="btn" v-if="unspents.length>0">Select coins</button>
+			<table style="table-layout:fixed; display: block;" v-if="coinselectionActive" id="coinselection-table">
+				<thead>
+				<tr>
+					<th></th><th>TxID</th><th>Address</th><th>Amount</th>
+				</tr>
+				</thead>
+				<tbody>
+					<tr v-for="tx in unspents" v-bind:key="tx.txid">
+						<td>
+							<input class="checkbox" type="checkbox" v-model="tx.selected" name="coinselect" v-bind:value="[tx.txid, tx.vout, tx.amount]">
+						</td>
+						<td class="tx scroll"><a :href="block_explorer+'tx/'+tx.txid" target="blank">[[ tx.txid ]]</a></td>
+						<td class="tx scroll">
+							<a :href="block_explorer+'address/'+tx.address" target="blank">
+								[[ tx.label != '' && tx.label != undefined ? tx.label : tx.address ]]
+							</a>
+						</td>
+						<td>[[ tx.amount ]]</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		<button type="submit" v-bind:disabled="above_wallet_amount || needs_more_selected_coins || amount == '' || address == ''" name="action" value="createpsbt" class="btn centered" style="margin-top: 20px;">Create unsigned transaction</button>
+	</div>
 </form>
 
 {% endblock %}
@@ -312,10 +120,6 @@
 function replace(hide, show) {
 	document.getElementById(hide).style.display="none";
 	document.getElementById(show).style.display="block";
-}
-
-function capitalize(str){
-	return str.charAt(0).toUpperCase()+str.substring(1);
 }
 
 function showFeeOption(myRadio) {
@@ -353,179 +157,13 @@ function loadDynamicFees() {
 	xhttp.open("GET", request, true);
 	xhttp.send();
 	}
-{% if not psbt and not list_psbts %}
+	
 document.addEventListener("DOMContentLoaded", loadDynamicFees)
 document.getElementById("fee_option_dynamic").checked = true
 document.getElementById("fee_unit").value = "BTC_KB"
 document.getElementById("slider_confTime").value = 6
-{% endif %}
-</script>
-<script type="module">
-
-{% if psbt %}
-	let currentSigningDevice = '';
-	let currentSigningDeviceNum;
-	let psbt0 = "{{psbt['base64']}}";
-	let sigscount = {{psbt["sigs_count"]}};
-
-	function combine(psbt1){
-		let url="/wallets/{{wallet.alias}}/combine/";
-		// console.log(url);
-		var xmlHttp = new XMLHttpRequest();
-		xmlHttp.onreadystatechange = function() { 
-			if(xmlHttp.readyState === 4 && xmlHttp.status === 200) {
-				console.log(psbt0);
-				console.log(psbt1);
-				let o = JSON.parse(this.responseText);
-				console.log(o);
-				if(o.complete){
-					window.location.replace("../tx/");
-				}else{
-					psbt0 = o["psbt"];
-					sigscount++;
-					document.getElementById("sigscount").innerHTML = sigscount;
-					document.getElementById("hwi_sign_btn_"+currentSigningDeviceNum).style = "background-color:#303c49;";
-					document.getElementById("hwi_sign_btn_"+currentSigningDeviceNum).disabled = true;
-					document.getElementById("hwi_sign_btn_"+currentSigningDeviceNum).innerHTML += ' (&#10004;)';
-
-				}
-				// console.log(this.responseText);
-			}else{
-				// document.getElementById("lbl").innerHTML = "Connection failed... Trying again...";
-			}
-		}
-		xmlHttp.onerror = function(e){
-			console.log(xmlHttp);
-			// err = xmlHttp;
-		}
-		xmlHttp.open("POST", url, true); // true for asynchronous 
-		// xmlHttp.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
-		xmlHttp.setRequestHeader('Content-Type', 'application/json; charset=UTF-8');
-		xmlHttp.send(JSON.stringify({"psbt0": psbt0, "psbt1": psbt1, "txid": "{{psbt['tx']['txid']}}", "device_name": currentSigningDevice}));
-		// xmlHttp.send(null);
-	}
-	document.addEventListener("DOMContentLoaded", function(){
-		let el = document.getElementById("pastetx");
-		el.addEventListener("click", function(){
-			let input = prompt("Paste signed transaction here");
-			if(input){
-				combine(input);
-			}
-		});
-	});
-
-	{# ================== Signers various device support ================== #}
-	{% if wallet.uses_hwi_device %}
-		document.addEventListener("DOMContentLoaded", function(){
-			initPageOverlay("hwi_sign_container");
-
-			{% if not wallet.is_multisig %}
-				document.getElementById("hwi_sign_btn").addEventListener("click", async function(e) {
-					e.preventDefault();
-					beginDetectWallet("{{ wallet.device_type }}");
-				});
-			{% else %}
-				{% for device in wallet.devices %}
-					{% if device.type in ['coldcard', 'keepkey', 'ledger', 'trezor', 'specter'] %}
-						document.getElementById("hwi_sign_btn_{{ loop.index }}").addEventListener("click", async function(e) {
-							currentSigningDevice = "{{ device.name }}"
-							currentSigningDeviceNum = "{{ loop.index }}"
-							e.preventDefault();
-							beginDetectWallet("{{ device.type }}");
-						});
-					{% endif %}
-				{% endfor %}
-			{% endif %}
-
-			document.getElementById("hwi_include__unlocked__submit").addEventListener("click", async function(e) {
-				e.preventDefault();
-				document.getElementById("hwi_device_name").textContent = capitalize(hwiCurrentWallet.type);
-				showPageOverlay("hwi_sign_container");
-
-				const psbt = "{{ psbt['base64'] }}";
-				var jsonResponse = await hwiSendPsbt(psbt);
-				if (jsonResponse.hasOwnProperty('error')) {
-					alert(jsonResponse.error);
-				} else if (jsonResponse.psbt !== "undefined") {
-					combine(jsonResponse.psbt);
-				}
-
-				hidePageOverlay("hwi_sign_container");
-			});
-		});
-	{% endif %}
-
-{% endif %}
-
-{% if not psbt or wallet.uses_qrcode_device %}
-		import QrScanner from "/static/qr/qr-scanner.min.js";
-		QrScanner.WORKER_PATH = '/static/qr/qr-scanner-worker.min.js';
-
-		const video = document.getElementById('qr-video');
-
-		const scanner = new QrScanner(video, result => {
-			scanner.stop();
-			document.getElementById("popup").style.display = 'none';
-			{% if not psbt %}
-				let addr = result;
-				if(addr.indexOf("bitcoin:") >= 0){
-					addr = addr.substr(addr.indexOf("bitcoin:")+8);
-				}
-				let arr = addr.split("?");
-				addr = arr[0]
-				document.getElementById("address").value = addr;
-				let evt = new Event('input');
-				document.getElementById("address").dispatchEvent(evt);
-				if(arr.length > 1){
-					arr = arr[1].split("&");
-					arr.forEach((e)=>{
-						if(e.startsWith("amount=")){
-							document.getElementById("amount").value = parseFloat(e.substr(7));
-							let evt = new Event('input');
-							document.getElementById("amount").dispatchEvent(evt);
-						}
-					});
-				}
-			{% else %}
-
-				combine(result);
-
-			{% endif %}
-		});
-		document.getElementById("scanme").addEventListener("click", function(){
-			try{
-				scanner.start();
-				document.getElementById("popup").style.display = 'flex';
-			}catch(e){
-				alert("Can't start the QR scanner!\n\n" + e);
-			}
-		});
-		document.getElementById("popup").addEventListener("click", function(){
-			document.getElementById("popup").style.display = 'none';
-			scanner.stop();
-		});
-{% endif %}
-
-{% if psbt and wallet.uses_sdcard_device %}
-		var el = document.getElementById("file");
-
-		el.addEventListener("change", (e) => {
-			let files = el.files;
-			console.log(files);
-			for(let i=0; i<files.length; i++){
-				console.log(files[i].name);
-				let reader = new FileReader();
-				reader.onload = function(e) {
-					let str = btoa(reader.result);
-					combine(str);
-				}
-				reader.readAsBinaryString(files[i]);
-			}
-		});
-{% endif %}
 </script>
 
-{% if not psbt %}
 <script>
 	var spend_coins = new Vue({
 		el: '#spend_coins',
@@ -576,7 +214,4 @@ document.getElementById("slider_confTime").value = 6
 		}
 	})
 </script>
-{% endif %}
-
-
 {% endblock %}

--- a/src/cryptoadvance/specter/templates/wallet_send_sign_psbt.html
+++ b/src/cryptoadvance/specter/templates/wallet_send_sign_psbt.html
@@ -273,31 +273,7 @@ function capitalize(str){
 		const scanner = new QrScanner(video, result => {
 			scanner.stop();
 			document.getElementById("popup").style.display = 'none';
-			{% if not psbt %}
-				let addr = result;
-				if(addr.indexOf("bitcoin:") >= 0){
-					addr = addr.substr(addr.indexOf("bitcoin:")+8);
-				}
-				let arr = addr.split("?");
-				addr = arr[0]
-				document.getElementById("address").value = addr;
-				let evt = new Event('input');
-				document.getElementById("address").dispatchEvent(evt);
-				if(arr.length > 1){
-					arr = arr[1].split("&");
-					arr.forEach((e)=>{
-						if(e.startsWith("amount=")){
-							document.getElementById("amount").value = parseFloat(e.substr(7));
-							let evt = new Event('input');
-							document.getElementById("amount").dispatchEvent(evt);
-						}
-					});
-				}
-			{% else %}
-
-				combine(result);
-
-			{% endif %}
+			combine(result);
 		});
 		document.getElementById("scanme").addEventListener("click", function(){
 			try{

--- a/src/cryptoadvance/specter/templates/wallet_send_sign_psbt.html
+++ b/src/cryptoadvance/specter/templates/wallet_send_sign_psbt.html
@@ -1,0 +1,335 @@
+{% extends "base.html" %}
+{% block main %}
+
+{% include "includes/hwi.html" %}
+
+<style>
+	.tx_info {
+		padding: 1em;
+		border: 1px solid #506072;
+		border-radius: 4px;
+		text-align: center;
+		margin-bottom: 2em;
+	}
+	.hwi_container{
+		margin-bottom: 2em;
+	}
+	.hwi-column-btn {
+		margin: 0.75em;
+	}
+	.tx {
+		width: 100%;
+		max-width: 179px;
+		min-width: 120px;
+	}
+	.checkbox {
+		width: 20px;
+  		height: 20px;
+	}
+</style>
+<h1>{{wallet.name}}</h1>
+{% set active_menuitem = "send" %}
+{% include "includes/wallet_menu.html" %}
+<br>
+<form action="./" method="POST" class="full-width">
+	<div class="tx_info">
+		
+		<div>Sending <b>{{psbt["amount"]}}</b> BTC to<b>
+			<a class="address-link" target="blank" href="{{specter.explorer}}address/{{ psbt['address'] }}">
+			{{wallet.getaddressname(psbt["address"], -1)}}
+			</a></b><br><br>
+		</div>
+
+		{% if wallet.is_multisig %}
+			<div class="log"><b id="sigscount">{{psbt["sigs_count"]}}</b> signatures acquired</div>
+		{% endif %}
+	</div>
+
+	{# ====================== Possible tx signers' inputs ====================== #}
+	{% if wallet.uses_hwi_device %}
+		<div class="hwi_container flex-center flex-column">
+			Sign transaction with your:<br/>
+			{% if not wallet.is_multisig %}
+				<button class="btn hwi-column-btn" id="hwi_sign_btn">{{ wallet.device }}</button>
+			{% else %}
+				{% for device in wallet.devices %}
+					{% if device.type in ['coldcard', 'keepkey', 'ledger', 'trezor', 'specter'] %}
+						<button class="btn hwi-column-btn" id="hwi_sign_btn_{{ loop.index }}" {{'disabled style=background-color:#303c49;' if device.name in psbt['devices_signed'] else ''}}>
+							{{ device.name }} {% if device.name in psbt['devices_signed'] %} (&#10004;) {% endif %}
+						</button>
+					{% endif %}
+				{% endfor %}
+			{% endif %}
+		</div>
+	{% endif %}
+
+	{% if wallet.uses_qrcode_device %}
+		<div class="row padded">
+			<label>
+				<input autocomplete="off" type="radio" name="psbt_type" value="compressed_psbt" class="hidden" checked>
+				<div class="btn radio left">Compressed PSBT</div>
+			</label>
+			<label>
+				<input autocomplete="off" type="radio" name="psbt_type" value="full_psbt" class="hidden">
+				<div class="btn radio right">Full PSBT</div>
+			</label>
+		</div>
+
+		<div class="row" style="min-height: 400px;">
+			<span id="compressed_psbt">
+				<qrencode class = 'center' text="{{psbt['specter']}}" width=400></qrencode>
+			</span>
+			<span id="full_psbt" style="display: none">
+				<qrencode class = 'center' text="{{psbt['base64']}}" width=400></qrencode>
+			</span>
+		</div>
+		<script src="/static/qr/vue-qrcode.min.js"></script>
+		<script type="text/javascript" src="/static/vue_qr.js"></script>
+		<script>
+			Vue.component(VueQrcode.name, VueQrcode);
+			var vmc = new Vue({ el: '#compressed_psbt'});
+			var vmf = new Vue({ el: '#full_psbt'});
+		</script>
+		<script>
+		document.addEventListener("DOMContentLoaded", function(){
+			document.forms[0].elements.psbt_type.forEach((o)=>{
+				o.addEventListener('change', e=>{
+					["compressed_psbt","full_psbt"].forEach(id=>{
+						let el = document.getElementById(id);
+						if(id==document.forms[0].elements.psbt_type.value){
+							el.style.display = "flex";
+						}else{
+							el.style.display = "none";
+						}
+					});
+				})
+			});
+		});
+		</script>
+		<!-- because coldcard psbt is the most complete (includes xpubs) -->
+		<div class="log"><code><pre>{{psbt['coldcard']}}</pre></code></div>
+	{% endif %}
+
+	{% if wallet.uses_sdcard_device %}
+		<div>
+			<a class="btn centered" download="to{{psbt['address']}}{{psbt['amount']}}.psbt" href="data:application/octet-stream;base64,{{psbt['coldcard']}}">Download transaction</a>
+		</div>
+		<br>
+	{% endif %}
+
+
+	{# ===================== Possible tx signers' outputs ===================== #}
+	{% if wallet.uses_hwi_device %}
+		<div id="hwi_sign_container" class="flex-center flex-column hidden">
+			<h2>Sign Transaction</h2>
+			<div>
+				Please confirm transaction on your <span id="hwi_device_name">device</span>
+			</div>
+			<div class="flex-center">
+				<img src="/static/img/loader_boxes.svg"/>
+			</div>
+		</div>
+	{% endif %}
+
+	{% if wallet.uses_qrcode_device %}
+		<div class="output_option">
+			<a class="btn centered" id="scanme">Scan signed transaction</a>
+		</div>
+	{% endif %}
+		<div class="output_option" style="margin-top:20px">
+			<a href="#" class="btn centered" id="pastetx">Paste signed transaction</a>
+		</div>
+
+
+	{% if wallet.uses_sdcard_device %}
+		<div class="row">
+			<input type="file" id="file" class="inputfile"/>
+			<label for="file" class="btn centered">Upload signed transaction</label>
+		</div>
+	{% endif %}
+
+	<div class="row padded">
+		<form action="./" method="POST">
+			<input type="hidden" name="pending_psbt" value="{{psbt}}">
+			<button type="submit" name="action" value="deletepsbt" class="btn danger centered" style="margin-left: 5px;">Delete Transaction</button>
+		</form>
+	</div>
+</form>
+
+{% endblock %}
+
+
+{% block scripts %}
+<div class="popup" id="popup">
+	<video muted playsinline id="qr-video" class="video"></video>
+</div>
+<script>
+
+function capitalize(str){
+	return str.charAt(0).toUpperCase()+str.substring(1);
+}
+
+</script>
+<script type="module">
+	let currentSigningDevice = '';
+	let currentSigningDeviceNum;
+	let psbt0 = "{{psbt['base64']}}";
+	let sigscount = {{psbt["sigs_count"]}};
+
+	function combine(psbt1){
+		let url="/wallets/{{wallet.alias}}/combine/";
+		// console.log(url);
+		var xmlHttp = new XMLHttpRequest();
+		xmlHttp.onreadystatechange = function() { 
+			if(xmlHttp.readyState === 4 && xmlHttp.status === 200) {
+				console.log(psbt0);
+				console.log(psbt1);
+				let o = JSON.parse(this.responseText);
+				console.log(o);
+				if(o.complete){
+					window.location.replace("../tx/");
+				}else{
+					psbt0 = o["psbt"];
+					sigscount++;
+					document.getElementById("sigscount").innerHTML = sigscount;
+					document.getElementById("hwi_sign_btn_"+currentSigningDeviceNum).style = "background-color:#303c49;";
+					document.getElementById("hwi_sign_btn_"+currentSigningDeviceNum).disabled = true;
+					document.getElementById("hwi_sign_btn_"+currentSigningDeviceNum).innerHTML += ' (&#10004;)';
+
+				}
+				// console.log(this.responseText);
+			}else{
+				// document.getElementById("lbl").innerHTML = "Connection failed... Trying again...";
+			}
+		}
+		xmlHttp.onerror = function(e){
+			console.log(xmlHttp);
+			// err = xmlHttp;
+		}
+		xmlHttp.open("POST", url, true); // true for asynchronous 
+		// xmlHttp.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
+		xmlHttp.setRequestHeader('Content-Type', 'application/json; charset=UTF-8');
+		xmlHttp.send(JSON.stringify({"psbt0": psbt0, "psbt1": psbt1, "txid": "{{psbt['tx']['txid']}}", "device_name": currentSigningDevice}));
+		// xmlHttp.send(null);
+	}
+	document.addEventListener("DOMContentLoaded", function(){
+		let el = document.getElementById("pastetx");
+		el.addEventListener("click", function(){
+			let input = prompt("Paste signed transaction here");
+			if(input){
+				combine(input);
+			}
+		});
+	});
+
+	{# ================== Signers various device support ================== #}
+	{% if wallet.uses_hwi_device %}
+		document.addEventListener("DOMContentLoaded", function(){
+			initPageOverlay("hwi_sign_container");
+
+			{% if not wallet.is_multisig %}
+				document.getElementById("hwi_sign_btn").addEventListener("click", async function(e) {
+					e.preventDefault();
+					beginDetectWallet("{{ wallet.device_type }}");
+				});
+			{% else %}
+				{% for device in wallet.devices %}
+					{% if device.type in ['coldcard', 'keepkey', 'ledger', 'trezor', 'specter'] %}
+						document.getElementById("hwi_sign_btn_{{ loop.index }}").addEventListener("click", async function(e) {
+							currentSigningDevice = "{{ device.name }}"
+							currentSigningDeviceNum = "{{ loop.index }}"
+							e.preventDefault();
+							beginDetectWallet("{{ device.type }}");
+						});
+					{% endif %}
+				{% endfor %}
+			{% endif %}
+
+			document.getElementById("hwi_include__unlocked__submit").addEventListener("click", async function(e) {
+				e.preventDefault();
+				document.getElementById("hwi_device_name").textContent = capitalize(hwiCurrentWallet.type);
+				showPageOverlay("hwi_sign_container");
+
+				const psbt = "{{ psbt['base64'] }}";
+				var jsonResponse = await hwiSendPsbt(psbt);
+				if (jsonResponse.hasOwnProperty('error')) {
+					alert(jsonResponse.error);
+				} else if (jsonResponse.psbt !== "undefined") {
+					combine(jsonResponse.psbt);
+				}
+
+				hidePageOverlay("hwi_sign_container");
+			});
+		});
+	{% endif %}
+
+
+	{% if wallet.uses_qrcode_device %}
+		import QrScanner from "/static/qr/qr-scanner.min.js";
+		QrScanner.WORKER_PATH = '/static/qr/qr-scanner-worker.min.js';
+
+		const video = document.getElementById('qr-video');
+
+		const scanner = new QrScanner(video, result => {
+			scanner.stop();
+			document.getElementById("popup").style.display = 'none';
+			{% if not psbt %}
+				let addr = result;
+				if(addr.indexOf("bitcoin:") >= 0){
+					addr = addr.substr(addr.indexOf("bitcoin:")+8);
+				}
+				let arr = addr.split("?");
+				addr = arr[0]
+				document.getElementById("address").value = addr;
+				let evt = new Event('input');
+				document.getElementById("address").dispatchEvent(evt);
+				if(arr.length > 1){
+					arr = arr[1].split("&");
+					arr.forEach((e)=>{
+						if(e.startsWith("amount=")){
+							document.getElementById("amount").value = parseFloat(e.substr(7));
+							let evt = new Event('input');
+							document.getElementById("amount").dispatchEvent(evt);
+						}
+					});
+				}
+			{% else %}
+
+				combine(result);
+
+			{% endif %}
+		});
+		document.getElementById("scanme").addEventListener("click", function(){
+			try{
+				scanner.start();
+				document.getElementById("popup").style.display = 'flex';
+			}catch(e){
+				alert("Can't start the QR scanner!\n\n" + e);
+			}
+		});
+		document.getElementById("popup").addEventListener("click", function(){
+			document.getElementById("popup").style.display = 'none';
+			scanner.stop();
+		});
+	{% endif %}
+
+	{% if wallet.uses_sdcard_device %}
+		var el = document.getElementById("file");
+
+		el.addEventListener("change", (e) => {
+			let files = el.files;
+			console.log(files);
+			for(let i=0; i<files.length; i++){
+				console.log(files[i].name);
+				let reader = new FileReader();
+				reader.onload = function(e) {
+					let str = btoa(reader.result);
+					combine(str);
+				}
+				reader.readAsBinaryString(files[i]);
+			}
+		});
+	{% endif %}
+</script>
+
+{% endblock %}

--- a/src/cryptoadvance/specter/templates/wallet_sendpending.html
+++ b/src/cryptoadvance/specter/templates/wallet_sendpending.html
@@ -1,0 +1,104 @@
+{% extends "base.html" %}
+{% block main %}
+
+<style>
+	.tx_info {
+		padding: 1em;
+		border: 1px solid #506072;
+		border-radius: 4px;
+		text-align: center;
+		margin-bottom: 2em;
+	}
+	.fee_container {
+		height: 11em;
+	}
+	.fee_rate {
+		width: 6em;
+		min-width: 6em;
+	}
+	.hwi_container{
+		margin-bottom: 2em;
+	}
+	.hwi-column-btn {
+		margin: 0.75em;
+	}
+	#coinselection-table .tx {
+		width: 100%;
+		max-width: 179px;
+		min-width: 120px;
+	}
+	.checkbox {
+		width: 20px;
+  		height: 20px;
+	}
+	#coinselect {
+		margin-bottom: 10px;
+	}
+</style>
+<h1>{{wallet.name}}</h1>
+{% set active_menuitem = "send" %}
+{% include "includes/wallet_menu.html" %}
+<br>
+		<div class="row">
+			<a href="{{ url_for('wallet_send',wallet_alias=wallet_alias)}}" class="btn radio left ">New</a>
+			<a href="{{ url_for('wallet_sendpending',wallet_alias=wallet_alias)}}" class="btn radio right checked">Pending</a>
+		</div>
+			<h1 class="padded">Pending Transactions:</h1>
+			<div class="table-holder">
+				<table>
+					<thead>
+					<tr>
+						<th></th><th>Address</th><th>Amount</th><th>Time</th><th>Sigs</th><th>Actions</th>
+					</tr>
+					</thead>
+					<tbody>
+						{% if pending_psbts %}
+							{% for txid in pending_psbts %}
+								{% set pending_psbt = pending_psbts[txid] %}
+								<tr>
+									<td></td>
+									<td class="tx scroll">
+										<a target="blank" href="{{specter.explorer}}address/{{ pending_psbt['address'] }}">
+											{{wallet.getaddressname(pending_psbt["address"], -1)}}
+										</a>
+									</td>
+									<td>
+										{{ pending_psbt["amount"] }}
+									</td>
+									<td>
+										{{ pending_psbt["time"] | datetime }}
+									</td>
+									<td>
+										{{ "{}/{}".format(pending_psbt["sigs_count"], wallet.sigs_required) }}
+									</td>
+									<td width="170px">
+										<div class="row">
+											<form action="{{ url_for('wallet_send',wallet_alias=wallet_alias)}}" method="POST">
+												<input type="hidden" name="pending_psbt" value="{{pending_psbt}}">
+												<button type="submit" name="action" value="openpsbt" class="btn" style="margin-right: 5px;">Open</button>
+											</form>
+
+											<form action="{{ url_for('wallet_sendpending',wallet_alias=wallet_alias)}}" method="POST">
+												<input type="hidden" name="pending_psbt" value="{{pending_psbt}}">
+												<button type="submit" name="action" value="deletepsbt" class="btn danger" style="margin-left: 5px;" onclick="javascript: form.action='./?pending=True';">Delete</button>
+											</form>
+										</div>
+									</td>
+								</tr>
+							{% endfor %}
+						{% else %}
+							<td></td><td>No transactions yet.</td><td></td><td></td><td></td><td></td>
+						{% endif %}
+					</tbody>
+				</table>
+			</div>
+
+{% endblock %}
+
+
+{% block scripts %}
+<div class="popup" id="popup">
+	<video muted playsinline id="qr-video" class="video"></video>
+</div>
+
+{% endblock %}

--- a/src/cryptoadvance/specter/templates/wallet_settings.html
+++ b/src/cryptoadvance/specter/templates/wallet_settings.html
@@ -1,6 +1,5 @@
 {% extends "base.html" %}
 {% block main %}
-
 <form action="./" method="POST">
 	<h1 id="nametitle">{{wallet.name}}</h1>
 	<input type="text" class="label" autocomplete="off" spellcheck="false" id="walletname" name="walletname" value="{{wallet.name}}" style="font-size: 1.5em; text-align: center; display: none;" />
@@ -10,13 +9,9 @@
 		<button type="button" class="btn edit" id="editname" onclick="toggleEdit()">Edit Wallet Name</button>
 	</div>
 </form>
-<div class="row padded">
-	<a href="/wallets/{{wallet['alias']}}/tx/" class="btn radio left">Transactions</a>
-	<a href="/wallets/{{wallet['alias']}}/addresses/" class="btn radio">Addresses</a>
-	<a href="/wallets/{{wallet['alias']}}/receive/" class="btn radio">Receive</a>
-	<a href="/wallets/{{wallet['alias']}}/send/" class="btn radio">Send</a>
-	<a href="/wallets/{{wallet['alias']}}/settings/" class="btn radio right checked">Settings</a>
-</div>
+<h1>{{wallet.name}}</h1>
+{% set active_menuitem = "settings" %}
+{% include "includes/wallet_menu.html" %}
 <h1>Keypool control</h1>
 <form action="." method="POST" class="padded" style="width: 500px">
 	<div>Currently watching {{wallet["keypool"]}} receiving and {{wallet["change_keypool"]}} change addresses.<div>

--- a/src/cryptoadvance/specter/templates/wallet_settings.html
+++ b/src/cryptoadvance/specter/templates/wallet_settings.html
@@ -9,7 +9,6 @@
 		<button type="button" class="btn edit" id="editname" onclick="toggleEdit()">Edit Wallet Name</button>
 	</div>
 </form>
-<h1>{{wallet.name}}</h1>
 {% set active_menuitem = "settings" %}
 {% include "includes/wallet_menu.html" %}
 <h1>Keypool control</h1>

--- a/src/cryptoadvance/specter/templates/wallet_tx.html
+++ b/src/cryptoadvance/specter/templates/wallet_tx.html
@@ -1,13 +1,8 @@
 {% extends "base.html" %}
 {% block main %}
 <h1>{{wallet.name}}</h1>
-<div class="row padded">
-	<a href="/wallets/{{wallet['alias']}}/tx/" class="btn radio left checked">Transactions</a>
-	<a href="/wallets/{{wallet['alias']}}/addresses/" class="btn radio">Addresses</a>
-	<a href="/wallets/{{wallet['alias']}}/receive/" class="btn radio">Receive</a>
-	<a href="/wallets/{{wallet['alias']}}/send/" class="btn radio">Send</a>
-	<a href="/wallets/{{wallet['alias']}}/settings/" class="btn radio right">Settings</a>
-</div>
+{% set active_menuitem = "transactions" %}
+{% include "includes/wallet_menu.html" %}
 {% if ( wallet.fullbalance ) is not none %}
 <h1><small style="line-height:30px">Total balance:<br></small><span style="color: #fff">
 	{{ "%0.8f" % ( wallet.fullbalance ) | float }}


### PR DESCRIPTION
The wallet_send.html slowly became a 570+ LOC monster which is much better off by cutting it in different pieces separating the different aspects. With this PR we get:
* wallet_send.html - the send-form and only that form
* wallet_send_pending.html - the list of pending psbts
* wallet_send_sign_psbt - all the HW-wallet signing stuff

Apart from that this also includes a refactoring of the wallet_menu which is now located in a separate include-file.