### PR TITLE
Disallow signing with wrong device

### DIFF
--- a/src/cryptoadvance/specter/hwi_rpc.py
+++ b/src/cryptoadvance/specter/hwi_rpc.py
@@ -37,14 +37,16 @@ class HWIBridge(JSONRPC):
         Returns a list of all connected devices (dicts).
         Standard HWI enumerate() command + Specter.
         """
-        self.devices = hwi_commands.enumerate()
-        self.devices += specter_enumerate()
+        self.devices = hwi_commands.enumerate(passphrase)
+        self.devices += specter_enumerate(passphrase)
         for device in self.devices:
             client = self._get_client(device_type=device['type'], path=device['path'], passphrase=passphrase, chain=chain)
             try:
                  device['fingerprint'] = client.get_master_fingerprint_hex()
             except:
                 pass
+            if client:
+                client.close()
         return self.devices
     
     def detect_device(self, device_type=None, path=None, fingerprint=None, rescan_devices=False):

--- a/src/cryptoadvance/specter/hwi_rpc.py
+++ b/src/cryptoadvance/specter/hwi_rpc.py
@@ -32,13 +32,19 @@ class HWIBridge(JSONRPC):
         self.enumerate()
 
     @locked(hwilock)
-    def enumerate(self):
+    def enumerate(self, passphrase='', chain=''):
         """
         Returns a list of all connected devices (dicts).
         Standard HWI enumerate() command + Specter.
         """
         self.devices = hwi_commands.enumerate()
         self.devices += specter_enumerate()
+        for device in self.devices:
+            client = self._get_client(device_type=device['type'], path=device['path'], passphrase=passphrase, chain=chain)
+            try:
+                 device['fingerprint'] = client.get_master_fingerprint_hex()
+            except:
+                pass
         return self.devices
     
     def detect_device(self, device_type=None, path=None, fingerprint=None, rescan_devices=False):

--- a/src/cryptoadvance/specter/static/hwi.js
+++ b/src/cryptoadvance/specter/static/hwi.js
@@ -94,7 +94,6 @@ class HWIBridge {
         /**
             Sends the current psbt to the server to relay to the HWI wallet.
         **/
-       alert(device.passphrase)
         if(!('passphrase' in device)){
             device.passphrase = passphrase;
         }

--- a/src/cryptoadvance/specter/static/hwi.js
+++ b/src/cryptoadvance/specter/static/hwi.js
@@ -37,8 +37,10 @@ class HWIBridge {
         }
         return data.result;
     }
-    async enumerate(){
-        return await this.fetch("enumerate");
+    async enumerate(passphrase=""){
+        return await this.fetch("enumerate", { 
+            passphrase
+        });
     }
     async detectDevice(type, rescan=true){
         // TODO: fingerprint, path, type
@@ -92,6 +94,7 @@ class HWIBridge {
         /**
             Sends the current psbt to the server to relay to the HWI wallet.
         **/
+       alert(device.passphrase)
         if(!('passphrase' in device)){
             device.passphrase = passphrase;
         }

--- a/src/cryptoadvance/specter/templates/includes/hwi/components/pin.jinja
+++ b/src/cryptoadvance/specter/templates/includes/hwi/components/pin.jinja
@@ -24,8 +24,6 @@
                 return null;
             }
             hidePageOverlay();
-        } else {
-            showHWIProgress("Awaiting Confirmation...", `Please confirm the action on your ${capitalize(device.type)} device.`);
         }
 
         let el = document.getElementById("hwi_pin_container");

--- a/src/cryptoadvance/specter/templates/includes/hwi/components/pin.jinja
+++ b/src/cryptoadvance/specter/templates/includes/hwi/components/pin.jinja
@@ -10,7 +10,7 @@
     async function enterPin(device, promptPin=true){
         let result = null;
         if (promptPin) {
-            showHWIProgress("Awaiting Confirmation...", `Please confirm the action on your ${capitalize(device.type)} device.`);
+            showHWIProgress("Processing...", `Keep your ${capitalize(device.type)} connected.`);
             try {
                 result = await hwi.promptPin(device);
             } catch (error) {
@@ -24,6 +24,8 @@
                 return null;
             }
             hidePageOverlay();
+        } else {
+            showHWIProgress("Awaiting Confirmation...", `Please confirm the action on your ${capitalize(device.type)} device.`);
         }
 
         let el = document.getElementById("hwi_pin_container");

--- a/src/cryptoadvance/specter/templates/includes/hwi/components/select_device.jinja
+++ b/src/cryptoadvance/specter/templates/includes/hwi/components/select_device.jinja
@@ -49,6 +49,14 @@
             handleHWIError(error);
             return null;
         }
+
+        showHWIProgress("Processing...", `Keep your ${capitalize(selectedDevice.type)} connected.`);
+        // Get the device again as it is now unlocked and the fingerprint is available
+        let rescanDevices = await enumerate(selectedDevice.type, selectedDevice.path);
+        if (rescanDevices.length == 1) {
+            selectedDevice = rescanDevices[0]
+        }
+        hidePageOverlay();
         console.log(passphrase);
         // maybe we get password here
         if(passphrase != null){

--- a/src/cryptoadvance/specter/templates/includes/hwi/components/select_device.jinja
+++ b/src/cryptoadvance/specter/templates/includes/hwi/components/select_device.jinja
@@ -52,7 +52,7 @@
 
         showHWIProgress("Processing...", `Keep your ${capitalize(selectedDevice.type)} connected.`);
         // Get the device again as it is now unlocked and the fingerprint is available
-        let rescanDevices = await enumerate(selectedDevice.type, selectedDevice.path);
+        let rescanDevices = await enumerate(selectedDevice.type, selectedDevice.path, passphrase);
         if (rescanDevices.length == 1) {
             selectedDevice = rescanDevices[0]
         }

--- a/src/cryptoadvance/specter/templates/includes/hwi/components/wallet.jinja
+++ b/src/cryptoadvance/specter/templates/includes/hwi/components/wallet.jinja
@@ -23,13 +23,19 @@
         let devices = await enumerate(deviceTypes);
         return devices;
     }
-    async function signTx(combine, deviceType, psbt){
+    async function signTx(combine, deviceType, psbt, fingerprint=null){
         let devices = await getConnectedWalletDevices([deviceType]);
         if(devices == null || devices.length == 0){
             return;
         }
         let device = await selectDevice(devices);
+        console.log(device)
         if(device == null){
+            return;
+        }
+
+        if (fingerprint && device.fingerprint != fingerprint) {
+            handleHWIError("Selected device does not have matching signing key.");
             return;
         }
         showHWIProgress("Signing transaction...", `Confirm on your ${capitalize(device.type)}.`);

--- a/src/cryptoadvance/specter/templates/includes/hwi/hwi.jinja
+++ b/src/cryptoadvance/specter/templates/includes/hwi/hwi.jinja
@@ -45,14 +45,19 @@
         }
     }
 
-    async function enumerate(deviceTypes=null){
+    async function enumerate(deviceTypes=null, deveicePath=null){
         // detect device
-        showHWIProgress("Detecting...", "Plug in your device");
+        if (deveicePath == null) {
+            showHWIProgress("Detecting...", "Plug in your device");
+        }
         let result = [];
         try {
             result = await hwi.enumerate();
             if(result!=null && deviceTypes!=null){
                 result = result.filter(dev => deviceTypes.includes(dev.type));
+            }
+            if(result!=null && deveicePath!=null){
+                result = result.filter(dev => dev.path == deveicePath);
             }
             while(result.length == 0){
                 await wait(1000);
@@ -67,18 +72,23 @@
                 if(result!=null && deviceTypes!=null){
                     result = result.filter(dev => deviceTypes.includes(dev.type));
                 }
+                if(result!=null && deveicePath!=null){
+                    result = result.filter(dev => dev.path == deveicePath);
+                }
             }
         } catch (error) {
             handleHWIError(error);
             return null;
         }
         console.log(result);
-        if(!overlayIsActive()){
+        if(!overlayIsActive() && deveicePath == null){
             showNotification("HWI is ready again", 10000);
             // no need to proceed at all
             return null;
         }
-        hidePageOverlay();
+        if (deveicePath == null){
+            hidePageOverlay();
+        }
         return result;
     }
     // TODO: remove, legacy

--- a/src/cryptoadvance/specter/templates/includes/hwi/hwi.jinja
+++ b/src/cryptoadvance/specter/templates/includes/hwi/hwi.jinja
@@ -45,19 +45,19 @@
         }
     }
 
-    async function enumerate(deviceTypes=null, deveicePath=null){
+    async function enumerate(deviceTypes=null, devicePath=null, passphrase=''){
         // detect device
-        if (deveicePath == null) {
+        if (devicePath == null) {
             showHWIProgress("Detecting...", "Plug in your device");
         }
         let result = [];
         try {
-            result = await hwi.enumerate();
+            result = await hwi.enumerate(passphrase);
             if(result!=null && deviceTypes!=null){
                 result = result.filter(dev => deviceTypes.includes(dev.type));
             }
-            if(result!=null && deveicePath!=null){
-                result = result.filter(dev => dev.path == deveicePath);
+            if(result!=null && devicePath!=null){
+                result = result.filter(dev => dev.path == devicePath);
             }
             while(result.length == 0){
                 await wait(1000);
@@ -68,12 +68,12 @@
                     return null;
                 }
                 console.log("Retrying enumerate...");
-                result = await hwi.enumerate();
+                result = await hwi.enumerate(passphrase);
                 if(result!=null && deviceTypes!=null){
                     result = result.filter(dev => deviceTypes.includes(dev.type));
                 }
-                if(result!=null && deveicePath!=null){
-                    result = result.filter(dev => dev.path == deveicePath);
+                if(result!=null && devicePath!=null){
+                    result = result.filter(dev => dev.path == devicePath);
                 }
             }
         } catch (error) {
@@ -81,12 +81,12 @@
             return null;
         }
         console.log(result);
-        if(!overlayIsActive() && deveicePath == null){
+        if(!overlayIsActive() && devicePath == null){
             showNotification("HWI is ready again", 10000);
             // no need to proceed at all
             return null;
         }
-        if (deveicePath == null){
+        if (devicePath == null){
             hidePageOverlay();
         }
         return result;

--- a/src/cryptoadvance/specter/templates/includes/overlay/overlay.html
+++ b/src/cryptoadvance/specter/templates/includes/overlay/overlay.html
@@ -39,17 +39,19 @@
     }
 
     function hidePageOverlay() {
-        // Transfer the content back into a holder div
-        var holder = document.createElement("div");
-        holder.style.display = "none";
-        document.body.appendChild(holder);
-        holder.appendChild(document.getElementById(document.getElementById("page_overlay_popup_content").children[0].id));
+        if (overlayIsActive()) {
+            // Transfer the content back into a holder div
+            var holder = document.createElement("div");
+            holder.style.display = "none";
+            document.body.appendChild(holder);
+            holder.appendChild(document.getElementById(document.getElementById("page_overlay_popup_content").children[0].id));
 
-        var overlay = document.getElementById("page_overlay");
-        overlay.style.display = "none";
+            var overlay = document.getElementById("page_overlay");
+            overlay.style.display = "none";
 
-        var overlayPopup = document.getElementById("page_overlay_popup");
-        overlayPopup.style.display = "none";
+            var overlayPopup = document.getElementById("page_overlay_popup");
+            overlayPopup.style.display = "none";
+        }
     }
 
     function overlayIsActive(){

--- a/src/cryptoadvance/specter/templates/includes/overlay/sign_tx_method.jinja
+++ b/src/cryptoadvance/specter/templates/includes/overlay/sign_tx_method.jinja
@@ -21,7 +21,16 @@
                 document.getElementById("{{ device.alias }}_hwi_sign_btn").addEventListener("click", e => {
                     e.preventDefault();
                     hidePageOverlay();
-                    signTx(combine, '{{ device.device_type }}', '{{ device_psbts["hwi"] }}');
+                    let fingerprint = null;
+                    {% for wallet_key in wallet.keys %}
+                        {% for device_key in device.keys %}
+                            {% if device_key == wallet_key %}
+                                fingerprint = '{{ device.keys[loop.index0].fingerprint }}'
+                            {% endif %}
+                        {% endfor %}
+                    {% endfor %}
+
+                    signTx(combine, '{{ device.device_type }}', '{{ device_psbts["hwi"] }}', fingerprint);
                 });
             </script>
         {% endif %}


### PR DESCRIPTION
Solve #226 

This works also for Trezor and KeepKey with passphrase enabled, by querying the fingerprint "manually" in the enumerate. Also made a PR for HWI to fix that behavior there https://github.com/bitcoin-core/HWI/pull/357

We should probably base on a similar approach as I did here for all device-specific communications (ref #78) by passing fingerprints, something I was wondering about is whatever we should assume a device can only have a single fingerprint (if yes we should enforce that).