### PR TITLE
Small amounts fix

### DIFF
--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -680,5 +680,9 @@ def derivation(wallet):
 def txonaddr(obj):
     return json.dumps(obj, indent=4)
 
+@app.template_filter('btcamount')
+def btcamount(value):
+    value = float(value)
+    return "{:.8f}".format(value).rstrip("0").rstrip(".")
 
     

--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -449,7 +449,7 @@ def wallet_send(wallet_alias):
             label = request.form['label']
             if request.form['label'] != "":
                 wallet.setlabel(address, label)
-            amount = float(request.form['amount'])
+            amount = float(request.form['btc_amount'])
             subtract = bool(request.form.get("subtract", False))
             fee_unit = request.form.get('fee_unit')
             selected_coins = request.form.getlist('coinselect')

--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -442,6 +442,7 @@ def wallet_send(wallet_alias):
     label = ""
     amount = 0
     fee_rate = 0.0
+    err = None
     if request.method == "POST":
         action = request.form['action']
         if action == "createpsbt":
@@ -471,18 +472,24 @@ def wallet_send(wallet_alias):
                             if address in v["scriptPubKey"]["addresses"]:
                                 amount = v["value"]
             except Exception as e:
-                flash(e, "error")
-            return render_template("wallet_send_sign_psbt.html", psbt=psbt, label=label, 
-                                                wallet_alias=wallet_alias, wallet=wallet, 
-                                                specter=app.specter, rand=rand)
+                err = e
+            if err is None:
+                return render_template("wallet_send_sign_psbt.html", psbt=psbt, label=label, 
+                                                    wallet_alias=wallet_alias, wallet=wallet, 
+                                                    specter=app.specter, rand=rand)
         elif action == "openpsbt":
             psbt = ast.literal_eval(request.form["pending_psbt"])
             return render_template("wallet_send_sign_psbt.html", psbt=psbt, label=label, 
                                                 wallet_alias=wallet_alias, wallet=wallet, 
                                                 specter=app.specter, rand=rand)
+        elif action == 'deletepsbt':
+            try:
+                wallet.delete_pending_psbt(ast.literal_eval(request.form["pending_psbt"])["tx"]["txid"])
+            except Exception as e:
+                flash("Could not delete Pending PSBT!")
     return render_template("wallet_send.html", psbt=psbt, label=label, 
                                                 wallet_alias=wallet_alias, wallet=wallet, 
-                                                specter=app.specter, rand=rand)
+                                                specter=app.specter, rand=rand, error=err)
 
 @app.route('/wallets/<wallet_alias>/send/pending/', methods=['GET', 'POST'])
 @login_required
@@ -494,10 +501,12 @@ def wallet_sendpending(wallet_alias):
         print(e)
         return render_template("base.html", error="Wallet not found", specter=app.specter, rand=rand)
     if request.method == "POST":
-        try:
-            wallet.delete_pending_psbt(ast.literal_eval(request.form["pending_psbt"])["tx"]["txid"])
-        except Exception as e:
-            flash("Could not delete Pending PSBT!")
+        action = request.form['action']
+        if action == 'deletepsbt':
+            try:
+                wallet.delete_pending_psbt(ast.literal_eval(request.form["pending_psbt"])["tx"]["txid"])
+            except Exception as e:
+                flash("Could not delete Pending PSBT!")
     pending_psbts = wallet.pending_psbts
     return render_template("wallet_sendpending.html", pending_psbts=pending_psbts,
                                                 wallet_alias=wallet_alias, wallet=wallet, 

--- a/src/cryptoadvance/specter/templates/includes/sidebar.html
+++ b/src/cryptoadvance/specter/templates/includes/sidebar.html
@@ -52,7 +52,7 @@
                 {{wallet.name}} 
                 {% if specter.chain %}
                 {% if wallet.fullbalance is not none %}
-                <span class="balance">{{ "%0.8f" % (wallet.fullbalance ) | float}}
+                <span class="balance">{{ wallet.fullbalance | btcamount}}
                  <!-- {% if specter.chain != "main" %} t{%endif%}BTC -->
                 </span>
                 {%endif%}

--- a/src/cryptoadvance/specter/templates/wallet_addresses.html
+++ b/src/cryptoadvance/specter/templates/wallet_addresses.html
@@ -115,7 +115,7 @@
 				{% set display_address = (tx["destination"]["address"] if ("destination" in tx and tx["destination"] != None) else tx["address"])%}
 				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}tx/{{tx['txid']}}">{{tx["txid"]}}</a></td>
 				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}address/{{display_address}}">{{wallet.getaddressname(display_address, -1)}}</a></td>
-				<td>{{tx["amount"]}}</td><td>
+				<td>{{'{:.8f}'.format(tx["amount"]).rstrip("0").rstrip(".")}}</td><td>
 				{%if tx["block_height"] == -1 %}
 					Pending
 				{% else %}

--- a/src/cryptoadvance/specter/templates/wallet_addresses.html
+++ b/src/cryptoadvance/specter/templates/wallet_addresses.html
@@ -40,10 +40,10 @@
 {% include "includes/wallet_menu.html" %}
 {% if ( wallet.fullbalance ) is not none %}
 <h1><small style="line-height:30px">Total balance:<br></small><span style="color: #fff">
-	{{ "%0.8f" % ( wallet.fullbalance ) | float }}
+	{{ wallet.fullbalance | btcamount }}
 	{% if specter.chain !='main' %}t{%endif%}BTC
 	{% if wallet.balance["untrusted_pending"] > 0 %}</span><br><small>
-	( {{ "%0.8f" % wallet.balance["trusted"] | float }} confirmed, {{"%0.8f" % wallet.balance["untrusted_pending"] | float}} pending )
+	( {{ wallet.balance["trusted"] | btcamount }} confirmed, {{wallet.balance["untrusted_pending"] | btcamount}} pending )
 	{% endif %}
 </small></h1>
 
@@ -81,7 +81,7 @@
 	<a target="blank" class="address" href="{{specter.explorer}}address/{{account}}">{{account}}</a>
 	{% endif %}
 	<p class="balance">Balance: 
-		{{"%0.8f" % (wallet.balanceonaddr(account) if isaddrview else wallet.balanceonlabel(account)) | float}} 
+		{{wallet.balanceonaddr(account) if isaddrview else wallet.balanceonlabel(account) | btcamount}} 
 		{% if specter.chain !='main' %}t{%endif%}BTC
 	</p>
 	<br><br>
@@ -115,7 +115,7 @@
 				{% set display_address = (tx["destination"]["address"] if ("destination" in tx and tx["destination"] != None) else tx["address"])%}
 				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}tx/{{tx['txid']}}">{{tx["txid"]}}</a></td>
 				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}address/{{display_address}}">{{wallet.getaddressname(display_address, -1)}}</a></td>
-				<td>{{'{:.8f}'.format(tx["amount"]).rstrip("0").rstrip(".")}}</td><td>
+				<td>{{tx["amount"] | btcamount}}</td><td>
 				{%if tx["block_height"] == -1 %}
 					Pending
 				{% else %}

--- a/src/cryptoadvance/specter/templates/wallet_send.html
+++ b/src/cryptoadvance/specter/templates/wallet_send.html
@@ -57,8 +57,8 @@
 		</div>
 		<div class="note">
 			[[Number.parseFloat(amount / (unit == "sat" ? 100000000 : 0.000000001)).toFixed((unit == "sat" ? 8 : 0))]] [[(unit == "sat" ? "BTC" : "sats")]], 
-			Available: {{"%.8f" % wallet.availablebalance}}{% if wallet.locked_amount > 0 %};
-			&nbsp;Locked in pending transactions: {{"%.8f" % wallet.locked_amount}}
+			Available: {{wallet.availablebalance | btcamount}}{% if wallet.locked_amount > 0 %};
+			&nbsp;Locked in pending transactions: {{wallet.locked_amount | btcamount}}
 			{% endif %}
 		</div>
 		<div><label><input type="checkbox" class="inline" name="subtract" value="1"> Subtract from amount</label></div>

--- a/src/cryptoadvance/specter/templates/wallet_send.html
+++ b/src/cryptoadvance/specter/templates/wallet_send.html
@@ -45,7 +45,10 @@
 		<input type="text" id="label" name="label" value="{{label}}">
 		<br><br>
 		Amount:<br>
-		<input type="number" name="amount" v-model="amount" id="amount" v-bind:max="max_amount_sendable" min=0 step="1e-8" autocomplete="off">
+		<input style="width:200px" type="number" name="amount" v-model="amount" id="amount" v-bind:max="(unit == 'sat' ? max_amount_sendable * 100000000 : max_amount_sendable)" min=0 step="1e-8" autocomplete="off">
+		<input type="hidden" name="btc_amount" :value="(unit == 'btc' ? amount : amount / 100000000)">
+		<label><input type="radio" class="inline" style="margin: 0 5px;" name="amount_unit" v-model="unit" value="sat" checked>sats</label>
+		<label><input type="radio" class="inline" style="margin: 0 5px;" name="amount_unit" v-model="unit" value="btc">BTC</label>
 		<div class="notification error" v-if="above_wallet_amount || needs_more_selected_coins">
 			<ul>
 				<li v-if="needs_more_selected_coins"> You need to select more coins to match your amount!</li>
@@ -53,6 +56,7 @@
 			</ul>
 		</div>
 		<div class="note">
+			[[Number.parseFloat(amount / (unit == "sat" ? 100000000 : 0.000000001)).toFixed((unit == "sat" ? 8 : 0))]] [[(unit == "sat" ? "BTC" : "sats")]], 
 			Available: {{"%.8f" % wallet.availablebalance}}{% if wallet.locked_amount > 0 %};
 			&nbsp;Locked in pending transactions: {{"%.8f" % wallet.locked_amount}}
 			{% endif %}
@@ -219,7 +223,8 @@ document.getElementById("popup").addEventListener("click", function(){
 			address: "",
 			amount: 0,
 			wallet_availablebalance: {{wallet.availablebalance}},
-			block_explorer: "{{specter.explorer}}"
+			block_explorer: "{{specter.explorer}}",
+			unit: "sat"
 		},
 		computed: {
 			selected_coins_sum: function() {
@@ -239,10 +244,10 @@ document.getElementById("popup").addEventListener("click", function(){
 				}
 			},
 			needs_more_selected_coins: function() {
-				return this.amount > this.selected_coins_sum && this.coinselectionActive
+				return (this.unit == 'sat' ? this.amount / 100000000 : this.amount) > this.selected_coins_sum && this.coinselectionActive
 			},
 			above_wallet_amount: function() {
-				return this.amount > this.wallet_availablebalance
+				return (this.unit == 'sat' ? this.amount / 100000000 : this.amount) > this.wallet_availablebalance
 			}
 		},
 		methods: {

--- a/src/cryptoadvance/specter/templates/wallet_send_sign_psbt.html
+++ b/src/cryptoadvance/specter/templates/wallet_send_sign_psbt.html
@@ -31,7 +31,7 @@
 {% set active_menuitem = "send" %}
 {% include "includes/wallet_menu.html" %}
 <br>
-<form action="./" method="POST" class="full-width">
+<form action="{{ url_for('wallet_send',wallet_alias=wallet_alias)}}" method="POST" class="full-width">
 	<div class="tx_info">
 		
 		<div>Sending <b>{{'{:.8f}'.format(psbt["amount"]).rstrip("0").rstrip(".")}}</b> BTC to<b>
@@ -149,10 +149,8 @@
 	{% endif %}
 
 	<div class="row padded">
-		<form action="./" method="POST">
-			<input type="hidden" name="pending_psbt" value="{{psbt}}">
-			<button type="submit" name="action" value="deletepsbt" class="btn danger centered" style="margin-left: 5px;">Delete Transaction</button>
-		</form>
+		<input type="hidden" name="pending_psbt" value="{{psbt}}">
+		<button type="submit" name="action" value="deletepsbt" class="btn danger centered" style="margin-left: 5px;">Delete Transaction</button>
 	</div>
 </form>
 

--- a/src/cryptoadvance/specter/templates/wallet_send_sign_psbt.html
+++ b/src/cryptoadvance/specter/templates/wallet_send_sign_psbt.html
@@ -34,7 +34,7 @@
 <form action="./" method="POST" class="full-width">
 	<div class="tx_info">
 		
-		<div>Sending <b>{{psbt["amount"]}}</b> BTC to<b>
+		<div>Sending <b>{{'{:.8f}'.format(psbt["amount"]).rstrip("0").rstrip(".")}}</b> BTC to<b>
 			<a class="address-link" target="blank" href="{{specter.explorer}}address/{{ psbt['address'] }}">
 			{{wallet.getaddressname(psbt["address"], -1)}}
 			</a></b><br><br>

--- a/src/cryptoadvance/specter/templates/wallet_send_sign_psbt.html
+++ b/src/cryptoadvance/specter/templates/wallet_send_sign_psbt.html
@@ -34,7 +34,7 @@
 <form action="{{ url_for('wallet_send',wallet_alias=wallet_alias)}}" method="POST" class="full-width">
 	<div class="tx_info">
 		
-		<div>Sending <b>{{'{:.8f}'.format(psbt["amount"]).rstrip("0").rstrip(".")}}</b> BTC to<b>
+		<div>Sending <b>{{psbt["amount"] | btcamount}}</b> BTC to<b>
 			<a class="address-link" target="blank" href="{{specter.explorer}}address/{{ psbt['address'] }}">
 			{{wallet.getaddressname(psbt["address"], -1)}}
 			</a></b><br><br>

--- a/src/cryptoadvance/specter/templates/wallet_sendpending.html
+++ b/src/cryptoadvance/specter/templates/wallet_sendpending.html
@@ -63,7 +63,7 @@
 										</a>
 									</td>
 									<td>
-										{{'{:.8f}'.format(pending_psbt["amount"]).rstrip("0").rstrip(".")}}
+										{{'pending_psbt["amount"] | btcamount}}
 									</td>
 									<td>
 										{{ pending_psbt["time"] | datetime }}

--- a/src/cryptoadvance/specter/templates/wallet_sendpending.html
+++ b/src/cryptoadvance/specter/templates/wallet_sendpending.html
@@ -63,7 +63,7 @@
 										</a>
 									</td>
 									<td>
-										{{ pending_psbt["amount"] }}
+										{{'{:.8f}'.format(pending_psbt["amount"]).rstrip("0").rstrip(".")}}
 									</td>
 									<td>
 										{{ pending_psbt["time"] | datetime }}

--- a/src/cryptoadvance/specter/templates/wallet_tx.html
+++ b/src/cryptoadvance/specter/templates/wallet_tx.html
@@ -5,10 +5,10 @@
 {% include "includes/wallet_menu.html" %}
 {% if ( wallet.fullbalance ) is not none %}
 <h1><small style="line-height:30px">Total balance:<br></small><span style="color: #fff">
-	{{ "%0.8f" % ( wallet.fullbalance ) | float }}
+	{{ wallet.fullbalance | btcamount }}
 	{% if specter.chain !='main' %}t{%endif%}BTC
 	{% if wallet.balance["untrusted_pending"] > 0 %}</span><br><small>
-	( {{ "%0.8f" % wallet.balance["trusted"] | float }} confirmed, {{"%0.8f" % wallet.balance["untrusted_pending"] | float}} pending )
+	( {{ wallet.balance["trusted"] | btcamount }} confirmed, {{ wallet.balance["untrusted_pending"] | btcamount }} pending )
 	{% endif %}
 </small></h1>
 <br>
@@ -44,7 +44,7 @@
 				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}address/{{tx['address']}}">
 					{{wallet.getaddressname(tx["address"] if tx["category"] != "send" or tx["destination"] == None else tx["destination"]["address"], -1)}}
 				</a></td>
-				<td>{{'{:.8f}'.format(tx["amount"] if tx["category"] != "send" or tx["destination"] == None else tx["destination"]["amount"]).rstrip("0").rstrip(".")}}</td><td>
+				<td>{{tx["amount"] if tx["category"] != "send" or tx["destination"] == None else tx["destination"]["amount"] | btcamount}}</td><td>
 				{%if tx["block_height"] == -1 %}
 					Pending
 				{% else %}

--- a/src/cryptoadvance/specter/templates/wallet_tx.html
+++ b/src/cryptoadvance/specter/templates/wallet_tx.html
@@ -44,7 +44,7 @@
 				<td class="tx scroll"><a target="blank" href="{{specter.explorer}}address/{{tx['address']}}">
 					{{wallet.getaddressname(tx["address"] if tx["category"] != "send" or tx["destination"] == None else tx["destination"]["address"], -1)}}
 				</a></td>
-				<td>{{tx["amount"] if tx["category"] != "send" or tx["destination"] == None else tx["destination"]["amount"]}}</td><td>
+				<td>{{'{:.8f}'.format(tx["amount"] if tx["category"] != "send" or tx["destination"] == None else tx["destination"]["amount"]).rstrip("0").rstrip(".")}}</td><td>
 				{%if tx["block_height"] == -1 %}
 					Pending
 				{% else %}


### PR DESCRIPTION
Fix #123 (note: I kept the amount the backend handles in btc and not sats since this is what Bitcoin Core expects to receive, and using sats would mean double conversion which would be even worse).

This PR fixes the way Specter displays small amounts (remove exponential notation) and allows users to specify sending amount in `sats` instead of BTC.
It also fixes two small bugs, one with the way Specter handles errors in the send screen (specifically, errors when PSBT wasn't created, for example when the amount is too small), the other is the delete button on the signing screen which stopped working properly.