### PR TITLE
Fix coldcard import fingerprint bug

### DIFF
--- a/src/cryptoadvance/specter/templates/new_device_xpubs.html
+++ b/src/cryptoadvance/specter/templates/new_device_xpubs.html
@@ -44,9 +44,9 @@ upub5En4f7k8gaG2KDHvBeEYox...rFpJRHpiZ4DE</pre>
 	<div class="note">
 {%if device_type == "coldcard" %}
 		<p>Export extended public keys for single-key wallets to the SD card from<br>
-			<b>Advanced → MicroSD Card → Electrum Wallet</b></p>
+			<b>Advanced → MicroSD Card → Export Wallet → Electrum Wallet</b></p>
 		<p>To export multisignature pubkeys go to <br>
-			<b>Settings → Multisig Wallets Export XPUB</b></p>
+			<b>Settings → Multisig Wallets → Export XPUB</b></p>
 		<p>We recommend using Native Segwit.</p>
 {% endif %}
 {%if device_type == "specter" %}

--- a/src/cryptoadvance/specter/templates/new_device_xpubs.html
+++ b/src/cryptoadvance/specter/templates/new_device_xpubs.html
@@ -84,7 +84,7 @@ el.addEventListener("change", (e) => {
 	            		prefix = "[";
 	            		let num = json.keystore.ckcc_xfp;
 	            		for(let i=0;i<4;i++){
-	            			prefix += (num % 256).toString(16);
+	            			prefix += ('0' + (num % 256).toString(16)).slice(-2);
 	            			num = num >>> 8;
 	            		}
 	            		prefix += json.keystore.derivation.substring(1);


### PR DESCRIPTION
There appears to be a tiny bug with how we import ColdCard fingerprint for single sig.
Currently, we parse every byte from decimal to hex, but when the hex is smaller than 10, we leave one digit instead of 2 (ie. `1` instead of `01`, `2` instead of `02` etc.). This returns an invalid fingerprint. This PR makes sure a `0` is added to the single-digit numbers.