### PR TITLE
add multi rpc call support, reduce call count

### DIFF
--- a/src/cryptoadvance/specter/rpc.py
+++ b/src/cryptoadvance/specter/rpc.py
@@ -148,10 +148,14 @@ class RpcError(Exception):
     '''
     def __init__(self, message, response):
         super(Exception, self).__init__(message)
-        self.status_code = response.status_code
         try:
-            error = json.loads(response.text)
             self.status_code = response.status_code
+            error = response.json()
+        except:
+            # ok already a dict
+            self.status_code = 500
+            error = response
+        try:
             self.error_code = error['error']['code']
             self.error_msg = error['error']['message']
         except Exception as e:
@@ -223,7 +227,7 @@ class BitcoinCLI:
         def fn(*args, **kwargs):
             r = self.multi([(method,*args)])[0]
             if r["error"] is not None:
-                raise Exception(r["error"])
+                raise RpcError("Request error: %s" % r["error"]["message"], r)
             return r["result"]
         return fn
 


### PR DESCRIPTION
This PR adds support of multiple rpc calls with one request to BitcoinCLI class.
Also refactors the most call-expensive wallet function to reduce number of rpc calls.