### PR TITLE
windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ At the moment Specter-Desktop is working with all major Hardware-Wallets includi
 * HWI support requires `libusb` 
  * Ubuntu/Debian: `sudo apt install libusb-1.0-0-dev libudev-dev`
  * macOS: `brew install libusb`
+ * windows: follow instructions in [`windows.md`](docs/windows.md)
 * Install Specter
 ```sh
 pip install cryptoadvance.specter

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -1,6 +1,6 @@
 # Running Specter-Desktop on Windows
 
-1. Install Python 3.7 from Microsoft Store (python 3.8 is not supported yet)
+1. Install Python 3.7 from Microsoft Store (python 3.8 is not supported yet). You may need to install [Visual C++ Redistributable](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads) for it.
 2. Install libusb:
 	- Download latest binary from https://libusb.info/
 	- Extract and copy content of MS64 folder to your `Windows\System32` folder

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -1,0 +1,18 @@
+# Running Specter-Desktop on Windows
+
+1. Install Python 3.7 from Microsoft Store (python 3.8 is not supported yet)
+2. Install libusb:
+	- Download latest binary from https://libusb.info/
+	- Extract and copy content of MS64 folder to your `Windows\System32` folder
+3. Edit Bitcoin Core config file and make sure `server=1` is set (it's in `~\AppData\Roaming\Bitcoin\bitcoin.conf`)
+
+Now you can install specter-desktop and run as usual:
+
+```sh
+python3 -m pip install cryptoadvance.specter
+python3 -m cryptoadvance.specter server
+```
+
+Web interface should be on http://localhost:25441/
+
+*Note:* `--daemon` flag is not available on Windows yet. Also communication with a remote node is not tested yet.

--- a/src/cryptoadvance/specter/__main__.py
+++ b/src/cryptoadvance/specter/__main__.py
@@ -13,7 +13,6 @@ from .bitcoind import (BitcoindDockerController,
 from .helpers import load_jsons, which
 from .server import DATA_FOLDER, create_app, init_app
 
-from daemonize import Daemonize
 from os import path
 import signal
 
@@ -125,6 +124,7 @@ def server(daemon, stop, restart, force, port, host, cert, key, tor):
 
     # check if we should run a daemon or not
     if daemon or restart:
+        from daemonize import Daemonize
         print("Starting server in background...")
         print("* Hopefully running on %s://%s:%d/" % (protocol, host, port))
         if tor is not None:


### PR DESCRIPTION
Added:
- instructions for windows in docs
- wallet path fix because win uses `\\` everywhere

Daemonize doesn't work on windows, so I moved the import to the part of the code where it's necessary.

Tested on Windows with Trezor.