### PR TITLE
Fix debug problem and duplicates of the flashed messages

### DIFF
--- a/src/cryptoadvance/specter/helpers.py
+++ b/src/cryptoadvance/specter/helpers.py
@@ -254,7 +254,7 @@ def set_loglevel(app,loglevel_string):
         "DEBUG" : logging.DEBUG
     }
     app.logger.setLevel(loglevels[loglevel_string])
-    logger.getLogger().setLevel(loglevels[loglevel_string])
+    logger.setLevel(loglevels[loglevel_string])
 
 def get_loglevel(app):
     

--- a/src/cryptoadvance/specter/templates/base.jinja
+++ b/src/cryptoadvance/specter/templates/base.jinja
@@ -25,7 +25,7 @@
 			{% endif %}
 			<img id="menubtn" src="/static/img/menu.svg"/>
 
-			{% with messages = get_flashed_messages() %}
+			{% with messages = get_flashed_messages() | unique %}
 				{% if messages %}
 					<div class="notification error">
 						<ul>

--- a/src/cryptoadvance/specter/templates/base.jinja
+++ b/src/cryptoadvance/specter/templates/base.jinja
@@ -25,11 +25,11 @@
 			{% endif %}
 			<img id="menubtn" src="/static/img/menu.svg"/>
 
-			{% with messages = get_flashed_messages() | unique %}
+			{% with messages = get_flashed_messages() %}
 				{% if messages %}
 					<div class="notification error">
 						<ul>
-						{% for message in messages %}
+						{% for message in messages | unique %}
 							<li>{{ message }}</li>
 						{% endfor %}
 						</ul>


### PR DESCRIPTION
It might make sense to squash the commits.

Bug 1. When saving anything in settings server was returning internal error
Bug 2. When saving anything in settings it was flashing version update error, and then redirecting to index that was also flashing version update message. Adding `|unique` to messages makes sure that messages will not be duplicated 