### PR TITLE
Fix issue with Daemonize

### DIFF
--- a/src/cryptoadvance/specter/__main__.py
+++ b/src/cryptoadvance/specter/__main__.py
@@ -132,7 +132,7 @@ def server(daemon, stop, restart, force, port, host, cert, key, tor):
             print("* For onion address check the file %s" % toraddr_file)
         # Note: we can't run flask as a deamon in debug mode,
         #       so use debug=False by default
-        d = Daemonize(app="specter", pid=pid_file, action=run)
+        d = Daemonize(app="specter", pid=pid_file, action=run, auto_close_fds=False)
         d.start()
     # if not a daemon we can use DEBUG
     else:


### PR DESCRIPTION
I've been experiencing an issue with the `--daemon` option of Specter not working, and not even outputting any crash logs or something of the sort. I've searched a bit aand looks like this line in the Daemonize lib is where it fails: https://github.com/thesharp/daemonize/blob/39a880f74c1d8ea09fa44fe2b99dec1c961201a9/daemonize.py#L136

When disabling this the daemon starts working for me.