### PR TITLE
improve logging, debug output for all tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,3 @@
 [pytest]
 norecursedirs = tests/bitcoin
-log_cli = 0
-log_cli_level = INFO
-log_cli_format = %(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)
-log_cli_date_format=%Y-%m-%d %H:%M:%S
+log_format = [%(levelname)8s] %(message)s %(name)s (%(filename)s:%(lineno)s)

--- a/src/cryptoadvance/specter/bitcoind.py
+++ b/src/cryptoadvance/specter/bitcoind.py
@@ -17,6 +17,7 @@ from .rpc import RpcError
 from .rpc_cache import BitcoinCLICached
 from .helpers import load_jsons
 
+logger = logging.getLogger(__name__)
 
 class Btcd_conn:
     ''' An object to easily store connection data '''
@@ -154,7 +155,7 @@ class BitcoindController:
             if datadir == None:
                 datadir = tempfile.mkdtemp(prefix="bitcoind_datadir")
             btcd_cmd += " -datadir={} ".format(datadir)
-        logging.info(" constructed bitcoind-command: {}".format(btcd_cmd))
+        logger.info(" constructed bitcoind-command: {}".format(btcd_cmd))
         return btcd_cmd
 
 class BitcoindPlainController(BitcoindController):
@@ -167,15 +168,15 @@ class BitcoindPlainController(BitcoindController):
     def _start_bitcoind(self, cleanup_at_exit=False):
         datadir = tempfile.mkdtemp(prefix="bitcoind_plain_datadir")
         bitcoind_cmd = self.construct_bitcoind_cmd(self.rpcconn, run_docker=False, datadir=datadir, bitcoind_path=self.bitcoind_path)
-        logging.debug("About to execute: {}".format(bitcoind_cmd))
+        logger.debug("About to execute: {}".format(bitcoind_cmd))
         # exec will prevent creating a child-process and will make bitcoind_proc.terminate() work as expected
         self.bitcoind_proc = subprocess.Popen("exec " + bitcoind_cmd, shell=True)  
-        logging.debug("Running bitcoind-process with pid {}".format(self.bitcoind_proc.pid))
+        logger.debug("Running bitcoind-process with pid {}".format(self.bitcoind_proc.pid))
         def cleanup_bitcoind():
             self.bitcoind_proc.kill() # much faster then terminate() and speed is key here over being nice
-            logging.debug("Killed bitcoind-process with pid {}".format(self.bitcoind_proc.pid))
+            logger.debug("Killed bitcoind-process with pid {}".format(self.bitcoind_proc.pid))
             shutil.rmtree(datadir)
-            logging.debug("removed temp-dir")
+            logger.debug("removed temp-dir")
         if cleanup_at_exit:
             atexit.register(cleanup_bitcoind)
     
@@ -204,12 +205,12 @@ class BitcoindDockerController(BitcoindController):
     def _start_bitcoind(self, cleanup_at_exit):
         bitcoind_path = self.construct_bitcoind_cmd(self.rpcconn )
         dclient = docker.from_env()
-        logging.debug("Running (in docker): {}".format(bitcoind_path))
+        logger.debug("Running (in docker): {}".format(bitcoind_path))
         ports={
             '{}/tcp'.format(self.rpcconn.rpcport-1): self.rpcconn.rpcport-1, 
             '{}/tcp'.format(self.rpcconn.rpcport): self.rpcconn.rpcport
         }
-        logging.debug("portmapping: {}".format(ports))
+        logger.debug("portmapping: {}".format(ports))
         image = dclient.images.get("registry.gitlab.com/cryptoadvance/specter-desktop/python-bitcoind:{}".format(self.docker_tag))
         self.btcd_container = dclient.containers.run("registry.gitlab.com/cryptoadvance/specter-desktop/python-bitcoind:{}".format(self.docker_tag), bitcoind_path,  ports=ports, detach=True)
         def cleanup_docker_bitcoind():
@@ -217,7 +218,7 @@ class BitcoindDockerController(BitcoindController):
             self.btcd_container.remove()
         if cleanup_at_exit:
             atexit.register(cleanup_docker_bitcoind)
-        logging.debug("Waiting for container {} to come up".format(self.btcd_container.id))
+        logger.debug("Waiting for container {} to come up".format(self.btcd_container.id))
         self.wait_for_container()
         rpcconn, _ = self.detect_bitcoind_container(self.rpcconn.rpcport)
         if rpcconn == None:
@@ -234,7 +235,7 @@ class BitcoindDockerController(BitcoindController):
                 _, container = self.detect_bitcoind_container(self.rpcconn.rpcport)
                 if container == self.btcd_container:
                     self.btcd_container.stop()
-                    logging.info("Stopped btcd_container {}".format(self.btcd_container))
+                    logger.info("Stopped btcd_container {}".format(self.btcd_container))
                     return 
         raise Exception('Ambigious Container running')
 
@@ -264,17 +265,17 @@ class BitcoindDockerController(BitcoindController):
         d_client = docker.from_env()
         potential_btcd_containers = BitcoindDockerController.search_bitcoind_container()
         if len(potential_btcd_containers) == 0:
-            logging.debug("could not detect container. Candidates: {}".format(d_client.containers.list()))
+            logger.debug("could not detect container. Candidates: {}".format(d_client.containers.list()))
             all_candidates = BitcoindDockerController.search_bitcoind_container(all=True)
-            logging.debug("could not detect container. All Candidates: {}".format(all_candidates))
+            logger.debug("could not detect container. All Candidates: {}".format(all_candidates))
             if len(all_candidates) > 0:
-                logging.debug("logs of first candidate")
-                logging.debug(all_candidates[0].logs())
+                logger.debug("100 chars of logs of first candidate")
+                logger.debug(all_candidates[0].logs()[0:100])
             return None
         for btcd_container in potential_btcd_containers:
             rpcport = int([arg for arg in btcd_container.attrs['Config']['Cmd'] if 'rpcport' in arg][0].split('=')[1])
             if rpcport != with_rpcport:
-                logging.debug("checking port {} against searched port {}".format(type(rpcport), type(with_rpcport)))
+                logger.debug("checking port {} against searched port {}".format(type(rpcport), type(with_rpcport)))
                 continue
             rpcpassword = [arg for arg in btcd_container.attrs['Config']['Cmd'] if 'rpcpassword' in arg][0].split('=')[1]
             rpcuser = [arg for arg in btcd_container.attrs['Config']['Cmd'] if 'rpcuser' in arg][0].split('=')[1]
@@ -285,9 +286,9 @@ class BitcoindDockerController(BitcoindController):
                 # This works on most machines but not on gitlab-CI
                 ipaddress ="127.0.0.1"
             rpcconn = Btcd_conn(rpcuser=rpcuser, rpcpassword=rpcpassword, rpcport=rpcport, ipaddress=ipaddress)
-            logging.info("detected container {}".format(btcd_container.id))
+            logger.info("detected container {}".format(btcd_container.id))
             return rpcconn, btcd_container
-        logging.debug("No matching container found")
+        logger.debug("No matching container found")
         return None
 
     

--- a/src/cryptoadvance/specter/helpers.py
+++ b/src/cryptoadvance/specter/helpers.py
@@ -14,6 +14,8 @@ try:
 except:
     collectionsAbc = collections
 
+logger = logging.getLogger(__name__)
+
 def deep_update(d, u):
     for k, v in six.iteritems(u):
         dv = d.get(k, {})
@@ -211,19 +213,19 @@ def which(program):
         # https://pyinstaller.readthedocs.io/en/v3.3.1/runtime-information.html#using-sys-executable-and-sys-argv-0
         exec_location = os.path.join(sys._MEIPASS, program)
         if is_exe(exec_location):
-            logging.info("Found %s executable in %s" % (program, exec_location))
+            logger.info("Found %s executable in %s" % (program, exec_location))
             return exec_location
 
     fpath, program_name = os.path.split(program)
     if fpath:
         if is_exe(program):
-            logging.info("Found %s executable in %s" % (program, program))
+            logger.info("Found %s executable in %s" % (program, program))
             return program
     else:
         for path in os.environ["PATH"].split(os.pathsep):
             exe_file = os.path.join(path, program)
             if is_exe(exe_file):
-                logging.info("Found %s executable in %s" % (program, path))
+                logger.info("Found %s executable in %s" % (program, path))
                 return exe_file
     raise Exception("Couldn't find executable %s" % program)
 
@@ -245,14 +247,14 @@ def run_shell(cmd):
         return { "code": 0xf00dbabe, "out": b"", "err": b"Can't run subprocess" }
 
 def set_loglevel(app,loglevel_string):
-    logging.info("Setting Loglevel to %s" % loglevel_string)
+    logger.info("Setting Loglevel to %s" % loglevel_string)
     loglevels = {
         "WARN": logging.WARN,
         "INFO": logging.INFO,
         "DEBUG" : logging.DEBUG
     }
     app.logger.setLevel(loglevels[loglevel_string])
-    logging.getLogger().setLevel(loglevels[loglevel_string])
+    logger.getLogger().setLevel(loglevels[loglevel_string])
 
 def get_loglevel(app):
     

--- a/src/cryptoadvance/specter/logic.py
+++ b/src/cryptoadvance/specter/logic.py
@@ -17,6 +17,8 @@ from .rpc import RPC_PORTS, autodetect_cli_confs, get_default_datadir, RpcError
 from .rpc_cache import BitcoinCLICached
 from .serializations import PSBT
 
+logger = logging.getLogger(__name__)
+
 # a gap of 20 addresses is what many wallets do
 WALLET_CHUNK = 20
 # we don't need to scan earlier than that 
@@ -136,7 +138,7 @@ class Specter:
                 self._info = self.cli.getblockchaininfo()
                 self._is_running = True
             except Exception as e:
-                logging.error("Exception %s while specter.check()" % e)
+                logger.error("Exception %s while specter.check()" % e)
                 pass
 
         if not self._is_running:
@@ -163,7 +165,7 @@ class Specter:
         try:
             self.wallets.load_all()
         except Exception as e:
-            logging.error("can't load wallets: %s " % e)
+            logger.error("can't load wallets: %s " % e)
 
     def test_rpc(self, **kwargs):
         conf = copy.deepcopy(self.config["rpc"])
@@ -181,7 +183,7 @@ class Specter:
                 cli.listwallets()
                 r['tests']['wallets'] = True
             except RpcError as rpce:
-                logging.error(rpce)
+                logger.error(rpce)
                 if rpce.status_code ==  404:
                     r['tests']['wallets'] = False
                 else:
@@ -190,18 +192,18 @@ class Specter:
             r["err"] = ""
             r["code"] = 0
         except ConnectionError as e:
-            logging.error(e)
+            logger.error(e)
             r['tests']['connectable'] = False
             r["err"] = "Failed to connect!"
             r["code"] = -1
         except RpcError as rpce:
-            logging.error(rpce)
+            logger.error(rpce)
             if rpce.status_code ==  401:
                 r['tests']['credentials'] = False
             else:
                 raise rpce
         except Exception as e:
-            logging.error(e)
+            logger.error(e)
             r["out"] = ""
             if cli.r is not None and "error" in cli.r:
                 r["err"] = cli.r["error"]
@@ -329,7 +331,7 @@ class DeviceManager:
         for dev in self:
             if dev["alias"] == fname:
                 return dev
-        logging.error("Could not find Device %s" % fname)
+        logger.error("Could not find Device %s" % fname)
 
     def remove(self, device):
         os.remove(device["fullpath"])
@@ -420,7 +422,7 @@ class WalletManager:
                 if os.path.join(self.cli_path,wallets[k]["alias"]) in existing_wallets:
                     self._wallets[k] = wallets[k]
                 else:
-                    logging.warn("Couldn't find wallet %s in core's wallets. Silently ignored!" % wallets[k]["alias"])
+                    logger.warn("Couldn't find wallet %s in core's wallets. Silently ignored!" % wallets[k]["alias"])
         else:
             self._wallets = {}
 
@@ -429,14 +431,14 @@ class WalletManager:
         loadable_wallets = [w["name"] for w in self.cli.listwalletdir()["wallets"]]
         not_loaded_wallets = [w for w in loadable_wallets if w not in loaded_wallets]
         if not_loaded_wallets != []:
-            logging.warn("not loaded wallets:%s" % not_loaded_wallets)
+            logger.warn("not loaded wallets:%s" % not_loaded_wallets)
         for k in self._wallets:
             if os.path.join(self.cli_path,self._wallets[k]["alias"]) in not_loaded_wallets:
-                logging.debug("loading %s " % self._wallets[k]["alias"])
+                logger.debug("loading %s " % self._wallets[k]["alias"])
                 self.cli.loadwallet(os.path.join(self.cli_path,self._wallets[k]["alias"]))
                 if "pending_psbts" in self._wallets[k] and len(self._wallets[k]["pending_psbts"]) > 0:
                     for psbt in self._wallets[k]["pending_psbts"]:
-                        logging.debug("lock %s " % self._wallets[k]["alias"], self._wallets[k]["pending_psbts"][psbt]["tx"]["vin"])
+                        logger.debug("lock %s " % self._wallets[k]["alias"], self._wallets[k]["pending_psbts"][psbt]["tx"]["vin"])
                         Wallet(self._wallets[k], self).cli.lockunspent(False, [utxo for utxo in self._wallets[k]["pending_psbts"][psbt]["tx"]["vin"]])
 
     def get_by_alias(self, alias):
@@ -555,7 +557,7 @@ class WalletManager:
         return w
 
     def delete_wallet(self, wallet):
-        logging.info("Deleting {}".format(wallet["alias"]))
+        logger.info("Deleting {}".format(wallet["alias"]))
         self.cli.unloadwallet(os.path.join(self.cli_path,wallet["alias"]))
         # Try deleting wallet file
         if get_default_datadir() and os.path.exists(os.path.join(get_default_datadir(), os.path.join(self.cli_path,wallet["alias"]))):
@@ -565,7 +567,7 @@ class WalletManager:
             os.remove(wallet["fullpath"])
 
     def rename_wallet(self, wallet, name):
-        logging.info("Renaming {}".format(wallet["alias"]))
+        logger.info("Renaming {}".format(wallet["alias"]))
         wallet["name"] = name
         if self.working_folder is not None:
             with open(wallet["fullpath"], "w+") as f:
@@ -1011,7 +1013,7 @@ class Wallet(dict):
         """
         if self.fullbalance < amount:
             return None
-        logging.debug("fee unit: %s" % fee_unit)
+        logger.debug("fee unit: %s" % fee_unit)
         if fee_unit not in ["SAT_B", "BTC_KB"]:
             raise ValueError('Invalid bitcoin unit')
 
@@ -1097,7 +1099,7 @@ class Wallet(dict):
                 inp.unknown[b"\xfc\xca\x01"+self.fingerprint] = b"".join([i.to_bytes(4, "little") for i in inp.hd_keypaths[k][-2:]])
                 inp.hd_keypaths = {}
         psbt["specter"]=qr_psbt.serialize()
-        logging.info("PSBT for Specter: %s" % psbt["specter"])
+        logger.info("PSBT for Specter: %s" % psbt["specter"])
 
         self.cli.lockunspent(False, psbt["tx"]["vin"])
 

--- a/src/cryptoadvance/specter/rpc.py
+++ b/src/cryptoadvance/specter/rpc.py
@@ -1,5 +1,8 @@
+import logging
 import requests, json, os
 import os, sys, errno
+
+logger = logging.getLogger(__name__)
 
 # TODO: redefine __dir__ and help
 

--- a/src/cryptoadvance/specter/rpc_cache.py
+++ b/src/cryptoadvance/specter/rpc_cache.py
@@ -1,5 +1,8 @@
+import logging
 from .rpc import BitcoinCLI, RpcError
 from .corecache import CoreCache
+
+logger = logging.getLogger(__name__)
 
 class BitcoinCLICached:
     def __init__(self, user="", passwd="", host="127.0.0.1", port=8332, protocol="http", path="", timeout=30, cli=None, **kwargs):

--- a/src/cryptoadvance/specter/rpc_cache.py
+++ b/src/cryptoadvance/specter/rpc_cache.py
@@ -41,6 +41,14 @@ class BitcoinCLICached:
     def url(self):
         return self.cli.url
 
+    @property
+    def passwd(self):
+        return self.cli.passwd
+
+    @passwd.setter
+    def passwd(self,value):
+        self.cli.passwd = value
+
     def test_connection(self):
         return self.cli.test_connection()
 

--- a/src/cryptoadvance/specter/rpctest.py
+++ b/src/cryptoadvance/specter/rpctest.py
@@ -1,6 +1,9 @@
+import logging
 import os, sys, errno
 from rpc import *
 import requests
+
+logger = logging.getLogger(__name__)
 
 if __name__ == '__main__':
     conf_arr = detect_cli_confs()

--- a/src/cryptoadvance/specter/server.py
+++ b/src/cryptoadvance/specter/server.py
@@ -68,7 +68,14 @@ def init_app(app, hwibridge=False, specter=None):
     app.register_blueprint(hwi_server, url_prefix='/hwi')
     if not hwibridge:
         with app.app_context():
-            from . import controller
+            from cryptoadvance.specter import controller
+            if app.config.get("TESTING") and len(app.view_functions) <=3 :
+                # Need to force a reload as otherwise the import is skipped
+                # in pytest, the app is created anew for ech test
+                # But we shouldn't do that if not necessary as this would result in
+                # --> View function mapping is overwriting an existing endpoint function
+                import importlib
+                importlib.reload(controller)
     return app
 
 def create_and_init():

--- a/src/cryptoadvance/specter/server.py
+++ b/src/cryptoadvance/specter/server.py
@@ -12,6 +12,8 @@ from .helpers import hwi_get_config
 from .logic import Specter
 from .hwi_server import hwi_server
 
+logger = logging.getLogger(__name__)
+
 env_path = Path('.') / '.flaskenv'
 load_dotenv(env_path)
 
@@ -27,7 +29,7 @@ def create_app(config="cryptoadvance.specter.config.DevelopmentConfig"):
         # https://pyinstaller.readthedocs.io/en/v3.3.1/runtime-information.html#using-sys-executable-and-sys-argv-0
         template_folder = os.path.join(sys._MEIPASS, 'templates')
         static_folder = os.path.join(sys._MEIPASS, 'static')
-        logging.info("pyinstaller based instance running in {}".format(sys._MEIPASS))
+        logger.info("pyinstaller based instance running in {}".format(sys._MEIPASS))
         app = Flask(__name__, template_folder=template_folder, static_folder=static_folder)
     else:
         app = Flask(__name__, template_folder="templates", static_folder="static")

--- a/tests/test_bitcoind.py
+++ b/tests/test_bitcoind.py
@@ -2,8 +2,8 @@ import logging
 from cryptoadvance.specter.helpers import which
 
 def test_bitcoinddocker_running(caplog, docker):
-
-    caplog.set_level(logging.DEBUG)
+    caplog.set_level(logging.INFO)
+    caplog.set_level(logging.DEBUG,logger="cryptoadvance.specter")
     if docker:
         from cryptoadvance.specter.bitcoind import BitcoindDockerController
         my_bitcoind = BitcoindDockerController(rpcport=18999) # completly different port to not interfere

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,9 @@
+import logging
 from cryptoadvance.specter.bitcoind import fetch_wallet_addresses_for_mining
 
-def test_fetch_wallet_addresses_for_mining(wallets_filled_data_folder):
+def test_fetch_wallet_addresses_for_mining(caplog, wallets_filled_data_folder):
+    caplog.set_level(logging.INFO)
+    caplog.set_level(logging.DEBUG,logger="cryptoadvance.specter")
     # Todo: instantiate a specter-testwallet
     addresses = fetch_wallet_addresses_for_mining(wallets_filled_data_folder)
     assert addresses # make more sense out of this test

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,7 +1,10 @@
+import logging
 import pytest
 
-def test_home(client):
+def test_home(caplog, client):
     ''' The root of the app '''
+    caplog.set_level(logging.INFO)
+    caplog.set_level(logging.DEBUG,logger="cryptoadvance.specter")
     result = client.get('/')
     # By default there is no authentication
     assert result.status_code == 200 # OK.

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -20,20 +20,23 @@ def test_home(caplog, client):
     assert b'Select the type of the wallet' in result.data
 
 
-@pytest.mark.skip(reason="no idea why /login returns a 404, help appreciated")
-def test_login_logout(app,client):
+
+def test_login_logout(caplog, app, client):
     ''' whether we can login or logout '''
-    with app.test_client() as client:
-        result = client.get('/login', follow_redirects=True)
-        assert b'blub' in result.data
-        result = login(client, 'secret')
-        assert b'Logged in successfully.' in result.data
-        result = logout(client)
-        assert b'You were logged out' in result.data
-        result = login(client, 'non_valid_password')
-        assert b'Invalid username or password' in result.data
-        result = login(client, 'blub')
-        assert b'Invalid username or password' in result.data
+    caplog.set_level(logging.DEBUG,logger="cryptoadvance.specter")
+    app.config['LOGIN_DISABLED'] = False
+    result = client.get('/login', follow_redirects=False)
+
+    assert result.status_code == 200
+    assert b'Pin' in result.data
+    result = login(client, 'secret')
+    assert b'Logged in successfully.' in result.data
+    result = logout(client)
+    assert b'You were logged out' in result.data
+    result = login(client, 'non_valid_password')
+    assert b'Invalid username or password' in result.data        
+    result = login(client, 'blub')
+    assert b'Invalid username or password' in result.data
 
 
 def login(client, password):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,4 +1,8 @@
-def test_load_jsons():
+import logging
+
+def test_load_jsons(caplog):
+    caplog.set_level(logging.INFO)
+    caplog.set_level(logging.DEBUG,logger="cryptoadvance.specter")
     import cryptoadvance.specter.helpers as helpers
     mydict = helpers.load_jsons("./tests/helpers_testdata")
     assert mydict["some_jsonfile"]["blub"] == "bla"
@@ -17,7 +21,9 @@ def test_load_jsons():
     # Quite handy if you want to get rid of it which is as easy as:
     # os.remove(mydict["ID123"]['fullpath'])
 
-def test_which():
+def test_which(caplog):
+    caplog.set_level(logging.INFO)
+    caplog.set_level(logging.DEBUG,logger="cryptoadvance.specter")
     import cryptoadvance.specter.helpers as helpers
     try:
         helpers.which("some_non_existing_binary")


### PR DESCRIPTION
This is a lot more fun to develop and troubleshoot tests:
* All logging in our files explicitely gets a logger and it's no longer the root-logger 
* This potentially enables differentiating log-levels in our code vs. other people's code
* In some tests i'm setting the log-level on INFO for the root-logger but on debug for our code
* This results in very precise debug-output only for our code when tests are failing

... and this practise probably also encourages the use of logger.debug("Bla") instead of print("bla").