### PR TITLE
Rename Pending -> Unsigned PSBTs

### DIFF
--- a/src/cryptoadvance/specter/templates/wallet/send/components/send_nav.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/send/components/send_nav.jinja
@@ -10,6 +10,6 @@
 	<br>
     <nav class="row">
 		{{ wallet_menu_item('wallet_send', 'New', wallet_alias, active_menuitem, isLeft=true) }}
-		{{ wallet_menu_item('wallet_sendpending', 'Pending', wallet_alias, active_menuitem, isRight=true) }}
+		{{ wallet_menu_item('wallet_sendpending', 'Unsigned', wallet_alias, active_menuitem, isRight=true) }}
 	</nav>
 {%- endmacro %}

--- a/src/cryptoadvance/specter/templates/wallet/send/pending/wallet_sendpending.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/send/pending/wallet_sendpending.jinja
@@ -3,9 +3,10 @@
 {% block content %}
 	{% from 'wallet/send/components/send_nav.jinja' import send_nav %}
 	{{ send_nav('wallet_sendpending', wallet_alias) }}
-		<h1 class="padded">Pending Transactions:</h1>
+		<h1 class="padded">Transactions Awaiting Siging:</h1>
 		<div class="table-holder">
 			{% from 'wallet/send/pending/components/pending_psbt_table.jinja' import pending_psbt_table %}
 			{{ pending_psbt_table(pending_psbts, wallet_alias, wallet, specter) }}
-		</div>
+		</div><br>
+		<span class="center note padded">Here you can manage PSBTs (Partially Signed Bitcoin Transactions) you have created but did not finish signing or broadcasted to the network.</span>
 {% endblock %}


### PR DESCRIPTION
Fix #168 

Rephrases "Pending" to "Unsigned" in the Pending PSBTs screen + a small note to explain what the screen is.