### PR TITLE
Support HWI toggle_passphrase

### DIFF
--- a/src/cryptoadvance/specter/device.py
+++ b/src/cryptoadvance/specter/device.py
@@ -19,6 +19,7 @@ class Device:
         self.sd_card_support = False
         self.qr_code_support = False
         self.hwi_support = False
+        self.supports_hwi_toggle_passphrase = False
         self.supports_hwi_multisig_display_address = False
 
     def create_psbts(self, base64_psbt, wallet):

--- a/src/cryptoadvance/specter/devices/keepkey.py
+++ b/src/cryptoadvance/specter/devices/keepkey.py
@@ -5,4 +5,5 @@ class Keepkey(HWIDevice):
         HWIDevice.__init__(self, name, alias, 'keepkey', keys, fullpath, manager)
         self.sd_card_support = False
         self.qr_code_support = False
+        self.supports_hwi_toggle_passphrase = True
         self.supports_hwi_multisig_display_address = True

--- a/src/cryptoadvance/specter/devices/trezor.py
+++ b/src/cryptoadvance/specter/devices/trezor.py
@@ -5,4 +5,5 @@ class Trezor(HWIDevice):
         HWIDevice.__init__(self, name, alias, 'trezor', keys, fullpath, manager)
         self.sd_card_support = False
         self.qr_code_support = False
+        self.supports_hwi_toggle_passphrase = True
         self.supports_hwi_multisig_display_address = True

--- a/src/cryptoadvance/specter/hwi_rpc.py
+++ b/src/cryptoadvance/specter/hwi_rpc.py
@@ -19,6 +19,7 @@ class HWIBridge(JSONRPC):
         self.exposed_rpc = {
             "enumerate": self.enumerate,
             "detect_device": self.detect_device,
+            "toggle_passphrase": self.toggle_passphrase,
             "prompt_pin": self.prompt_pin,
             "send_pin": self.send_pin,
             "extract_xpubs": self.extract_xpubs,
@@ -59,6 +60,14 @@ class HWIBridge(JSONRPC):
             res = [dev for dev in self.devices if dev["path"] == path]
         if len(res) > 0:
             return res[0]
+
+    @locked(hwilock)
+    def toggle_passphrase(self, device_type=None, path=None, passphrase='', chain=''):
+        if device_type == "keepkey" or device_type == "trezor":
+            client = self._get_client(device_type=device_type, path=path, passphrase=passphrase, chain=chain)
+            return hwi_commands.toggle_passphrase(client)
+        else:
+            raise Exception("Invalid HWI device type %s, toggle_passphrase is only supported for Trezor and Keepkey devices" % device_type)
 
     @locked(hwilock)
     def prompt_pin(self, device_type=None, path=None, passphrase='', chain=''):

--- a/src/cryptoadvance/specter/static/hwi.js
+++ b/src/cryptoadvance/specter/static/hwi.js
@@ -46,18 +46,14 @@ class HWIBridge {
             { device_type: type, rescan_devices: rescan });
     }
 
-    async togglePassphrase(device, passphrase="") {
+    async togglePassphrase(device) {
         /**
             Tells the server to send the 'togglepassphrase' command to the device.
             KeepKey and Trezor only.
         **/
-        if(!('passphrase' in device)){
-            device.passphrase = passphrase;
-        }
         return await this.fetch('toggle_passphrase', {
             device_type: device.type,
-            path: device.path,
-            passphrase: device.passphrase,
+            path: device.path
         });
     }
 

--- a/src/cryptoadvance/specter/static/hwi.js
+++ b/src/cryptoadvance/specter/static/hwi.js
@@ -45,6 +45,22 @@ class HWIBridge {
         return await this.fetch("detect_device", 
             { device_type: type, rescan_devices: rescan });
     }
+
+    async togglePassphrase(device, passphrase="") {
+        /**
+            Tells the server to send the 'togglepassphrase' command to the device.
+            KeepKey and Trezor only.
+        **/
+        if(!('passphrase' in device)){
+            device.passphrase = passphrase;
+        }
+        return await this.fetch('toggle_passphrase', {
+            device_type: device.type,
+            path: device.path,
+            passphrase: device.passphrase,
+        });
+    }
+
     async promptPin(device, passphrase="") {
         /**
             Tells the server to send the 'promptpin' command to the device.

--- a/src/cryptoadvance/specter/templates/device/device.jinja
+++ b/src/cryptoadvance/specter/templates/device/device.jinja
@@ -1,5 +1,6 @@
 {% extends "base.jinja" %}
 {% block main %}
+	{% include "includes/hwi/hwi.jinja" %}
 	<h1>{{ device.name }}</h1>
 	<form action="./" method="POST">
 		<div class="row">
@@ -48,12 +49,16 @@
 	</div>
 	<div class="spacer"></div>
 	<div class="row">
+		{% if device.supports_hwi_toggle_passphrase %}
+		<button type="button" class="btn centered" onclick="togglePassphrase()">Toggle device passphrase</button>
+		&nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp;
+		{% endif %}
 		{% if device.device_type != 'bitcoincore' %}
 		<form action="./" method="POST">
 			<button id="add_keys" type="submit" name="action" value="add_keys" class="btn centered">Add more keys</button>
 		</form>
-		{% endif %}
 		&nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp;
+		{% endif %}
 		<form action="./" method="POST">
 			<button type="submit" name="action" value="forget" class="btn danger centered">Forget the device</button>
 		</form>
@@ -95,5 +100,37 @@
 				}
 			}, false);
 		});
+
+		async function togglePassphrase(){
+        	let devices = await enumerate('{{ device.device_type }}');
+			if(devices == null || devices.length == 0){
+				return;
+			}
+			let device = await selectDevice(devices);
+        	showHWIProgress("Processing...", `Keep your ${capitalize(device.type)} connected.`);
+			let result = null;
+			try {
+				result = await hwi.togglePassphrase(device);
+			} catch (error) {
+				handleHWIError(error);
+				return null;
+			}
+			if(!overlayIsActive()){
+				showNotification("HWI is ready again", 10000);
+				// no need to proceed at all
+				return null;
+			}
+			hidePageOverlay();
+			if (device.type == "keepkey") {
+				result = await enterPin(device, false);
+				if(result == null){
+					return null;
+				}
+				if(!('success' in result) || !result.success){
+					throw "Failed to unlock device! Invalid PIN code?";
+				}
+			}
+			showNotification("{{ device.name }} passphrase toggled successfuly", 5000)
+		}
 	</script>
 {% endblock %}

--- a/src/cryptoadvance/specter/templates/device/device.jinja
+++ b/src/cryptoadvance/specter/templates/device/device.jinja
@@ -106,7 +106,7 @@
 			if(devices == null || devices.length == 0){
 				return;
 			}
-			let device = await selectDevice(devices);
+			let device = await selectDevice(devices, '');
         	showHWIProgress("Processing...", `Keep your ${capitalize(device.type)} connected.`);
 			let result = null;
 			try {

--- a/src/cryptoadvance/specter/templates/includes/hwi/components/pin.jinja
+++ b/src/cryptoadvance/specter/templates/includes/hwi/components/pin.jinja
@@ -7,22 +7,24 @@
 </div>
 
 <script type="text/javascript">
-    async function enterPin(device){
-        showHWIProgress("Processing...", `Keep your ${capitalize(device.type)} connected.`);
+    async function enterPin(device, promptPin=true){
         let result = null;
-        try {
-            result = await hwi.promptPin(device);
-        } catch (error) {
-            handleHWIError(error);
-            return null;
+        if (promptPin) {
+            showHWIProgress("Awaiting Confirmation...", `Please confirm the action on your ${capitalize(device.type)} device.`);
+            try {
+                result = await hwi.promptPin(device);
+            } catch (error) {
+                handleHWIError(error);
+                return null;
+            }
+            console.log(result);
+            if(!overlayIsActive()){
+                showNotification("HWI is ready again", 10000);
+                // no need to proceed at all
+                return null;
+            }
+            hidePageOverlay();
         }
-        console.log(result);
-        if(!overlayIsActive()){
-            showNotification("HWI is ready again", 10000);
-            // no need to proceed at all
-            return null;
-        }
-        hidePageOverlay();
 
         let el = document.getElementById("hwi_pin_container");
         let stars = document.getElementById("hwi_pin_stars");

--- a/src/cryptoadvance/specter/templates/includes/hwi/components/select_device.jinja
+++ b/src/cryptoadvance/specter/templates/includes/hwi/components/select_device.jinja
@@ -5,7 +5,7 @@
 </div>
 
 <script type="text/javascript">
-    async function selectDevice(devices){
+    async function selectDevice(devices, passphrase=null){
         /** 
         Spawns a window and asks user for a device.
         Retuns null if user closed the window.
@@ -42,9 +42,9 @@
             }
         }
         hidePageOverlay();
-        let passphrase = null;
+
         try{
-            passphrase = await unlockDevice(selectedDevice);
+            passphrase = await unlockDevice(selectedDevice, passphrase);
         }catch(error){
             handleHWIError(error);
             return null;
@@ -59,7 +59,8 @@
         console.log(selectedDevice);
         return selectedDevice;
     }
-    async function unlockDevice(device){
+
+    async function unlockDevice(device, passphrase=null){
         if('needs_pin_sent' in device && device.needs_pin_sent){
             let result = await enterPin(device);
             if(result == null){
@@ -69,6 +70,9 @@
                 throw "Failed to unlock device! Invalid PIN code?";
             }
             device.needs_pin_sent = false;
+        }
+        if(passphrase!=null){
+            return passphrase;
         }
         if('needs_passphrase_sent' in device && device.needs_passphrase_sent){
             console.log("need password...");


### PR DESCRIPTION
Adds a toggle passphrase button for Trezor and Keepkey devices in the device tab.
In theory, it would have been best to find the device by fingerprint, so you see only the specific device in the device screen, but there is an issue with that for KeepKey (and maybe Trezor One) where you can't get fingerprint if the passphrase is enabled without entering a non-empty passphrase. So that's something we should try to fix, but I think for now it's fine the way it is. 