### PR TITLE
Backup wallets

### DIFF
--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -10,7 +10,7 @@ from .key import Key
 from functools import wraps
 from flask import g, request, redirect, url_for
 
-from flask import Flask, Blueprint, render_template, request, redirect, url_for, jsonify, flash
+from flask import Flask, Blueprint, render_template, request, redirect, url_for, jsonify, flash, send_file
 from flask_login import login_required, login_user, logout_user, current_user
 from flask_login.config import EXEMPT_METHODS
 
@@ -288,6 +288,13 @@ def general_settings():
             app.specter.update_explorer(explorer, current_user)
             app.specter.update_hwi_bridge_url(hwi_bridge_url, current_user)
             app.specter.check()
+        elif action == "backup":
+            return send_file(
+                app.specter.wallet_manager.wallets_backup_file,
+                attachment_filename='specter-backup.zip',
+                as_attachment=True
+            )
+
     return render_template(
         "settings/general_settings.jinja",
         explorer=explorer,

--- a/src/cryptoadvance/specter/templates/settings/general_settings.jinja
+++ b/src/cryptoadvance/specter/templates/settings/general_settings.jinja
@@ -22,6 +22,14 @@
 				Then update this setting here to the URL you are running Specter on (default: http://127.0.0.1:25441/hwi/api/).
 			</div>
 			<br><br>
+			<div class="row">
+				<button type="submit" class="btn" name="action" value="backup">Download wallets backup files</button>
+			</div>
+			<div class="note">
+				It is recommended to keep your backup files privately as sharing them with result in privacy leaks.
+				Backups are recommended to ensure access to funds remains even in case a device from a multisig wallet is lost.
+			</div>
+			<br><br>
 			{% if current_user.is_admin %}
 			Log Level:<br>
 			<select name="loglevel">

--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -264,7 +264,8 @@ class Wallet():
     @property
     def blockheight(self):
         if len(self.transactions) > 0 and 'block_height' in self.transactions[0]:
-            return self.transactions[0]['block_height'] - 101 # To ensure coinbase transactions are indexed properly
+            blockheight = self.transactions[0]['block_height'] - 101 # To ensure coinbase transactions are indexed properly
+            return 0 if blockheight < 0 else blockheight # To ensure regtest don't have negative blockheight
         return self.cli.getblockcount()
 
     @property

--- a/src/cryptoadvance/specter/wallet_manager.py
+++ b/src/cryptoadvance/specter/wallet_manager.py
@@ -1,4 +1,5 @@
-import os, json, logging, shutil
+import os, json, logging, shutil, time, zipfile
+from io import BytesIO
 from collections import OrderedDict
 from hwilib.descriptor import AddChecksum
 from .helpers import alias, load_jsons
@@ -172,3 +173,15 @@ class WalletManager:
         if self.working_folder is not None:
             wallet.save_to_file()
         self.update()
+
+    @property
+    def wallets_backup_file(self):
+        memory_file = BytesIO()
+        with zipfile.ZipFile(memory_file, 'w') as zf:
+            for wallet in self.wallets.values():
+                data = zipfile.ZipInfo('{}.json'.format(wallet.name))
+                data.date_time = time.localtime(time.time())[:6]
+                data.compress_type = zipfile.ZIP_DEFLATED
+                zf.writestr('{}.json'.format(wallet.name), wallet.account_map)
+        memory_file.seek(0)
+        return memory_file


### PR DESCRIPTION
Add a backup wallets button in the general settings tab. This will download a zip with all wallets account maps as separate zip files, so they could be imported back into Specter if needed.