### PR TITLE
ignore version info if we can't get it

### DIFF
--- a/src/cryptoadvance/specter/helpers.py
+++ b/src/cryptoadvance/specter/helpers.py
@@ -168,16 +168,22 @@ def get_version_info():
         the latest version and whether you should upgrade 
     '''
     name="cryptoadvance.specter"
-    latest_version = str(subprocess.run([sys.executable, '-m', 'pip', 'install', '{}==random'.format(name)], capture_output=True, text=True))
-    latest_version = latest_version[latest_version.find('(from versions:')+15:]
-    latest_version = latest_version[:latest_version.find(')')]
-    latest_version = latest_version.replace(' ','').split(',')[-1]
+    try:
+        raise RuntimeError("asd")
+        latest_version = str(subprocess.run([sys.executable, '-m', 'pip', 'install', '{}==random'.format(name)], capture_output=True, text=True))
+        latest_version = latest_version[latest_version.find('(from versions:')+15:]
+        latest_version = latest_version[:latest_version.find(')')]
+        latest_version = latest_version.replace(' ','').split(',')[-1]
 
-    current_version = str(subprocess.run([sys.executable, '-m', 'pip', 'show', '{}'.format(name)], capture_output=True, text=True))
-    current_version = current_version[current_version.find('Version:')+8:]
-    current_version = current_version[:current_version.find('\\n')].replace(' ','') 
+        current_version = str(subprocess.run([sys.executable, '-m', 'pip', 'show', '{}'.format(name)], capture_output=True, text=True))
+        current_version = current_version[current_version.find('Version:')+8:]
+        current_version = current_version[:current_version.find('\\n')].replace(' ','') 
 
-    return current_version, latest_version, latest_version != current_version
+        return current_version, latest_version, latest_version != current_version
+    except:
+        # if pip is not installed or we are using python3.6 or below
+        # we just don't show the version
+        return "Unknown version", "Unknown version", False
 
 def get_users_json(specter):
     users = [

--- a/src/cryptoadvance/specter/helpers.py
+++ b/src/cryptoadvance/specter/helpers.py
@@ -169,7 +169,6 @@ def get_version_info():
     '''
     name="cryptoadvance.specter"
     try:
-        raise RuntimeError("asd")
         latest_version = str(subprocess.run([sys.executable, '-m', 'pip', 'install', '{}==random'.format(name)], capture_output=True, text=True))
         latest_version = latest_version[latest_version.find('(from versions:')+15:]
         latest_version = latest_version[:latest_version.find(')')]


### PR DESCRIPTION
Close https://github.com/cryptoadvance/specter-desktop/issues/198

There might be different reasons why get version info could fail:
- Python3.6 doesn't support `capture_output` flag. Could be solved with `subprocess.check_output()` though
- Pip might be not installed - because specter was installed with `setup.py` or runs from a binary (in the future)

It shouldn't break the rest of the functionality, so this PR returns "Unknown version" if a normal call failed.