### PR TITLE
Add copy button for QR code component

### DIFF
--- a/src/cryptoadvance/specter/static/img/content_copy-24px.svg
+++ b/src/cryptoadvance/specter/static/img/content_copy-24px.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>

--- a/src/cryptoadvance/specter/templates/includes/qr-code.html
+++ b/src/cryptoadvance/specter/templates/includes/qr-code.html
@@ -22,10 +22,35 @@
     .note{
       font-size: 0.7em;
     }
+    .copy{
+      display: none;
+      height: 26px;
+      width: 26px;
+      color: #000;
+      margin: 0;
+      margin-bottom: -26px;
+      margin-left: auto;
+      z-index: 3;
+      cursor: pointer;
+      border-radius: 3px;
+      box-sizing: border-box;
+      background: rgba(255,255,255,0.7);
+      padding: 3px;
+    }
+    .qr-holder:hover .copy{
+      display: block;
+    }
+    .copy:hover{
+      background: rgba(255,255,255,1);
+    }
+    .copy img{
+      width: 10px;
+    }
   </style>
   <div class="qr-holder">
-  <div class="qr-code"></div>
-  <div class="note">Click to animate</div>
+    <a class="copy"><img src="/static/img/content_copy-24px.svg"></a>
+    <div class="qr-code"></div>
+    <div class="note">Click to animate</div>
   </div>
 </template>
 
@@ -50,6 +75,8 @@ class QRCodeElement extends HTMLElement {
     this.isQRtoolarge = false;
     this.idx = 0;
 
+    this.copybtn = clone.querySelector(".copy");
+
     // Attach the created element to the shadow dom
     shadow.appendChild(clone);
 
@@ -62,6 +89,11 @@ class QRCodeElement extends HTMLElement {
           this.note.innerHTML = "Click to animate";
         }
       }
+    });
+    this.copybtn.addEventListener('click', e=>{
+      e.cancelBubble = true;
+      var value = this.getAttribute('value');
+      copyText(value, "QR code content is copied!");
     });
     window.setInterval(()=>{
       if((this.qrcode==null) || this.chunks.length<=1){


### PR DESCRIPTION
Adds a small button in the QR code component to copy it's content.
Mostly for debugging Specter-DIY, but might be useful in some other cases as well - to share psbt transaction over email or chat for example.