### PR TITLE
fix non-standard keys

### DIFF
--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -15,7 +15,7 @@ from flask_login.config import EXEMPT_METHODS
 
 from .helpers import (alias, get_devices_with_keys_by_type, hash_password, 
                       get_loglevel, get_version_info, run_shell, set_loglevel, 
-                      verify_password, bcur2base64)
+                      verify_password, bcur2base64, get_txid)
 from .specter import Specter
 from .specter_error import SpecterError
 from .wallet_manager import purposes
@@ -93,7 +93,7 @@ def broadcast(wallet_alias):
         res = wallet.cli.testmempoolaccept([tx])[0]
         if res['allowed']:
             app.specter.broadcast(tx)
-            wallet.delete_pending_psbt(wallet.cli.decoderawtransaction(tx)['txid'])
+            wallet.delete_pending_psbt(get_txid(tx))
             return jsonify(success=True)
         else:
             return jsonify(success=False, error="Failed to broadcast transaction: transaction is invalid\n%s" % res["reject-reason"])

--- a/src/cryptoadvance/specter/helpers.py
+++ b/src/cryptoadvance/specter/helpers.py
@@ -1,9 +1,10 @@
 import binascii, collections, copy, hashlib, json, logging, os, six, subprocess, sys
 from collections import OrderedDict
 from .descriptor import AddChecksum
-from hwilib.serializations import PSBT
+from hwilib.serializations import PSBT, CTransaction
 from .bcur import bcur_decode
 import threading
+from io import BytesIO
 
 # use this for all fs operations
 fslock = threading.Lock()
@@ -350,3 +351,12 @@ def clean_psbt(b64psbt):
 def bcur2base64(encoded):
     raw = bcur_decode(encoded.split("/")[-1])
     return binascii.b2a_base64(raw).strip()
+
+def get_txid(tx):
+    b = BytesIO(bytes.fromhex(tx))
+    t = CTransaction()
+    t.deserialize(b)
+    for inp in t.vin:
+        inp.scriptSig = b""
+    t.rehash()
+    return t.hash

--- a/src/cryptoadvance/specter/templates/device/device.jinja
+++ b/src/cryptoadvance/specter/templates/device/device.jinja
@@ -26,7 +26,7 @@
 								{{ bitcoin_svg('test', 16) }} Test
 							{% endif %}
 						</td>
-						<td>{{ purposes[key.key_type] }}</td>
+						<td>{{ key.purpose }}</td>
 						<td>{{ key.derivation }}</td>
 						<td width="10" class="qr-trigger">
 							<img src="/static/img/qr_tiny.svg"/>

--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -213,8 +213,9 @@ class Wallet():
         except:
             # UTXO was spent
             pass
-        del self.pending_psbts[txid]
-        self.save_to_file()
+        if txid in self.pending_psbts:
+            del self.pending_psbts[txid]
+            self.save_to_file()
 
     def update_pending_psbt(self, psbt, txid, raw):
         if txid in self.pending_psbts:

--- a/tests/test_device_manager.py
+++ b/tests/test_device_manager.py
@@ -22,7 +22,7 @@ def test_DeviceManager(empty_data_folder):
     # the DeviceManager doesn't care so much about the content of a key
     # so this is a minimal valid "key":
     another_key = Key.from_json({
-        'original': 'blub'
+        'original': 'tpubDDZ5jjGT5RvrAyjoLZfdCfv1PAPmicnhNctwZGKiCMF1Zy5hCGMqppxwYZzWgvPqk7LucMMHo7rkB6Dyj5ZLd2W62FAEP3U6pV4jD5gb9ma'
     })
     dm.add_device("some_name","the_type",[a_key, another_key])
     # A json file was generated for the new device:
@@ -70,7 +70,7 @@ def test_DeviceManager(empty_data_folder):
     # Adding keys can be done by passing an array of keys object to the `add_keys` method of a device
     # A key dict must contain an `original` property
     third_key = Key.from_json({
-        'original': 'third_key'
+        'original': 'tpubDEmTg3b5aPNFnkHXx481F3h9dPSVJiyvqV24dBMXWncoRRu6VJzPDeEtQ4H7EnRtLbn2aPkxhTn8odWXsXkSRDdmAvCCrPmfjfPSVswfDhg'
     })
     some_device.add_keys([third_key])
     assert len(some_device.keys) == 3


### PR DESCRIPTION
Fixes issues if:
- fingerprint is not provided
- derivation is not provided
- key type is unknown
- migration from `fingerprint: null` and `key_type: null` in pre-v0.5 json files
- disaplay of generic keys in the table (was empty)

Also fixes a bug when deletepsbt is called on not-saved txid