### PR TITLE
mobile-friendly-ish styles

### DIFF
--- a/src/cryptoadvance/specter/static/img/menu.svg
+++ b/src/cryptoadvance/specter/static/img/menu.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path fill="#ffffff" d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/></svg>

--- a/src/cryptoadvance/specter/static/styles.css
+++ b/src/cryptoadvance/specter/static/styles.css
@@ -794,9 +794,6 @@ a:focus + .tool-tip .tool-tip__info {
 }
 
 @media (max-width: 1100px){
-  main{
-    padding-left: 15px;
-  }
   #side-content{
     position: absolute;
     height: 100%;
@@ -815,6 +812,9 @@ a:focus + .tool-tip .tool-tip__info {
     max-width: 230px;
   }
   @media (hover: hover){
+    main{
+      padding-left: 15px;
+    }
     #side-content:hover{
       position: absolute;
       left: 0px;
@@ -846,9 +846,6 @@ a:focus + .tool-tip .tool-tip__info {
   .card{
     border-width: 0px;
     width: 100%;
-  }
-  .btn.radio.left, .btn.radio.right{
-    border-radius: 0;
   }
   nav.row{
     padding-left: 0;

--- a/src/cryptoadvance/specter/static/styles.css
+++ b/src/cryptoadvance/specter/static/styles.css
@@ -120,6 +120,11 @@ nav.top{
     border-bottom: 1px solid var(--cmap-bg-lightest);
     -webkit-app-region: drag;
 }
+nav.row{
+    width: 100%;
+    padding: 10px 30px;
+    justify-content: center;
+}
 nav.side{
     display: flex;
     min-height: min-content;
@@ -145,7 +150,7 @@ main{
     flex-direction: column;
     align-items: center;
     /*justify-content: center;*/
-    padding: 50px 0 20px 0;
+    padding: 50px 0 100px 0;
     /*padding: 30px 0 20px 0;*/
     overflow-y: scroll;
 }
@@ -245,14 +250,13 @@ nav .separator{
 }
 .item .btn{
     margin: 5px 20px 5px 20px;
-    min-width: 170px;
+    /*min-width: 170px;*/
 }
 .btn{
     background: var(--cmap-border);
     border: 1px solid transparent;
     border-radius: 4px;
     padding: 8px 15px 8px 10px;
-    width: 170px;
     color: #fff;
     font-size: 0.85em;
     text-align: center;
@@ -272,6 +276,9 @@ nav .separator{
 .btn svg path{
     stroke: #fff;
     fill: #fff;
+}
+button.btn{
+    width: 170px;
 }
 .pin_button {
     background: var(--cmap-border);
@@ -362,6 +369,7 @@ input:hover{
     border: 1px solid #607082;
 }
 .card{
+    max-width: 100%;
     width: 580px;
     border: 1px solid var(--cmap-border);
     border-radius: 4px;
@@ -423,7 +431,7 @@ input:hover{
 }
 .note{
     font-size: 0.7em;
-    width: 400px;
+    max-width: 400px;
     margin: 0 auto;
     line-height: 1.5;
 }
@@ -518,6 +526,9 @@ textarea{
     cursor: pointer;
     background: transparent;
     border: 1px solid var(--cmap-border-darker);
+    flex-grow: 1;
+    flex-basis: 0;
+    max-width: 170px;
 }
 .btn.radio:hover{
     background: #304052;
@@ -566,11 +577,13 @@ table{
     width: 100%;
 }
 .full-width{
-    all: inherit;
     width: 100%;
-    height: 100%;
+    /*height: 100%;*/
     padding: 0;
     margin: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 }
 td, th{
     padding: 20px 10px;
@@ -763,11 +776,16 @@ a:focus + .tool-tip .tool-tip__info {
     display: none;
 }
 @media (max-width: 1100px){
+  main{
+    padding-left: 15px;
+  }
   #side-content{
     position: absolute;
     height: 100%;
     left: -235px;
     transition: left 0.3s;
+    box-shadow: 3px 0px 10px rgba(0,0,0,0.3);
+    z-index: 100;
   }
   #side-expand{
     display: flex;
@@ -793,5 +811,18 @@ a:focus + .tool-tip .tool-tip__info {
     #side-content.active > #side-expand{
       transform: scaleX(-1);
     }
+  }
+}
+@media (max-width: 580px){
+  .card{
+    border-width: 0px;
+    width: 100%;
+  }
+  .btn.radio.left, .btn.radio.right{
+    border-radius: 0;
+  }
+  nav.row{
+    padding-left: 0;
+    padding-right: 0;
   }
 }

--- a/src/cryptoadvance/specter/static/styles.css
+++ b/src/cryptoadvance/specter/static/styles.css
@@ -38,9 +38,8 @@ body{
     margin: 5px;
 }
 .logout{
-    position: absolute;
-    right: 0px;
-    top: 0px;
+    position: relative;
+    margin-left: auto;
     background: rgba(0,0,0,0);
     color: var(--cmap-blue);
     padding: 10px 20px;
@@ -150,7 +149,7 @@ main{
     flex-direction: column;
     align-items: center;
     /*justify-content: center;*/
-    padding: 50px 0 100px 0;
+    padding: 0;
     /*padding: 30px 0 20px 0;*/
     overflow-y: scroll;
 }

--- a/src/cryptoadvance/specter/static/styles.css
+++ b/src/cryptoadvance/specter/static/styles.css
@@ -824,7 +824,11 @@ a:focus + .tool-tip .tool-tip__info {
     }
   }
 }
-@media (hover: none), (max-width: 580){
+/* touch based devices need a menu button */
+@media (any-hover: none) and (max-width: 1100px), 
+       (any-pointer: coarse) and (max-width: 1100px), 
+       (pointer: none) and (max-width: 1100px), 
+       (max-width: 600){
   #menubtn{
     display: block;
   }
@@ -842,7 +846,7 @@ a:focus + .tool-tip .tool-tip__info {
     display: none;
   }
 }
-@media (max-width: 580px){
+@media (max-width: 600px){
   .card{
     border-width: 0px;
     width: 100%;

--- a/src/cryptoadvance/specter/static/styles.css
+++ b/src/cryptoadvance/specter/static/styles.css
@@ -34,6 +34,11 @@ body{
 *{
     box-sizing: border-box;
 }
+ul, li{
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+}
 .output_option{
     margin: 5px;
 }
@@ -124,6 +129,9 @@ nav.row{
     padding: 10px 30px;
     justify-content: center;
 }
+nav.row .btn{
+    width: 200px;
+}
 nav.side{
     display: flex;
     min-height: min-content;
@@ -141,6 +149,7 @@ nav.side{
     display: flex;
     flex-direction: row;
     overflow-y: scroll;
+    z-index: 100;
 }
 main{
     flex-grow: 1;
@@ -352,6 +361,7 @@ input.inline, .input.inline{
 }
 input[type="checkbox"].inline{
     min-width: auto;
+    width: auto;
 }
 input[type="radio"].inline{
     min-width: auto;
@@ -496,9 +506,10 @@ textarea{
 .notification{
     min-width: 200px;
     max-width: 800px;
-    margin: auto;
     position: absolute;
     top: 0;
+    left: 50%;
+    transform:translateX(-50%);
     font-size: 0.7em;
     color: #fff;
     overflow-x: scroll;
@@ -507,6 +518,7 @@ textarea{
     padding: 7px 30px;
     box-shadow: 0 3px 3px rgba(0,0,0,0.7);
     line-height: 1.5;
+    text-align: center;
 }
 .notification.error, .btn.danger{
     background: var(--cmap-red-darker);
@@ -624,10 +636,6 @@ table a, .address-link{
 table a:hover, .address-link:hover{
     color: #fff;
     text-decoration: underline;
-}
-table svg.core.test{
-    margin: 0 3px -3px 0;
-    opacity: 0.7;
 }
 .qr-popup{
     /*display: none;*/
@@ -784,7 +792,6 @@ a:focus + .tool-tip .tool-tip__info {
     left: -235px;
     transition: left 0.3s;
     box-shadow: 3px 0px 10px rgba(0,0,0,0.3);
-    z-index: 100;
   }
   #side-expand{
     display: flex;

--- a/src/cryptoadvance/specter/static/styles.css
+++ b/src/cryptoadvance/specter/static/styles.css
@@ -823,23 +823,23 @@ a:focus + .tool-tip .tool-tip__info {
       transform: scaleX(-1);
     }
   }
-  @media (hover: none){
-    #menubtn{
-      display: block;
-    }
-    #side-content.active{
-      position: absolute;
-      left: 0px;
-    }
-    #side-content.active > #side-expand{
-      transform: scaleX(-1);
-    }
-    #side-content{
-      left: -250px;
-    }
-    #side-expand{
-      display: none;
-    }
+}
+@media (hover: none), (max-width: 580){
+  #menubtn{
+    display: block;
+  }
+  #side-content.active{
+    position: absolute;
+    left: 0px;
+  }
+  #side-content.active > #side-expand{
+    transform: scaleX(-1);
+  }
+  #side-content{
+    left: -250px;
+  }
+  #side-expand{
+    display: none;
   }
 }
 @media (max-width: 580px){

--- a/src/cryptoadvance/specter/static/styles.css
+++ b/src/cryptoadvance/specter/static/styles.css
@@ -762,16 +762,12 @@ a:focus + .tool-tip .tool-tip__info {
 #side-expand{
     display: none;
 }
-@media screen and (max-width: 1100px) {
+@media (max-width: 1100px){
   #side-content{
     position: absolute;
     height: 100%;
     left: -235px;
     transition: left 0.3s;
-  }
-  #side-content:hover, #side-content.active{
-    position: absolute;
-    left: 0px;
   }
   #side-expand{
     display: flex;
@@ -779,10 +775,23 @@ a:focus + .tool-tip .tool-tip__info {
     justify-content: center;
     font-size: 14px;
     cursor: pointer;
+  }    
+  @media (hover: hover){
+    #side-content:hover{
+      position: absolute;
+      left: 0px;
+    }
+    #side-content:hover > #side-expand{
+      transform: scaleX(-1);
+    }
   }
-  #side-content:hover > #side-expand,
-  #side-content.active > #side-expand{
-    /*transform: scaleX(-1);*/
-    display: none;
+  @media (hover: none){
+    #side-content.active{
+      position: absolute;
+      left: 0px;
+    }
+    #side-content.active > #side-expand{
+      transform: scaleX(-1);
+    }
   }
 }

--- a/src/cryptoadvance/specter/static/styles.css
+++ b/src/cryptoadvance/specter/static/styles.css
@@ -450,6 +450,11 @@ input:hover{
     margin: 0 auto;
     line-height: 1.5;
 }
+.card .note, .note.full-width{
+    margin-left: 0;
+    margin-right: 0;
+    max-width: 100%;
+}
 textarea{
     margin-bottom: 5px;
     height: 100px;

--- a/src/cryptoadvance/specter/static/styles.css
+++ b/src/cryptoadvance/specter/static/styles.css
@@ -125,7 +125,7 @@ nav.side{
     min-height: min-content;
     flex-direction: column;
     justify-content: flex-start;
-    flex-grow: 0;
+    flex-grow: 1;
 }
 #side-content{
     background: var(--cmap-bg-ligher);
@@ -135,7 +135,7 @@ nav.side{
     border-right: 1px solid var(--cmap-bg-lightest);
     padding-top: 10px;
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     overflow-y: scroll;
 }
 main{
@@ -680,4 +680,31 @@ table tr:hover .btn.hovering{
 }
 .dropdown:hover .dropbtn {
     background: (--cmap-border-darker);
+}
+#side-expand{
+    display: none;
+}
+@media screen and (max-width: 1100px) {
+  #side-content{
+    position: absolute;
+    height: 100%;
+    left: -235px;
+    transition: left 0.3s;
+  }
+  #side-content:hover, #side-content.active{
+    position: absolute;
+    left: 0px;
+  }
+  #side-expand{
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 14px;
+    cursor: pointer;
+  }
+  #side-content:hover > #side-expand,
+  #side-content.active > #side-expand{
+    /*transform: scaleX(-1);*/
+    display: none;
+  }
 }

--- a/src/cryptoadvance/specter/static/styles.css
+++ b/src/cryptoadvance/specter/static/styles.css
@@ -586,6 +586,7 @@ table{
 .table-holder{
     padding: 0 30px;
     width: 100%;
+    /*overflow-x: scroll;*/
 }
 .full-width{
     width: 100%;
@@ -799,7 +800,10 @@ a:focus + .tool-tip .tool-tip__info {
     justify-content: center;
     font-size: 14px;
     cursor: pointer;
-  }    
+  }
+  td.xpub{
+    max-width: 230px;
+  }
   @media (hover: hover){
     #side-content:hover{
       position: absolute;

--- a/src/cryptoadvance/specter/static/styles.css
+++ b/src/cryptoadvance/specter/static/styles.css
@@ -39,6 +39,12 @@ ul, li{
     margin: 0;
     padding: 0;
 }
+#menubtn{
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    opacity: 0.7;
+}
 .output_option{
     margin: 5px;
 }
@@ -783,6 +789,10 @@ a:focus + .tool-tip .tool-tip__info {
 #side-expand{
     display: none;
 }
+#menubtn{
+    display: none;
+}
+
 @media (max-width: 1100px){
   main{
     padding-left: 15px;
@@ -814,12 +824,21 @@ a:focus + .tool-tip .tool-tip__info {
     }
   }
   @media (hover: none){
+    #menubtn{
+      display: block;
+    }
     #side-content.active{
       position: absolute;
       left: 0px;
     }
     #side-content.active > #side-expand{
       transform: scaleX(-1);
+    }
+    #side-content{
+      left: -250px;
+    }
+    #side-expand{
+      display: none;
     }
   }
 }

--- a/src/cryptoadvance/specter/templates/base.html
+++ b/src/cryptoadvance/specter/templates/base.html
@@ -60,9 +60,6 @@ function showLoader(){
 function hideLoader(){
 	document.getElementById("loader").style.display = "none";
 }
-// document.querySelectorAll("button").forEach((e)=>{
-// 	e.addEventListener("click", showLoader);
-// });
 </script>
 {% block scripts %}
 {% endblock %}

--- a/src/cryptoadvance/specter/templates/base.html
+++ b/src/cryptoadvance/specter/templates/base.html
@@ -21,6 +21,8 @@
 	<main>
 		{% if specter.config.auth!="none" and current_user.is_authenticated %}
 		<a class="logout" href="{{ url_for('logout') }}"><img src="/static/img/exit_from_app-24px.svg" style="width: 24px;"/><div>Logout</div></a>
+		{% else %}
+		<div><br><br></div>
 		{% endif %}
 
 		{% with messages = get_flashed_messages() %}

--- a/src/cryptoadvance/specter/templates/base.html
+++ b/src/cryptoadvance/specter/templates/base.html
@@ -19,6 +19,10 @@
 	{% include "includes/sidebar.html" %}
 	{% endblock %}
 	<main>
+		{% if specter.config.auth!="none" and current_user.is_authenticated %}
+		<a class="logout" href="{{ url_for('logout') }}"><img src="/static/img/exit_from_app-24px.svg" style="width: 24px;"/><div>Logout</div></a>
+		{% endif %}
+
 		{% with messages = get_flashed_messages() %}
 		{% if messages %}
 			<div class="notification error">

--- a/src/cryptoadvance/specter/templates/base.html
+++ b/src/cryptoadvance/specter/templates/base.html
@@ -18,12 +18,13 @@
 	{% block sidebar %}
 	{% include "includes/sidebar.html" %}
 	{% endblock %}
-	<main>
+	<main>		
 		{% if specter.config.auth!="none" and current_user.is_authenticated %}
 		<a class="logout" href="{{ url_for('logout') }}"><img src="/static/img/exit_from_app-24px.svg" style="width: 24px;"/><div>Logout</div></a>
 		{% else %}
 		<div><br><br></div>
 		{% endif %}
+		<img id="menubtn" src="/static/img/menu.svg"/>
 
 		{% with messages = get_flashed_messages() %}
 		{% if messages %}
@@ -66,6 +67,21 @@ function showLoader(){
 function hideLoader(){
 	document.getElementById("loader").style.display = "none";
 }
+function sideToggle(){
+    let el = document.getElementById("side-content");
+    el.classList.toggle("active");
+}
+window.addEventListener('load', (event) => {
+    let main = document.getElementsByTagName("main")[0];
+    main.addEventListener('click', (event) => {
+        document.getElementById("side-content").classList.remove("active");
+    });
+    let menubtn = document.getElementById("menubtn");
+    menubtn.addEventListener('click', (event) => {
+    	document.getElementById("side-content").classList.add("active");
+    	event.stopPropagation();
+    });
+});
 </script>
 {% block scripts %}
 {% endblock %}

--- a/src/cryptoadvance/specter/templates/base.html
+++ b/src/cryptoadvance/specter/templates/base.html
@@ -3,6 +3,7 @@
 <head>
 	<link rel="shortcut icon" type="image/png" href="/static/img/icon.png"/>
 	<title>Specter Desktop</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<link rel="stylesheet" type="text/css" href="/static/styles.css?{{rand}}">
 {% if debug %}
 	<!-- Developer Version of vue.js because debug=true -->

--- a/src/cryptoadvance/specter/templates/includes/sidebar.html
+++ b/src/cryptoadvance/specter/templates/includes/sidebar.html
@@ -100,21 +100,7 @@
         </a>
     </div>
 </nav>
-<div id="side-expand" onclick="sideToggle()">
+<div id="side-expand">
     <div>▶</div>
 </div>
 </div>
-<script type="text/javascript">
-function sideToggle(){
-    let el = document.getElementById("side-content");
-    el.classList.toggle("active");
-    el.blur();
-    document.getElementById("side-expand").blur();
-}
-window.addEventListener('load', (event) => {
-    let main = document.getElementsByTagName("main")[0];
-    main.addEventListener('click', (event) => {
-        document.getElementById("side-content").classList.remove("active");
-    });
-});
-</script>

--- a/src/cryptoadvance/specter/templates/includes/sidebar.html
+++ b/src/cryptoadvance/specter/templates/includes/sidebar.html
@@ -104,13 +104,16 @@
         </a>
     </div>
 </nav>
-<div id="side-expand" onclick="sideExpand()">
+<div id="side-expand" onclick="sideToggle()">
     <div>▶</div>
 </div>
 </div>
 <script type="text/javascript">
-function sideExpand(){
-    document.getElementById("side-content").classList.add("active");
+function sideToggle(){
+    let el = document.getElementById("side-content");
+    el.classList.toggle("active");
+    el.blur();
+    document.getElementById("side-expand").blur();
 }
 window.addEventListener('load', (event) => {
     let main = document.getElementsByTagName("main")[0];

--- a/src/cryptoadvance/specter/templates/includes/sidebar.html
+++ b/src/cryptoadvance/specter/templates/includes/sidebar.html
@@ -1,3 +1,7 @@
+{% if specter.config.auth!="none" and current_user.is_authenticated %}
+<a class="logout" href="{{ url_for('logout') }}"><img src="/static/img/exit_from_app-24px.svg" style="width: 24px;"/><div>Logout</div></a>
+{% endif %}
+
 <div id="side-content">
 <nav class="side">
     {% if specter.info["initialblockdownload"] %}
@@ -99,9 +103,6 @@
             <img src="/static/img/ca.png">
         </a>
     </div>
-    {% if specter.config.auth!="none" and current_user.is_authenticated %}
-    <a class="logout" href="{{ url_for('logout') }}"><img src="/static/img/exit_from_app-24px.svg" style="width: 24px;"/><div>Logout</div></a>
-    {% endif %}
 </nav>
 <div id="side-expand" onclick="sideExpand()">
     <div>▶</div>

--- a/src/cryptoadvance/specter/templates/includes/sidebar.html
+++ b/src/cryptoadvance/specter/templates/includes/sidebar.html
@@ -101,4 +101,18 @@
     <a class="logout" href="{{ url_for('logout') }}"><img src="/static/img/exit_from_app-24px.svg" style="width: 24px;"/><div>Logout</div></a>
     {% endif %}
 </nav>
+<div id="side-expand" onclick="sideExpand()">
+    <div>▶</div>
 </div>
+</div>
+<script type="text/javascript">
+function sideExpand(){
+    document.getElementById("side-content").classList.add("active");
+}
+window.addEventListener('load', (event) => {
+    let main = document.getElementsByTagName("main")[0];
+    main.addEventListener('click', (event) => {
+        document.getElementById("side-content").classList.remove("active");
+    });
+});
+</script>

--- a/src/cryptoadvance/specter/templates/includes/sidebar.html
+++ b/src/cryptoadvance/specter/templates/includes/sidebar.html
@@ -1,7 +1,3 @@
-{% if specter.config.auth!="none" and current_user.is_authenticated %}
-<a class="logout" href="{{ url_for('logout') }}"><img src="/static/img/exit_from_app-24px.svg" style="width: 24px;"/><div>Logout</div></a>
-{% endif %}
-
 <div id="side-content">
 <nav class="side">
     {% if specter.info["initialblockdownload"] %}

--- a/src/cryptoadvance/specter/templates/includes/wallet_menu.html
+++ b/src/cryptoadvance/specter/templates/includes/wallet_menu.html
@@ -1,7 +1,7 @@
-<div class="row padded">
+<nav class="row">
 	<a href="{{ url_for('wallet_tx',wallet_alias=wallet_alias)}}" class="btn radio left {% if active_menuitem == 'transactions' %}checked{% endif %}">Transactions</a>
 	<a href="{{ url_for('wallet_addresses',wallet_alias=wallet_alias)}}" class="btn radio {% if active_menuitem == 'addresses' %}checked{% endif %}">Addresses</a>
 	<a href="{{ url_for('wallet_receive',wallet_alias=wallet_alias)}}" class="btn radio {% if active_menuitem == 'receive' %}checked{% endif %}">Receive</a>
 	<a href="{{ url_for('wallet_send',wallet_alias=wallet_alias)}}" class="btn radio {% if active_menuitem == 'send' %}checked{% endif %}">Send</a>
 	<a href="{{ url_for('wallet_settings',wallet_alias=wallet_alias)}}" class="btn radio right {% if active_menuitem == 'settings' %}checked{% endif %}">Settings</a>
-</div>
+</nav>

--- a/src/cryptoadvance/specter/templates/new_simple.html
+++ b/src/cryptoadvance/specter/templates/new_simple.html
@@ -6,8 +6,8 @@
 
 
 <h1>Type of the wallet</h1>
+<nav class="row">
 {% if sigs_total %}
-<div class="row center">
 <label>
 	{% if wallet_type=="sh-wsh" %}
 	<input type="radio" name="type" value="sh-wsh" class="hidden" checked>
@@ -25,7 +25,6 @@
 	<div class="btn radio right">Segwit</div>
 </label>
 {% else %}
-<div class="row center">
 <label>
 	<input type="radio" name="type" value="sh-wpkh" class="hidden">
 	<div class="btn radio left">Nested Segwit</div>
@@ -35,7 +34,7 @@
 	<div class="btn radio right">Segwit</div>
 </label>
 {% endif %}
-</div>
+</nav>
 
 <div class="note"><center>
 	<br><b>Segwit</b> uses bech32-encoded addresses (bc1), <b>Nested Segwit</b> makes it compatible with legacy software. Don't use legacy.

--- a/src/cryptoadvance/specter/templates/new_wallet.html
+++ b/src/cryptoadvance/specter/templates/new_wallet.html
@@ -22,7 +22,7 @@
 		</div>
 	</center>
 </div>
-<div class="row">
+<nav class="row">
 	<a href="./simple/" class="small-card">
 		<img src="/static/img/simple_icon.svg"/>
 		Single key wallet
@@ -31,7 +31,7 @@
 		<img src="/static/img/multisig_icon.svg"/>
 		Multisignature wallet
 	</a>
-</div>
+</nav>
 <div class="note">
 	<center>Multisig is better for larg-ish amounts.</center>
 </div>

--- a/src/cryptoadvance/specter/templates/wallet_addresses.html
+++ b/src/cryptoadvance/specter/templates/wallet_addresses.html
@@ -48,10 +48,10 @@
 </small></h1>
 
 <div style="padding: 0 30px; width: 100%;">
-	<div class="row padded" style="width: intrinsic; margin: auto;">
+	<nav class="row">
 		<a href="./?all=True&view={{viewtype}}" class="btn radio left {% if alladdresses %}checked{% endif %}">History</a>
 		<a href="./?all=False&view={{viewtype}}" class="btn radio right {% if alladdresses != True %}checked{% endif %}">UTXO</a>
-	</div>
+	</nav>
 	<span>View Type: </span><br>
 	<div class="dropdown" style="margin-top: 5px;">
 		<button class="btn radio dropbtn">{{viewtype|title}} View &#9660;</button>

--- a/src/cryptoadvance/specter/templates/wallet_addresses.html
+++ b/src/cryptoadvance/specter/templates/wallet_addresses.html
@@ -88,7 +88,7 @@
 	<table>
 		<thead>
 		<tr>
-			<th></th><th>TxID</th><th>Address</th><th>Amount</th><th>Confirmations</th><th>Time</th>
+			<th></th><th>TxID</th><th>Address</th><th>Amount</th><th>Status</th>
 		</tr>
 		</thead>
 		<tbody>
@@ -117,16 +117,15 @@
 				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}address/{{display_address}}">{{wallet.getaddressname(display_address, -1)}}</a></td>
 				<td>{{tx["amount"] | btcamount}}</td><td>
 				{%if tx["block_height"] == -1 %}
-					Pending
+					Pending.
 				{% else %}
-					{{specter.info.blocks - tx["block_height"] + 1}}
+					{{specter.info.blocks - tx["block_height"] + 1}} conf.
 				{% endif %}
-				</td>
-				<td>{{tx["time"] | datetime}}</td></tr>
+				({{tx["time"] | datetime}})</td></tr>
 			{% endif %}
 			{% endfor %}
 			{% else %}
-			<td></td><td>No transactions yet.</td><td></td><td></td><td></td><td></td>
+			<td></td><td>No transactions yet.</td><td></td><td></td><td></td>
 			{% endif %}
 		</tbody>
 	</table>

--- a/src/cryptoadvance/specter/templates/wallet_send.html
+++ b/src/cryptoadvance/specter/templates/wallet_send.html
@@ -18,6 +18,8 @@
 	}
 	.checkbox {
 		width: 20px;
+		max-width: 20px;
+		min-width: 20px;
   		height: 20px;
 	}
 	#coinselect {

--- a/src/cryptoadvance/specter/templates/wallet_send.html
+++ b/src/cryptoadvance/specter/templates/wallet_send.html
@@ -28,11 +28,11 @@
 {% set active_menuitem = "send" %}
 {% include "includes/wallet_menu.html" %}
 <br>
-<form action="{{ url_for('wallet_send',wallet_alias=wallet_alias)}}" method="POST" class="full-width">
-	<div class="row">
+<form action="{{ url_for('wallet_send',wallet_alias=wallet_alias)}}" method="POST">
+	<nav class="row">
 		<a href="{{ url_for('wallet_send',wallet_alias=wallet_alias)}}" class="btn radio left checked">New</a>
 		<a href="{{ url_for('wallet_sendpending',wallet_alias=wallet_alias)}}" class="btn radio right">Pending</a>
-	</div>
+	</nav>
 	<h1 class="padded">Sending to:</h1>
 	<div class="card"  id="spend_coins">
 		Recipient address:<br>

--- a/src/cryptoadvance/specter/templates/wallet_send_sign_psbt.html
+++ b/src/cryptoadvance/specter/templates/wallet_send_sign_psbt.html
@@ -64,16 +64,16 @@
 	{% endif %}
 
 	{% if wallet.uses_qrcode_device %}
-		<div class="row padded">
+		<nav class="row">
 			<label>
 				<input autocomplete="off" type="radio" name="psbt_type" value="compressed_psbt" class="hidden" checked>
-				<div class="btn radio left">Compressed PSBT</div>
+				<div class="btn radio left" style="width:200px">Compressed PSBT</div>
 			</label>
 			<label>
 				<input autocomplete="off" type="radio" name="psbt_type" value="full_psbt" class="hidden">
-				<div class="btn radio right">Full PSBT</div>
+				<div class="btn radio right" style="width:200px">Full PSBT</div>
 			</label>
-		</div>
+		</nav>
 
 		<div class="row" style="min-height: 400px;">
 			<span id="compressed_psbt">

--- a/src/cryptoadvance/specter/templates/wallet_sendpending.html
+++ b/src/cryptoadvance/specter/templates/wallet_sendpending.html
@@ -38,7 +38,7 @@
 <h1>{{wallet.name}}</h1>
 {% set active_menuitem = "send" %}
 {% include "includes/wallet_menu.html" %}
-<br>
+<br><br>
 		<nav class="row">
 			<a href="{{ url_for('wallet_send',wallet_alias=wallet_alias)}}" class="btn radio left ">New</a>
 			<a href="{{ url_for('wallet_sendpending',wallet_alias=wallet_alias)}}" class="btn radio right checked">Pending</a>

--- a/src/cryptoadvance/specter/templates/wallet_sendpending.html
+++ b/src/cryptoadvance/specter/templates/wallet_sendpending.html
@@ -39,10 +39,10 @@
 {% set active_menuitem = "send" %}
 {% include "includes/wallet_menu.html" %}
 <br>
-		<div class="row">
+		<nav class="row">
 			<a href="{{ url_for('wallet_send',wallet_alias=wallet_alias)}}" class="btn radio left ">New</a>
 			<a href="{{ url_for('wallet_sendpending',wallet_alias=wallet_alias)}}" class="btn radio right checked">Pending</a>
-		</div>
+		</nav>
 			<h1 class="padded">Pending Transactions:</h1>
 			<div class="table-holder">
 				<table>

--- a/src/cryptoadvance/specter/templates/wallet_settings.html
+++ b/src/cryptoadvance/specter/templates/wallet_settings.html
@@ -40,7 +40,7 @@
 			<button type="submit" name="action" value="rescanblockchain" class="btn">Rescan</button>
 		</div>
 		{% if specter.info['pruned']  %}
-			<div class="note center">Note: You are using a pruned node. Rescan is limited by the pruned height to block: {{specter.info['pruneheight']}}</div>
+			<div class="note center full-width">Note: You are using a pruned node. Rescan is limited by the pruned height to block: {{specter.info['pruneheight']}}</div>
 		{% endif %}
 		<div class="note center"><b>481824</b> was the first Segwit block.</div>
 	{% endif %}

--- a/src/cryptoadvance/specter/templates/wallet_tx.html
+++ b/src/cryptoadvance/specter/templates/wallet_tx.html
@@ -17,7 +17,7 @@
 	<table>
 		<thead>
 		<tr>
-			<th></th><th>TxID</th><th>Address</th><th>Amount</th><th>Confirmations</th><th>Time</th>
+			<th></th><th>TxID</th><th>Address</th><th>Amount</th><th>Status</th>
 		</tr>
 		</thead>
 		<tbody>
@@ -46,15 +46,14 @@
 				</a></td>
 				<td>{{tx["amount"] if tx["category"] != "send" or tx["destination"] == None else tx["destination"]["amount"] | btcamount}}</td><td>
 				{%if tx["block_height"] == -1 %}
-					Pending
+					Pending.
 				{% else %}
-					{{specter.info.blocks - tx["block_height"] + 1}}
+					{{specter.info.blocks - tx["block_height"] + 1}} conf.
 				{% endif %}
-				</td>
-				<td>{{tx["time"] | datetime}}</td></tr>
+				({{tx["time"] | datetime}})</td></tr>
 			{% endfor %}
 			{% else %}
-			<td></td><td>No transactions yet.</td><td></td><td></td><td></td><td></td>
+			<td></td><td>No transactions yet.</td><td></td><td></td><td></td>
 			{% endif %}
 		</tbody>
 	</table>


### PR DESCRIPTION
Getting started with https://github.com/cryptoadvance/specter-desktop/issues/26
For now only hiding sidebar if the screen is small.
Navbar appears when hovered, for touchscreens if clicked on the arrow.

![ezgif-7-12ad306c0c46](https://user-images.githubusercontent.com/1706012/80050553-3a2ca300-8516-11ea-85b0-2f91d35ba9d7.gif)
