### PR TITLE
redirect to pending transactions in /send if there are any

### DIFF
--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -788,9 +788,23 @@ def fees(blocks):
     res = app.specter.estimatesmartfee(int(blocks))
     return res
 
-@app.route('/wallets/<wallet_alias>/send/new', methods=['GET', 'POST'])
+@app.route('/wallets/<wallet_alias>/send')
 @login_required
 def wallet_send(wallet_alias):
+    app.specter.check()
+    try:
+        wallet = app.specter.wallet_manager.get_by_alias(wallet_alias)
+    except SpecterError as se:
+        app.logger.error("SpecterError while wallet_send: %s" % se)
+        return render_template("base.jinja", error=se, specter=app.specter, rand=rand)
+    if len(wallet.pending_psbts) > 0:
+        return redirect(url_for('wallet_sendpending', wallet_alias=wallet_alias))
+    else:
+        return redirect(url_for('wallet_sendnew', wallet_alias=wallet_alias))
+
+@app.route('/wallets/<wallet_alias>/send/new', methods=['GET', 'POST'])
+@login_required
+def wallet_sendnew(wallet_alias):
     app.specter.check()
     try:
         wallet = app.specter.wallet_manager.get_by_alias(wallet_alias)

--- a/src/cryptoadvance/specter/templates/wallet/send/components/send_nav.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/send/components/send_nav.jinja
@@ -9,7 +9,7 @@
 {% macro send_nav(active_menuitem, wallet_alias) -%}
 	<br>
     <nav class="row">
-		{{ wallet_menu_item('wallet_send', 'New', wallet_alias, active_menuitem, isLeft=true) }}
+		{{ wallet_menu_item('wallet_sendnew', 'New', wallet_alias, active_menuitem, isLeft=true) }}
 		{{ wallet_menu_item('wallet_sendpending', 'Unsigned', wallet_alias, active_menuitem) }}
 		{{ wallet_menu_item('wallet_importpsbt', 'Import', wallet_alias, active_menuitem, isRight=true) }}
 	</nav>

--- a/src/cryptoadvance/specter/templates/wallet/send/import/wallet_importpsbt.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/send/import/wallet_importpsbt.jinja
@@ -5,7 +5,7 @@
 	{{ send_nav('wallet_importpsbt', wallet_alias) }}
 		<h1 class="padded">Import PSBT transaction:</h1>
 		<span class="center note padded">Paste base64-encoded PSBT transaction here to import.</span>
-		<form action="{{ url_for('wallet_send',wallet_alias=wallet_alias) }}" method="POST">
+		<form action="{{ url_for('wallet_sendnew',wallet_alias=wallet_alias) }}" method="POST">
 			<div class="card">
 				<textarea name="rawpsbt" placeholder="Paste PSBT here"></textarea>
 				<button type="submit" name="action" value="importpsbt" class="btn centered" style="margin-top: 20px;">Import transaction</button>

--- a/src/cryptoadvance/specter/templates/wallet/send/new/wallet_send.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/send/new/wallet_send.jinja
@@ -9,7 +9,7 @@
 		</ul>
 	</message-box>
 
-	<form action="{{ url_for('wallet_send',wallet_alias=wallet_alias) }}" method="POST">
+	<form action="{{ url_for('wallet_sendnew',wallet_alias=wallet_alias) }}" method="POST">
 		<h1 class="padded">Sending to:</h1>
 		<div class="card">
 			Recipient address:<br>

--- a/src/cryptoadvance/specter/templates/wallet/send/new/wallet_send.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/send/new/wallet_send.jinja
@@ -2,7 +2,7 @@
 {% set tab = 'wallet_send' %}
 {% block content %}
 	{% from 'wallet/send/components/send_nav.jinja' import send_nav %}
-	{{ send_nav('wallet_send', wallet_alias) }}
+	{{ send_nav('wallet_sendnew', wallet_alias) }}
 
 	<message-box type="error" id="amount_errors_container" style="position: absolute; top: 0; display: none;">
 		Error!

--- a/src/cryptoadvance/specter/templates/wallet/send/pending/components/pending_psbt_item.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/send/pending/components/pending_psbt_item.jinja
@@ -24,7 +24,7 @@
         </td>
         <td width="170px">
             <div class="row">
-                <form action="{{ url_for('wallet_send',wallet_alias=wallet_alias) }}" method="POST">
+                <form action="{{ url_for('wallet_sendnew',wallet_alias=wallet_alias) }}" method="POST">
                     <input type="hidden" name="pending_psbt" value='{{ pending_psbt|tojson|safe }}'>
                     <button type="submit" name="action" value="openpsbt" class="btn" style="margin-right: 5px;">Open</button>
                 </form>

--- a/src/cryptoadvance/specter/templates/wallet/send/sign/wallet_send_sign_psbt.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/send/sign/wallet_send_sign_psbt.jinja
@@ -60,7 +60,7 @@
 	</style>
 	<br>
 	{% from 'wallet/components/explorer_link.jinja' import explorer_link %}
-	<form action="{{ url_for('wallet_send',wallet_alias=wallet_alias) }}" method="POST" class="full-width" id="send_sign_psbt_form">
+	<form action="{{ url_for('wallet_sendnew',wallet_alias=wallet_alias) }}" method="POST" class="full-width" id="send_sign_psbt_form">
 		<div class="tx_info">
 			
 			<div>Sending <b>{{ psbt["amount"] | btcamount }}</b> BTC to<b>


### PR DESCRIPTION
Pending transactions are locking funds used in these transactions and people get confused.
This PR redirects to pending transactions screen from `/send` tab if there are any pending transactions.
If there are no pending transaction we load the usual `/send/new` tab.