### PR TITLE
get back display address for singlesig ledger

### DIFF
--- a/src/cryptoadvance/specter/templates/wallet/receive/wallet_receive.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/receive/wallet_receive.jinja
@@ -41,7 +41,7 @@
 		{% for device in wallet.devices if device.supports_hwi_multisig_display_address %}
 			{% set supports_hwi_multisig_display_address = supports_hwi_multisig_display_address.append(device) %}
 		{% endfor %}
-		{% if supports_hwi_multisig_display_address != [] %}
+		{% if supports_hwi_multisig_display_address != [] or not wallet.is_multisig %}
 			<button type="button" onclick="displayAddressOnDevice()" class="btn centered">Display Address on Device</button><br>
 			<p class="note center">Multsig address on-device display is only available for ColdCard, KeepKey, and Trezor devices.</p>
 		{% endif %}


### PR DESCRIPTION
Ledger doesn't support display of multisig addresses, but works for single sig.
This PR returns the "Display address" button for Ledger in case of single-sig wallets.