### PR TITLE
proper pinning of bitcoind-version in different branches

### DIFF
--- a/docker/python-bitcoind/Dockerfile
+++ b/docker/python-bitcoind/Dockerfile
@@ -15,7 +15,7 @@ RUN dpkg -i *.deb && rm *.deb
 RUN apt update && apt install git build-essential autoconf libboost-all-dev libssl-dev libprotobuf-dev protobuf-compiler libqt4-dev libqrencode-dev libtool libevent-dev pkg-config bsdmainutils -y 
 
 RUN git clone https://github.com/bitcoin/bitcoin.git
-RUN cd bitcoin && git checkout v0.19.0
+RUN cd bitcoin && git checkout v0.19.1
 RUN cd bitcoin && ./autogen.sh && ./configure && make
 RUN cd bitcoin && make install
 

--- a/docker/python-bitcoind/Readme.md
+++ b/docker/python-bitcoind/Readme.md
@@ -1,4 +1,8 @@
 This Dockerimage is manually created and uploaded:
 
-docker build -t registry.gitlab.com/cryptoadvance/specter-desktop/python-bitcoind .
-docker push registry.gitlab.com/cryptoadvance/specter-desktop/python-bitcoind .
+docker build -t registry.gitlab.com/cryptoadvance/specter-desktop/python-bitcoind:v0.19.1 .
+docker push registry.gitlab.com/cryptoadvance/specter-desktop/python-bitcoind:v0.19.1
+
+Here the version is v0.19.1 but that's just an example. This folder just explains how the image is created. Which image is USED is specified:
+* In the case of tests in pytest.ini in the addopts-line (MIGHT be different in different branches)
+* in the case of running `python3 -m cryptoadvance.specter bitcoind` it's using "latest" but you can override like this: `python3 -m cryptoadvance.specter bitcoind --docker-tag v0.20.0`

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 norecursedirs = tests/bitcoin
 log_format = [%(levelname)8s] %(message)s %(name)s (%(filename)s:%(lineno)s)
+addopts = --bitcoind-version v0.19.1

--- a/src/cryptoadvance/specter/bitcoind.py
+++ b/src/cryptoadvance/specter/bitcoind.py
@@ -72,6 +72,13 @@ class BitcoindController:
         self.mine(block_count=100)
         return self.rpcconn
 
+
+    def version(self):
+        ''' Returns the version of bitcoind, e.g. "v0.19.1" '''
+        version = self.get_cli().getnetworkinfo()['subversion']
+        version = version.replace('/','').replace('Satoshi:','v')
+        return version
+
     def get_cli(self):
         ''' wrapper for convenience '''
         return self.rpcconn.get_cli()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ def pytest_addoption(parser):
         see pytest_generate_tests(metafunc) on how to check that
     '''
     parser.addoption("--docker", action="store_true", help="run bitcoind in docker")
+    parser.addoption('--bitcoind-version', action='store', default='v0.19.1', help='setup environment: development')
 
 def pytest_generate_tests(metafunc):
     #ToDo: use custom compiled version of bitcoind
@@ -31,17 +32,20 @@ def pytest_generate_tests(metafunc):
             metafunc.parametrize("docker", [False], scope="module")
 
 @pytest.fixture(scope="module")
-def bitcoin_regtest(docker):
+def bitcoin_regtest(docker, request):
     #logging.getLogger().setLevel(logging.DEBUG)
+    requested_version = request.config.getoption("--bitcoind-version")
     if docker:
-        bitcoind_controller = BitcoindDockerController(rpcport=18543)
+        bitcoind_controller = BitcoindDockerController(rpcport=18543, docker_tag=requested_version)
     else:
         if os.path.isfile('tests/bitcoin/src/bitcoind'):
             bitcoind_controller = BitcoindPlainController(bitcoind_path='tests/bitcoin/src/bitcoind') # always prefer the self-compiled bitcoind if existing
         else:
             bitcoind_controller = BitcoindPlainController() # Alternatively take the one on the path for now
-
     bitcoind_controller.start_bitcoind(cleanup_at_exit=True)
+    running_version = bitcoind_controller.version()
+    requested_version = request.config.getoption("--bitcoind-version")
+    assert(running_version != requested_version, "Please make sure that the Bitcoind-version (%s) matches with the version in pytest.ini (%s)"%(running_version,requested_version))
     return bitcoind_controller
 
 

--- a/tests/install_bitcoind.sh
+++ b/tests/install_bitcoind.sh
@@ -35,7 +35,6 @@ else
         echo "    --> Pinned: $PINNED! Checkout not needed!"
     else
         echo "    --> Pinned: $PINNED! Checkout needed!"
-        git pull
         git checkout $PINNED
         bitcoind_setup_needed=true
     fi

--- a/tests/install_bitcoind.sh
+++ b/tests/install_bitcoind.sh
@@ -18,8 +18,8 @@ fi
 # Determine if we need to pull. From https://stackoverflow.com/a/3278427
 UPSTREAM=${1:-'@{u}'}
 LOCAL=$(git rev-parse @)
-if [ -f ../bitcoin_pin ]; then
-    PINNED=$(cat ../bitcoin_pin)
+if cat ../../pytest.ini | grep "addopts = --bitcoind-version" ; then
+    PINNED=$(cat ../../pytest.ini | grep "addopts = --bitcoind-version" | cut -d' ' -f4)
 fi
 if [ -z $PINNED ]; then
     REMOTE=$(git rev-parse "$UPSTREAM")

--- a/tests/test_bitcoind.py
+++ b/tests/test_bitcoind.py
@@ -1,23 +1,28 @@
 import logging
 from cryptoadvance.specter.helpers import which
 
-def test_bitcoinddocker_running(caplog, docker):
+def test_bitcoinddocker_running(caplog, docker, request):
     caplog.set_level(logging.INFO)
     caplog.set_level(logging.DEBUG,logger="cryptoadvance.specter")
+    requested_version = request.config.getoption("--bitcoind-version")
     if docker:
         from cryptoadvance.specter.bitcoind import BitcoindDockerController
-        my_bitcoind = BitcoindDockerController(rpcport=18999) # completly different port to not interfere
+        my_bitcoind = BitcoindDockerController(rpcport=18999, docker_tag=requested_version) # completly different port to not interfere
     else:
         try:
             which("bitcoind")
         except:
             # Skip this test as bitcoind is not available
+            # Doesn't make sense to print anything as this won't be shown
+            # for passing tests
             return
         from cryptoadvance.specter.bitcoind import BitcoindPlainController
         # This doesn't work if you don't have a bitcoind on the path
         my_bitcoind = BitcoindPlainController() # completly different port to not interfere    
     #assert my_bitcoind.detect_bitcoind_container() == True
     rpcconn = my_bitcoind.start_bitcoind(cleanup_at_exit=True)
+    requested_version = request.config.getoption("--bitcoind-version")
+    assert my_bitcoind.version() == requested_version
     assert rpcconn.get_cli() != None
     assert rpcconn.get_cli().ipaddress != None
     rpcconn.get_cli().getblockchaininfo()


### PR DESCRIPTION
We might want to support different bitcoind-versions on different branches in the future. This change prepares this.
The used version of bitcoin is from now on no longer "latest" (or master) but specified in pytest.ini.
This version will be expected to be existing as a docker-container or as a tag on github.com/bitcoin/bitcoin
