### PR TITLE
Fix Pending PSBTs page

### DIFF
--- a/src/cryptoadvance/specter/templates/wallet_sendpending.html
+++ b/src/cryptoadvance/specter/templates/wallet_sendpending.html
@@ -63,7 +63,7 @@
 										</a>
 									</td>
 									<td>
-										{{'pending_psbt["amount"] | btcamount}}
+										{{ pending_psbt["amount"] | btcamount }}
 									</td>
 									<td>
 										{{ pending_psbt["time"] | datetime }}


### PR DESCRIPTION
Seems like there was an accidental `'` left in the pending PSBT screen and which causes it to crash. We might need to release a hotfix to yesterday's release :(