### PR TITLE
fix: don't update explorer if chain is unknown

### DIFF
--- a/src/cryptoadvance/specter/specter.py
+++ b/src/cryptoadvance/specter/specter.py
@@ -189,6 +189,9 @@ class Specter:
     
     def update_explorer(self, explorer):
         ''' update the block explorers urls '''
+        # we don't know what chain to change
+        if not self.chain:
+            return
         if explorer and not explorer.endswith("/"):
             # make sure the urls end with a "/"
             explorer += "/"


### PR DESCRIPTION
If Core is not running or the user sets a wrong port he will get an error due to key error due to explorer update function.
This PR fixes it.