### PR TITLE
disable unavailable devices in new wallet screen

### DIFF
--- a/src/cryptoadvance/specter/device.py
+++ b/src/cryptoadvance/specter/device.py
@@ -82,6 +82,10 @@ class Device:
                 f.write(json.dumps(self.json,indent=4))
         self.manager.update()
 
+    def key_types(self, network='main'):
+        test = network != 'main'
+        return [key.key_type for key in self.keys if (key.is_testnet == test)]
+
     def __eq__(self, other):
         if other is None:
             return False

--- a/src/cryptoadvance/specter/key.py
+++ b/src/cryptoadvance/specter/key.py
@@ -152,6 +152,10 @@ class Key:
         return metadata
 
     @property
+    def is_testnet(self):
+        return not self.xpub.startswith("xpub")
+
+    @property
     def json(self):
         return {
             'original': self.original,

--- a/src/cryptoadvance/specter/static/styles.css
+++ b/src/cryptoadvance/specter/static/styles.css
@@ -577,7 +577,15 @@ input[type="checkbox"]:checked + .btn.hovering
 input[type="radio"]:checked + .small-card,
 input[type="checkbox"]:checked + .small-card
 {
-	  background: #304052;
+	background: #304052;
+}
+input[type="radio"]:disabled + .small-card,
+input[type="checkbox"]:disabled + .small-card,
+input[type="radio"]:disabled + .small-card:hover,
+input[type="checkbox"]:disabled + .small-card:hover
+{
+    background: transparent;
+    opacity: 0.2;
 }
 table{
     border-collapse: collapse;

--- a/src/cryptoadvance/specter/templates/wallet/new_wallet/new_wallet.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/new_wallet/new_wallet.jinja
@@ -8,11 +8,13 @@
 		<h1>Type of the wallet</h1>
 		<nav class="row">
 			<label>
-				<input type="radio" name="type" value="{{'sh-wsh' if wallet_type == 'multisig' else 'sh-wpkh'}}" class="hidden">
+				<input type="radio" name="type" value="{{'sh-wsh' if wallet_type == 'multisig' else 'sh-wpkh'}}"
+				class="hidden" onchange="updateType(this.value);">
 				<div class="btn radio left">Nested Segwit</div>
 			</label>
 			<label>
-				<input type="radio" name="type" value="{{'wsh' if wallet_type == 'multisig' else 'wpkh'}}" checked class="hidden">
+				<input type="radio" name="type" value="{{'wsh' if wallet_type == 'multisig' else 'wpkh'}}" checked 
+				class="hidden" onchange="updateType(this.value);">
 				<div class="btn radio right">Segwit</div>
 			</label>
 		</nav>
@@ -39,11 +41,12 @@
 		{% endif %}
 		<div class="row overflow">
 			{% for device_name in specter.device_manager.devices_names %}
+				{% set device = specter.device_manager.devices[device_name] %}
 				<label>
-					<input type="{{ 'checkbox' if wallet_type == 'multisig' else 'radio' }}" name="devices" value="{{ specter.device_manager.devices[device_name].alias }}" class="hidden">
+					<input type="{{ 'checkbox' if wallet_type == 'multisig' else 'radio' }}" name="devices" value="{{ device.alias }}" class="hidden" data-key-types='{{ device.key_types(specter.chain) | tojson }}' chain="{{specter.chain}}">
 					<div class="small-card radio">
-						{% if specter.device_manager.devices[device_name].device_type in ['specter', 'coldcard', 'trezor', 'ledger'] %}
-							<img src="/static/img/{{ specter.device_manager.devices[device_name].device_type }}_icon.svg" width="18px">
+						{% if device.device_type in ['specter', 'coldcard', 'trezor', 'ledger'] %}
+							<img src="/static/img/{{ device.device_type }}_icon.svg" width="18px">
 						{% else %}
 							<img src="/static/img/other_icon.svg" width="18px">
 						{% endif %}
@@ -64,4 +67,26 @@
 			</center>
 		</div>
 	</form>
+{% endblock %}
+{% block scripts %}
+<script type="text/javascript">
+	function updateType(val){
+		console.log(val);
+		let devs = document.getElementsByName('devices');
+		devs.forEach(dev => {
+			let types = JSON.parse(dev.getAttribute('data-key-types'));
+			dev.disabled = !(types.includes("") || types.includes(val));
+			if(dev.disabled){
+				dev.checked = false;
+			}
+		});
+	}
+	// initial trigger
+	let els = document.getElementsByName("type");
+	els.forEach(el=>{
+		if (el.checked){
+			updateType(el.value);
+		}
+	})
+</script>
 {% endblock %}

--- a/src/cryptoadvance/specter/templates/wallet/new_wallet/new_wallet.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/new_wallet/new_wallet.jinja
@@ -71,7 +71,6 @@
 {% block scripts %}
 <script type="text/javascript">
 	function updateType(val){
-		console.log(val);
 		let devs = document.getElementsByName('devices');
 		devs.forEach(dev => {
 			let types = JSON.parse(dev.getAttribute('data-key-types'));


### PR DESCRIPTION
disables devices that don't have keys of the correct type
<img width="832" alt="Screenshot 2020-07-16 at 11 51 25" src="https://user-images.githubusercontent.com/1706012/87657362-064ecb80-c75b-11ea-97c1-048949700111.png">
