### PR TITLE
Improve terminology for unsigned PSBT utxo

### DIFF
--- a/src/cryptoadvance/specter/templates/wallet/send/new/wallet_send.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/send/new/wallet_send.jinja
@@ -28,11 +28,20 @@
 			<input type="hidden" name="btc_amount" id="btc_amount">
 			<label><input type="radio" class="inline" style="margin: 0 5px;" name="amount_unit" value="sat" onchange="toggleUnit(this)" checked>sat</label>
 			<label><input type="radio" class="inline" style="margin: 0 5px;" name="amount_unit" value="btc" onchange="toggleUnit(this)">BTC</label>
-			<div class="note">
-				<span id="converted_unit_amount">-</span> <span id="converted_unit_label">BTC</span>, 
-				Available: {{wallet.full_available_balance | btcamount}};
+			<div>
+				<span class="note" id="converted_unit_amount">-</span> <span class="note" id="converted_unit_label">BTC</span>, 
+				<span class="note">Available: {{wallet.full_available_balance | btcamount}};</span>
 				{% if wallet.locked_amount > 0 %}
-					&nbsp;Locked in pending transactions: {{wallet.locked_amount | btcamount}}
+					<span class="note" >&nbsp;Waiting in usigned transactions: {{wallet.locked_amount | btcamount}}</span>
+					<div class="tool-tip" style="text-align: center;">
+						<i class="tool-tip__icon">i</i>
+						<p class="tool-tip__info">
+							<span class="info">
+								<span class="info__title">Funds waiting in usigned transactions<br><br></span>
+								To make funds available to spend in new transactions, just click on the "Unsigned" tab and delete unsigned transaction you have no need for.
+							</span>
+						</p>
+					</div>
 				{% endif %}
 			</div><br>
 			{% include "wallet/send/new/components/fee_selection.jinja" %}

--- a/src/cryptoadvance/specter/templates/wallet/send/pending/wallet_sendpending.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/send/pending/wallet_sendpending.jinja
@@ -3,7 +3,7 @@
 {% block content %}
 	{% from 'wallet/send/components/send_nav.jinja' import send_nav %}
 	{{ send_nav('wallet_sendpending', wallet_alias) }}
-		<h1 class="padded">Transactions Awaiting Siging:</h1>
+		<h1 class="padded">Transactions Awaiting Signing:</h1>
 		<div class="table-holder">
 			{% from 'wallet/send/pending/components/pending_psbt_table.jinja' import pending_psbt_table %}
 			{{ pending_psbt_table(pending_psbts, wallet_alias, wallet, specter) }}


### PR DESCRIPTION
Improves the terminology used in the "Send" tab to describe balances of UTXOs locked by unsigned PSBTs. Adds a tooltip explaining how to make the funds available again. Fix a typo: "Siging" -> "Signing".