### PR TITLE
Add Electrum wallet device

### DIFF
--- a/src/cryptoadvance/specter/device.py
+++ b/src/cryptoadvance/specter/device.py
@@ -4,15 +4,29 @@ from .helpers import fslock
 
 class Device:
     def __init__(self, name, alias, device_type, keys, fullpath, manager):
+        """
+        From child classes call super().__init__ and also set
+        support for communication methods
+        """
         self.name = name
         self.alias = alias
         self.device_type = device_type
         self.keys = keys
         self.fullpath = fullpath
         self.manager = manager
+        # override these vars to add support 
+        # of different communication methods
+        self.sd_card_support = False
+        self.qr_code_support = False
+        self.hwi_support = False
+        self.supports_hwi_multisig_display_address = False
 
     def create_psbts(self, base64_psbt, wallet):
-        """Overwrite this method for a device"""
+        """
+        Overwrite this method for a device.
+        Possible keys:
+        hwi, qrcode, sdcard
+        """
         return {}
 
     @classmethod

--- a/src/cryptoadvance/specter/device_manager.py
+++ b/src/cryptoadvance/specter/device_manager.py
@@ -7,6 +7,7 @@ from .devices.keepkey import Keepkey
 from .devices.specter import Specter
 from .devices.cobo import Cobo
 from .devices.generic import GenericDevice
+from .devices.electrum import Electrum
 from .devices.bitcoin_core import BitcoinCore
 from .helpers import alias, load_jsons, fslock
 
@@ -21,6 +22,7 @@ device_classes = {
     'specter': Specter,
     'cobo': Cobo,
     'bitcoincore': BitcoinCore,
+    'electrum': Electrum,
     'other': GenericDevice,
 }
 

--- a/src/cryptoadvance/specter/devices/electrum.py
+++ b/src/cryptoadvance/specter/devices/electrum.py
@@ -1,0 +1,72 @@
+from binascii import hexlify, unhexlify, b2a_base64, a2b_base64
+from typing import List
+from .generic import GenericDevice
+
+class Electrum(GenericDevice):
+    def __init__(self, name, alias, device_type, keys, fullpath, manager):
+        super().__init__(name, alias, 'electrum', keys, fullpath, manager)
+        self.sd_card_support = True
+        self.qr_code_support = True
+
+    def create_psbts(self, base64_psbt, wallet):
+        psbts = {
+            'qrcode': b43_encode(a2b_base64(base64_psbt)),
+            'sdcard': base64_psbt,
+        }
+        return psbts
+
+########### base43 encodings ###############
+
+BASE43_CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ$*+-./:"
+
+def b43_encode(b: bytes) -> str:
+    """Encode bytes to a base58-encoded string"""
+
+    # Convert big-endian bytes to integer
+    n: int = int('0x0' + hexlify(b).decode('utf8'), 16)
+
+    # Divide that integer into base58
+    temp: List[str] = []
+    while n > 0:
+        n, r = divmod(n, 43)
+        temp.append(BASE43_CHARS[r])
+    res: str = ''.join(temp[::-1])
+
+    # Encode leading zeros as base58 zeros
+    czero: int = 0
+    pad: int = 0
+    for c in b:
+        if c == czero:
+            pad += 1
+        else:
+            break
+    return BASE43_CHARS[0] * pad + res
+
+def b43_decode(s: str) -> bytes:
+    """Decode a base58-encoding string, returning bytes"""
+    if not s:
+        return b''
+
+    # Convert the string to an integer
+    n: int = 0
+    for c in s:
+        n *= 43
+        if c not in BASE43_CHARS:
+            raise ValueError('Character %r is not a valid base43 character' % c)
+        digit = BASE43_CHARS.index(c)
+        n += digit
+
+    # Convert the integer to bytes
+    h: str = '%x' % n
+    if len(h) % 2:
+        h = '0' + h
+    res = unhexlify(h.encode('utf8'))
+
+    # Add padding back.
+    pad = 0
+    for c in s[:-1]:
+        if c == BASE43_CHARS[0]:
+            pad += 1
+        else:
+            break
+    return b'\x00' * pad + res

--- a/src/cryptoadvance/specter/devices/generic.py
+++ b/src/cryptoadvance/specter/devices/generic.py
@@ -1,4 +1,3 @@
-import hashlib
 from ..device import Device
 
 class GenericDevice(Device):

--- a/src/cryptoadvance/specter/templates/device/components/device_type.jinja
+++ b/src/cryptoadvance/specter/templates/device/components/device_type.jinja
@@ -10,6 +10,7 @@
             <option value="trezor">Trezor</option>
             <option value="specter">Specter</option>
             <option value="cobo">Cobo Vault</option>
+            <option value="electrum">Electrum</option>
             <option value="other">Other</option>
         </select>
     </fieldset>

--- a/src/cryptoadvance/specter/templates/device/new_device.jinja
+++ b/src/cryptoadvance/specter/templates/device/new_device.jinja
@@ -73,7 +73,11 @@ upub5En4f7k8gaG2KDHvBeEYox...rFpJRHpiZ4DE
 			</pre>
 					Loading from file supports ColdCard and Electrum wallet format.<br>
 				</div>
+{% if not device %}
 				<button type="submit" class="btn centered" name="action" value="newcolddevice">Continue</button>
+{% else %}
+				<button type="submit" class="btn centered" name="action" value="morekeys">Continue</button>
+{% endif %}
 			</div>
 {% if not device %}
 			<div id="hot_device" class="hidden">

--- a/src/cryptoadvance/specter/templates/includes/overlay/qr_code_sign.jinja
+++ b/src/cryptoadvance/specter/templates/includes/overlay/qr_code_sign.jinja
@@ -40,16 +40,16 @@
     <!-- because coldcard psbt is the most complete (includes xpubs) -->
     <div class="log"><code><pre>{{ device_psbts['sdcard'] }}</pre></code></div>
 
-    <div id="qr_code_sign_popup" class="popup">
-        <video muted playsinline id="qr-video" class="video"></video>
-        <div id="qr-progress"></div>
+    <div id="{{ device.alias }}_qr_code_sign_popup" class="popup">
+        <video muted playsinline id="{{ device.alias }}_qr-video" class="video"></video>
+        <div id="{{ device.alias }}_qr-progress"></div>
     </div>
 
     <script type="module">
         import QrScanner from "/static/qr/qr-scanner.min.js";
         QrScanner.WORKER_PATH = '/static/qr/qr-scanner-worker.min.js';
 
-        const video = document.getElementById('qr-video');
+        const video = document.getElementById('{{ device.alias }}_qr-video');
 
         var partial_qr = {
             "len": 0, // total number of qr codes scanned
@@ -58,8 +58,8 @@
         // we don't have access to showError from module
         function triggerError(msg){
             scanner.stop();
-            document.getElementById("qr-progress").style.display = 'none';
-            document.getElementById("qr_code_sign_popup").style.display = 'none';
+            document.getElementById("{{ device.alias }}_qr-progress").style.display = 'none';
+            document.getElementById("{{ device.alias }}_qr_code_sign_popup").style.display = 'none';
             hidePageOverlay();
             let event = new CustomEvent('errormsg', { detail: { message: msg } });
             document.dispatchEvent(event);
@@ -94,8 +94,8 @@
                     // it's javascript magic... 
                     // https://itnext.io/heres-why-mapping-a-constructed-array-doesn-t-work-in-javascript-f1195138615a
                     partial_qr.parts = [...Array(n)];
-                    document.getElementById("qr-progress").style.display = 'block';
-                    document.getElementById("qr-progress").innerHTML = "";
+                    document.getElementById("{{ device.alias }}_qr-progress").style.display = 'block';
+                    document.getElementById("{{ device.alias }}_qr-progress").innerHTML = "";
                 }
                 // fill corresponding part
                 if(p1){
@@ -108,7 +108,7 @@
                 }
                 // display scanning progress
                 let s = partial_qr.parts.map((e) => {return ((e) ? " 👻 " : " ❔ ");});
-                document.getElementById("qr-progress").innerHTML = s.join("");
+                document.getElementById("{{ device.alias }}_qr-progress").innerHTML = s.join("");
                 // check if we still have missing parts
                 if(partial_qr.parts.includes(undefined)){
                     // just return -> we are not ready to combine yet
@@ -124,13 +124,13 @@
                 partial_qr.parts = [];
                 partial_qr.len = 0;
                 // reset progress
-                document.getElementById("qr-progress").innerHTML = "";
-                document.getElementById("qr-progress").style.display = 'none';
+                document.getElementById("{{ device.alias }}_qr-progress").innerHTML = "";
+                document.getElementById("{{ device.alias }}_qr-progress").style.display = 'none';
             }
             // if we are done
             scanner.stop();
-            document.getElementById("qr-progress").style.display = 'none';
-            document.getElementById("qr_code_sign_popup").style.display = 'none';
+            document.getElementById("{{ device.alias }}_qr-progress").style.display = 'none';
+            document.getElementById("{{ device.alias }}_qr_code_sign_popup").style.display = 'none';
             hidePageOverlay();
             combine(result);
         });
@@ -138,15 +138,15 @@
             try {
                 event.preventDefault();
                 scanner.start();
-                document.getElementById("qr_code_sign_popup").style.display = 'flex';
+                document.getElementById("{{ device.alias }}_qr_code_sign_popup").style.display = 'flex';
             } catch(e) {
                 triggerError("Can't start the QR scanner!<br>" + e);
             }
         });
-        document.getElementById("qr_code_sign_popup").addEventListener("click", function() {
-            document.getElementById("qr_code_sign_popup").style.display = 'none';
-            document.getElementById("qr-progress").innerHTML = "";
-            document.getElementById("qr-progress").style.display = 'none';
+        document.getElementById("{{ device.alias }}_qr_code_sign_popup").addEventListener("click", function() {
+            document.getElementById("{{ device.alias }}_qr_code_sign_popup").style.display = 'none';
+            document.getElementById("{{ device.alias }}_qr-progress").innerHTML = "";
+            document.getElementById("{{ device.alias }}_qr-progress").style.display = 'none';
             scanner.stop();
         });
     </script>

--- a/src/cryptoadvance/specter/templates/includes/overlay/sign_tx_method.jinja
+++ b/src/cryptoadvance/specter/templates/includes/overlay/sign_tx_method.jinja
@@ -11,7 +11,7 @@
     <div id="{{ device.alias }}_sign_tx_method" class="flex-center flex-column hidden">
         <h2>Sign Transaction</h2><br>
         <div>
-            Please choose a signing method for your {{ device.name }} device.
+            Please choose a signing method for your {{ device.name }}.
         </div>
         {% if device.hwi_support %}
             <button id="{{ device.alias }}_hwi_sign_btn" class="btn flex-item" style="width: 190px; margin: 15px auto;">


### PR DESCRIPTION
Adds support for Electrum wallet as a device - supports QR code, SD card and copy-paste of the transactions.
Works both with desktop and mobile Electrum wallet. Electrum can be airgapped.

Also fixes a few things:
- adding keys to the device
- problem with two QR-code based devices