### PR TITLE
Improve import wallet support

### DIFF
--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -246,7 +246,10 @@ def new_wallet_simple():
             rescan_blockchain = 'rescanblockchain' in request.form
             if rescan_blockchain:
                 if app.specter.info['chain'] == "main":
-                    startblock = 481824
+                    if not app.specter.info['pruned'] or app.specter.info['pruneheight'] < 481824:
+                        startblock = 481824
+                    else:
+                        startblock = app.specter.info['pruneheight']
                 else:
                     startblock = 0
                 try:

--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -243,6 +243,20 @@ def new_wallet_simple():
                 return render_template("base.html", error="Key not found", specter=app.specter, rand=rand)
             # create a wallet here
             wallet = app.specter.wallets.create_simple(wallet_name, wallet_type, key, device)
+            rescan_blockchain = 'rescanblockchain' in request.form
+            if rescan_blockchain:
+                if app.specter.info['chain'] == "main":
+                    startblock = 481824
+                else:
+                    startblock = 0
+                try:
+                    wallet.cli.rescanblockchain(startblock, timeout=1)
+                except requests.exceptions.ReadTimeout:
+                    pass
+                except Exception as e:
+                    print(e)
+                    error = "%r" % e
+                wallet.getdata()
             return redirect("/wallets/%s/" % wallet["alias"])
     return render_template("new_simple.html", wallet_name=wallet_name, device=device, error=err, specter=app.specter, rand=rand)
 

--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -251,7 +251,10 @@ def new_wallet_simple():
                     else:
                         startblock = app.specter.info['pruneheight']
                 else:
-                    startblock = 0
+                    if not app.specter.info['pruned']:
+                        startblock = 0
+                    else:
+                        startblock = app.specter.info['pruneheight']
                 try:
                     wallet.cli.rescanblockchain(startblock, timeout=1)
                 except requests.exceptions.ReadTimeout:

--- a/src/cryptoadvance/specter/static/styles.css
+++ b/src/cryptoadvance/specter/static/styles.css
@@ -690,3 +690,62 @@ table tr:hover .btn.hovering{
 .dropdown:hover .dropbtn {
     background: (--cmap-border-darker);
 }
+
+/************** Tool Tip Styles ********************************/
+.tool-tip {
+    display: inline-block;
+    position: relative;
+    margin-left: 0.5em;
+}
+.tool-tip .tool-tip__icon {
+    color: #fff;
+    background: #27b1f0;
+    border-radius: 10px;
+    cursor: pointer;
+    display: inline-block;
+    font-style: italic;
+    font-family: times new roman;
+    height: 20px;
+    line-height: 1.3em;
+    text-align: center;
+    width: 20px;
+}
+.tool-tip .tool-tip__info {
+    display: none;
+    background: #262626;
+    border: 1px solid #27b1f0;
+    border-radius: 3px;
+    font-size: 0.875em;
+    padding: 1em;
+    position: absolute;
+    left: 30px;
+    top: -20px;
+    width: 250px;
+    z-index: 2;
+}
+.tool-tip .tool-tip__info:before, .tool-tip .tool-tip__info:after {
+    content: "";
+    position: absolute;
+    left: -10px;
+    top: 7px;
+    border-style: solid;
+    border-width: 10px 10px 10px 0;
+    border-color: transparent #27b1f0;
+}
+.tool-tip .tool-tip__info:after {
+    left: -8px;
+    border-right-color: #262626;
+}
+.tool-tip .tool-tip__info .info {
+    display: block;
+}
+.tool-tip .tool-tip__info .info__title {
+    color: #4A90E2;
+}
+.tool-tip:hover .tool-tip__info, .tool-tip:focus .tool-tip__info {
+    display: inline-block;
+}
+
+a:focus + .tool-tip .tool-tip__info {
+    display: inline-block;
+}

--- a/src/cryptoadvance/specter/static/styles.css
+++ b/src/cryptoadvance/specter/static/styles.css
@@ -691,6 +691,16 @@ table tr:hover .btn.hovering{
     background: (--cmap-border-darker);
 }
 
+.warning {
+    text-align: center;
+    font-size: 12px;
+    background: #FFCC00b0;
+    padding: 10px;
+    color: #111111;
+    margin: 10px;
+    border-radius: 7px;
+}
+
 /************** Tool Tip Styles ********************************/
 .tool-tip {
     display: inline-block;

--- a/src/cryptoadvance/specter/templates/includes/sidebar.html
+++ b/src/cryptoadvance/specter/templates/includes/sidebar.html
@@ -68,7 +68,7 @@
         {% endfor %}
         <div class="item">
             <a href="/new_wallet/" class="btn">
-                <svg width="20" height="20" viewBox="0 0 24 24"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/></svg>Create new wallet
+                <svg width="20" height="20" viewBox="0 0 24 24"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/></svg>Add new wallet
             </a>
         </div>
     {% endif %}

--- a/src/cryptoadvance/specter/templates/includes/sidebar.html
+++ b/src/cryptoadvance/specter/templates/includes/sidebar.html
@@ -1,13 +1,7 @@
 <div id="side-content">
 <nav class="side">
     {% if specter.info["initialblockdownload"] %}
-        <p style="text-align: center;
-        font-size: 12px;
-        background: #FFCC00b0;
-        padding: 10px;
-        color: #111111;
-        margin: 10px;
-        border-radius: 7px;">⚠️<br>Blockchain is still syncing...<br>Data may be shown incorrectly.</p>
+        <p class="warning">⚠️<br>Blockchain is still syncing...<br>Data may be shown incorrectly.</p>
     {% endif %}
     <a href="/settings/" class="item core">
         <svg class="core {{specter.info.chain}}" height="32" width="32" viewBox="0 0 64 64">

--- a/src/cryptoadvance/specter/templates/new_simple_keys.html
+++ b/src/cryptoadvance/specter/templates/new_simple_keys.html
@@ -16,6 +16,11 @@
 				<span class="info">
 					<span class="info__title">Importing an existing wallet<br></span>
 					Check this option to scan the blockchain for existing wallet balance and history.
+					{% if specter.info["pruned"] %}
+						<span class="warning" style="display: inline-block;">
+							Please Note:<br>You are using a pruned node.<br> Wallet history may not fully appear.
+						</span>
+					{% endif %}
 				</span>
 			</p>
 		</div>

--- a/src/cryptoadvance/specter/templates/new_simple_keys.html
+++ b/src/cryptoadvance/specter/templates/new_simple_keys.html
@@ -6,9 +6,24 @@
 {% else %}
 <h1>Select the key of devices to use in {{wallet_name}}.</h1>
 {% endif %}
-
+<div class="center">
+	<div style="display: inline-block; text-align: center; margin-top: 10px;">
+		<input form="keysform" type="checkbox" name="rescanblockchain" id="rescan" class="inline">
+		<label for="rescan">Scan for existing funds?</label>
+		<div class="tool-tip">
+			<i class="tool-tip__icon">i</i>
+			<p class="tool-tip__info">
+				<span class="info">
+					<span class="info__title">Importing an existing wallet<br></span>
+					Check this option to scan the blockchain for existing wallet balance and history.
+				</span>
+			</p>
+		</div>
+	</div>
+</div>
+<div class="spacer"></div>
 {% if cosigners %}
-<form action="./" method="POST" class="table-holder">
+<form id="keysform" action="./" method="POST" class="table-holder">
 	<input type="hidden" name="wallet_name" value="{{wallet_name}}">
 	{% for cosigner in cosigners %}
 	<input type="hidden" name="cosigner{{loop.index0}}" value="{{cosigner['name']}}"/>
@@ -72,7 +87,6 @@
 
 {% else %}
 <!-- UGLY COPY-PASTE -->
-<div class="spacer"></div>
 <div class="table-holder">
 	<table>
 		<thead>
@@ -103,7 +117,7 @@
 			<td>{{key["derivation"]}}</td>
 			<td class="scroll xpub"><span>{{key["original"]}}</span></td>
 			<td width="120px">
-				<form action="./" method="POST">
+				<form id="keysform" action="./" method="POST">
 					<input type="hidden" name="key" value="{{key['original']}}">
 					<input type="hidden" name="wallet_name" value="{{wallet_name}}">
 					<input type="hidden" name="device" value="{{device['name']}}">

--- a/src/cryptoadvance/specter/templates/new_wallet.html
+++ b/src/cryptoadvance/specter/templates/new_wallet.html
@@ -2,6 +2,20 @@
 {% block main %}
 <div class="spacer"></div>
 <h1>Select the type of the wallet</h1>
+<div>
+	<center>
+		<span>Importing an existing wallet?</span>
+		<div class="tool-tip">
+			<i class="tool-tip__icon">i</i>
+            <p class="tool-tip__info">
+				<span class="info">
+					<span class="info__title">Importing an existing wallet?<br></span>
+					After choosing device(s), click continue, then just select the:<br> "Scan for existing funds" checkbox on the next screen.
+				</span>
+            </p>
+		</div>
+	</center>
+</div>
 <div class="row">
 	<a href="./simple/" class="small-card">
 		<img src="/static/img/simple_icon.svg"/>

--- a/src/cryptoadvance/specter/templates/new_wallet.html
+++ b/src/cryptoadvance/specter/templates/new_wallet.html
@@ -11,6 +11,12 @@
 				<span class="info">
 					<span class="info__title">Importing an existing wallet?<br></span>
 					After choosing device(s), click continue, then just select the:<br> "Scan for existing funds" checkbox on the next screen.
+					<br>
+					{% if specter.info["pruned"] %}
+						<span class="warning" style="display: inline-block;">
+							Please Note:<br>You are using a pruned node.<br> Wallet history may not fully appear.
+						</span>
+					{% endif %}
 				</span>
             </p>
 		</div>

--- a/src/cryptoadvance/specter/templates/wallet_settings.html
+++ b/src/cryptoadvance/specter/templates/wallet_settings.html
@@ -32,7 +32,7 @@
 			{% if specter.info.chain == "main" %}
 			{% set startblock=(481824 if not specter.info['pruned'] or specter.info['pruneheight'] < 481824 else specter.info['pruneheight']) %}
 			{% else %}
-			{% set startblock=0 %}
+			{% set startblock=(0 if not specter.info['pruned'] else specter.info['pruneheight']) %}
 			{% endif %}
 
 			<input type="number" name="startblock" value="{{startblock}}" style="margin-right: 10px" min="{{startblock}}">

--- a/src/cryptoadvance/specter/templates/wallet_settings.html
+++ b/src/cryptoadvance/specter/templates/wallet_settings.html
@@ -30,14 +30,17 @@
 		Rescan blockchain from block:<br>
 		<div class="row aligned">
 			{% if specter.info.chain == "main" %}
-			{% set startblock=481824 %}
+			{% set startblock=(481824 if not specter.info['pruned'] or specter.info['pruneheight'] < 481824 else specter.info['pruneheight']) %}
 			{% else %}
 			{% set startblock=0 %}
 			{% endif %}
 
-			<input type="number" name="startblock" value="{{startblock}}" style="margin-right: 10px">
+			<input type="number" name="startblock" value="{{startblock}}" style="margin-right: 10px" min="{{startblock}}">
 			<button type="submit" name="action" value="rescanblockchain" class="btn">Rescan</button>
 		</div>
+		{% if specter.info['pruned']  %}
+			<div class="note center">Note: You are using a pruned node. Rescan is limited by the pruned height to block: {{specter.info['pruneheight']}}</div>
+		{% endif %}
 		<div class="note center"><b>481824</b> was the first Segwit block.</div>
 	{% endif %}
 </form>


### PR DESCRIPTION
Since #95 rescanning the blockchain identifies old addresses used by the wallet outside of Specter, in order to allow easier migration of existing wallets.

This PR should make the flow for importing an existing wallet in this way a bit clearer and simpler, by adding some tooltips and the option to rescan the blockchain as part of the add wallet screen.

<img width="1529" alt="tooltip2" src="https://user-images.githubusercontent.com/10667901/81337722-25bedd80-90b4-11ea-8ae9-422420a8f15e.png">
<img width="912" alt="tooltip1" src="https://user-images.githubusercontent.com/10667901/81337727-28b9ce00-90b4-11ea-8d97-932024cd9dbd.png">

Edit:
Fix #126 
