### PR TITLE
fix coinselection error

### DIFF
--- a/src/cryptoadvance/specter/templates/wallet/send/new/wallet_send.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/send/new/wallet_send.jinja
@@ -4,12 +4,12 @@
 	{% from 'wallet/send/components/send_nav.jinja' import send_nav %}
 	{{ send_nav('wallet_send', wallet_alias) }}
 
-	<div class="notification error" id="amount_errors_container" style="display: none;">
+	<message-box type="error" id="amount_errors_container" style="position: absolute; top: 0; display: none;">
 		<ul>
 			<li id="above_selected_coins_error" style="display: none;"> You need to select more coins to match your amount!</li>
 			<li id="above_wallet_balance_error" style="display: none;"> You cannot send more than {{ wallet.full_available_balance | btcamount }} BTC!</li>
 		</ul>
-	</div>
+	</message-box>
 
 	<form action="{{ url_for('wallet_send',wallet_alias=wallet_alias) }}" method="POST">
 		<h1 class="padded">Sending to:</h1>


### PR DESCRIPTION
As we migrated to message-box elements for errors and notifications, the error about selected coins didn't appear anymore.
This PR gets back the coinselection warning.