### PR TITLE
Wallet export to other software

### DIFF
--- a/src/cryptoadvance/specter/static/styles.css
+++ b/src/cryptoadvance/specter/static/styles.css
@@ -769,19 +769,21 @@ table tr:hover .btn.hovering{
 /************** Overlay Popup ********************************/
 .page_overlay {
     display: none;
-    position: absolute;
+    position: fixed;
     top: 0;
     left: 0;
+    bottom: 0;
+    right: 0;
     width: 100%;
     height: 100%;
-    justify-content: center;
-    align-items: center;
+    overflow: auto;
     background-color: rgba(0,0,0, 0.75);
     z-index: 2;
+    padding: 20px;
 }
 .page_overlay_popup {
+    margin: auto;
     display: none;
-    /*margin: 0 auto;*/
     max-width: 500px;
     text-align: center;
     border-radius: 0.5em;

--- a/src/cryptoadvance/specter/templates/wallet/settings/components/export_wallet_account_map.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/settings/components/export_wallet_account_map.jinja
@@ -2,10 +2,10 @@
     <h1>Export Wallet</h1>
     <h2>Scan this with your wallet software</h2>
     <br>
-    <qr-code value="{{ wallet.account_map }}" width="400"></qr-code>
+    <qr-code value='{{ wallet.account_map }}' width="400"></qr-code>
     <br>
     <h2>Import this JSON file</h2>
-    <a download="{{ wallet.name }}.json" href="data:text/json;charset=utf-8,{{ wallet.account_map }}" class="btn centered padded">Download wallet file</a>
+    <a download="{{ wallet.name }}.json" href='data:text/json;charset=utf-8,{{ wallet.account_map }}' class="btn centered padded">Download wallet file</a>
 <pre id="account_map" style="white-space: -moz-pre-wrap; white-space: -o-pre-wrap; word-wrap: break-word; text-align: left;">
 {{ wallet.account_map }}
 </pre>

--- a/src/cryptoadvance/specter/templates/wallet/settings/components/export_wallet_account_map.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/settings/components/export_wallet_account_map.jinja
@@ -1,0 +1,13 @@
+<div id="account_map_export" style="display: none;">
+    <h1>Export Wallet</h1>
+    <h2>Scan this with your wallet software</h2>
+    <br>
+    <qr-code value="{{ wallet.account_map }}" width="400"></qr-code>
+    <br>
+    <h2>Import this JSON file</h2>
+    <a download="{{ wallet.name }}.json" href="data:text/json;charset=utf-8,{{ wallet.account_map }}" class="btn centered padded">Download wallet file</a>
+<pre id="account_map" style="white-space: -moz-pre-wrap; white-space: -o-pre-wrap; word-wrap: break-word; text-align: left;">
+{{ wallet.account_map }}
+</pre>
+    <button onclick="copyText(document.getElementById('account_map').innerText, 'Copied wallet data')" type="button" class="btn centered padded">Copy wallet data</button>
+</div>

--- a/src/cryptoadvance/specter/templates/wallet/settings/wallet_settings.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/settings/wallet_settings.jinja
@@ -50,33 +50,44 @@
 		{% endfor %}
 	</div>
 	<br>
-	<h1>Cache</h1>
+	{% set supports_export_to_device = [] %}
+	{% for device in wallet.devices if device.exportable_to_wallet %}
+		{% set supports_export_to_device = supports_export_to_device.append(device) %}
+	{% endfor %}
+	{% if supports_export_to_device != [] %}
+		<h1>Export To Device</h1>
+		<div class="note center">
+			Import this wallet to a device by scanning its QR code or importing its data file.
+		</div>
+
+		{% for device in wallet.devices %}
+			{% if device.exportable_to_wallet %}
+				{% if device.wallet_export_type == 'file' %}
+					<a download="{{ wallet.name }}" href="data:text/plain;charset=US-ASCII,{{ device.export_wallet(wallet) }}" class="btn centered padded">Download {{ device.name }} file</a>
+				{% elif device.wallet_export_type == 'qr' %}
+					<button onclick="showPageOverlay('{{ device.alias }}_export_qr_code')" type="button" class="btn centered padded">Show {{ device.name }} QR Code</button>
+					<div id="{{ device.alias }}_export_qr_code" style="display: none;">
+						<h1>Scan this with your {{ device.name }} device </h1>
+						<qr-code value="{{ device.export_wallet(wallet) }}" width="400"></qr-code>
+					</div>
+				{% endif %}
+			{% endif %}
+		{% endfor %}
+		<br>
+	{% endif %}
+	
+	<h1>Export To Wallet Software</h1>
+	<div class="note center">
+		Import this wallet to another Specter instance or other supported wallet softwares by scanning the QR code or importing the JSON file.
+	</div>
+	<button onclick="showPageOverlay('account_map_export')" type="button" class="btn centered padded">Export</button>
+	{% include "wallet/settings/components/export_wallet_account_map.jinja" %}
 	<form action="." method="POST" class="padded" style="width: 500px">
+		<h1>Cache</h1>
 		<div class="row center">
 			<button type="submit" name="action" value="rebuildcache" class="btn" style="max-width: 160px;">Rebuild Cache</button>
 		</div>
 	</form>
-	<br>
-
-	<h1>Export To Device</h1>
-	<div class="note center">
-		Import this wallet to a device by scanning its QR code or importing its data file.
-	</div>
-
-	{% for device in wallet.devices %}
-		{% if device.exportable_to_wallet %}
-			{% if device.wallet_export_type == 'file' %}
-				<a download="{{ wallet.name }}" href="data:text/plain;charset=US-ASCII,{{ device.export_wallet(wallet) }}" class="btn centered padded">Download {{ device.name }} file</a>
-			{% elif device.wallet_export_type == 'qr' %}
-				<button onclick="showPageOverlay('{{ device.alias }}_export_qr_code')" type="button" class="btn centered padded">Show {{ device.name }} QR Code</button>
-				<div id="{{ device.alias }}_export_qr_code" style="display: none;">
-					<h1>Scan this with your {{ device.name }} device </h1>
-					<qr-code value="{{ device.export_wallet(wallet) }}" width="400"></qr-code>
-				</div>
-			{% endif %}
-		{% endif %}
-	{% endfor %}
-
 	<form action="." method="POST" class="padded" style="width: 500px">
 		<h1>Delete Wallet</h1>
 		<button type="submit" name="action" value="deletewallet" class="btn danger centered" style="max-width: 160px;">Delete Wallet</button>

--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -269,7 +269,7 @@ class Wallet():
 
     @property
     def account_map(self):
-        return { 'label': self.name, 'blockheight': self.blockheight, 'descriptor': self.recv_descriptor }
+        return "{ 'label': '" + self.name + "', 'blockheight': " + str(self.blockheight) + ", 'descriptor': '" + self.recv_descriptor.replace("/", "\\/") + "' }"
 
     def getnewaddress(self, change=False):
         label = "Change" if change else "Address"

--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -269,7 +269,7 @@ class Wallet():
 
     @property
     def account_map(self):
-        return "{ 'label': '" + self.name + "', 'blockheight': " + str(self.blockheight) + ", 'descriptor': '" + self.recv_descriptor.replace("/", "\\/") + "' }"
+        return '{ "label": "' + self.name + '", "blockheight": ' + str(self.blockheight) + ', "descriptor": "' + self.recv_descriptor.replace("/", "\\/") + '" }'
 
     def getnewaddress(self, change=False):
         label = "Change" if change else "Address"

--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -261,6 +261,16 @@ class Wallet():
         else:
             return self.info["scanning"]["progress"]
 
+    @property
+    def blockheight(self):
+        if len(self.transactions) > 0 and 'block_height' in self.transactions[0]:
+            return self.transactions[0]['block_height'] - 1
+        return self.cli.getblockcount()
+
+    @property
+    def account_map(self):
+        return { 'label': self.name, 'blockheight': self.blockheight, 'descriptor': self.recv_descriptor }
+
     def getnewaddress(self, change=False):
         label = "Change" if change else "Address"
         if change:


### PR DESCRIPTION
Starts work on #212.
Adds an export wallet button to the wallet settings page. Clicking the button will prompt the popup as in the picture below.
The format is as described here: https://github.com/cryptoadvance/specter-desktop/issues/212#issuecomment-657319858
The blockheight property for the wallet is retrieved from the block before the first transaction, or if no transactions exist, the latest block number. The wallet data is available either as a QR code, JSON file, and simple text to copy.
<img width="573" alt="Screen Shot 2020-07-13 at 23 40 58" src="https://user-images.githubusercontent.com/10667901/87351596-50209180-c562-11ea-93a7-6a2febb8af55.png">

Cc @Fonta1n3