### PR TITLE
remove dependency on bip32

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-bip32==0.0.8
 certifi==2019.9.11
 chardet==3.0.4
 Click==7.0

--- a/src/cryptoadvance/specter/devices/bitcoin_core.py
+++ b/src/cryptoadvance/specter/devices/bitcoin_core.py
@@ -1,10 +1,13 @@
 import os, shutil
-from bip32 import BIP32
 from mnemonic import Mnemonic
 from hwilib.descriptor import AddChecksum
 from ..device import Device
-from ..helpers import alias, convert_xpub_prefix, encode_base58_checksum, get_xpub_fingerprint, seed_to_hd_master_key
+from ..helpers import (alias, convert_xpub_prefix,
+                       encode_base58_checksum, decode_base58,
+                       get_xpub_fingerprint)
 from ..key import Key
+from io import BytesIO
+import hmac
 
 class BitcoinCore(Device):
     def __init__(self, name, alias, device_type, keys, fullpath, manager):
@@ -35,48 +38,58 @@ class BitcoinCore(Device):
         if passphrase:
             cli.encryptwallet(passphrase)
 
-        bip32 = BIP32.from_seed(seed)
-        xpubs = ""
-        master_fpr = get_xpub_fingerprint(bip32.get_xpub_from_path('m/0h')).hex()
+        xpubs_str = ""
+        paths = [
+            "m", # to get fingerprint
+            f"m/49h/{coin}h/0h", # nested
+            f"m/84h/{coin}h/0h", # native
+            f"m/48h/{coin}h/0h/1h", # nested multisig
+            f"m/48h/{coin}h/0h/2h", # native multisig
+        ]
+        xpubs = derive_xpubs_from_xprv(xprv, paths, wallet_manager.cli)
+        # it's not parent fingerprint, it's self fingerprint
+        master_fpr = get_xpub_fingerprint(xpubs[0]).hex()
 
         if not testnet:
             # Nested Segwit
-            xpub = bip32.get_xpub_from_path('m/49h/0h/0h')
+            xpub = xpubs[1]
             ypub = convert_xpub_prefix(xpub, b'\x04\x9d\x7c\xb2')
-            xpubs += "[%s/49'/0'/0']%s\n" % (master_fpr, ypub)
+            xpubs_str += "[%s/49'/0'/0']%s\n" % (master_fpr, ypub)
             # native Segwit
-            xpub = bip32.get_xpub_from_path('m/84h/0h/0h')
+            xpub = xpubs[2]
             zpub = convert_xpub_prefix(xpub, b'\x04\xb2\x47\x46')
-            xpubs += "[%s/84'/0'/0']%s\n" % (master_fpr, zpub)
+            xpubs_str += "[%s/84'/0'/0']%s\n" % (master_fpr, zpub)
             # Multisig nested Segwit
-            xpub = bip32.get_xpub_from_path('m/48h/0h/0h/1h')
+            xpub = xpubs[3]
             Ypub = convert_xpub_prefix(xpub, b'\x02\x95\xb4\x3f')
-            xpubs += "[%s/48'/0'/0'/1']%s\n" % (master_fpr, Ypub)
+            xpubs_str += "[%s/48'/0'/0'/1']%s\n" % (master_fpr, Ypub)
             # Multisig native Segwit
-            xpub = bip32.get_xpub_from_path('m/48h/0h/0h/2h')
+            xpub = xpubs[4]
             Zpub = convert_xpub_prefix(xpub, b'\x02\xaa\x7e\xd3')
-            xpubs += "[%s/48'/0'/0'/2']%s\n" % (master_fpr, Zpub)
+            xpubs_str += "[%s/48'/0'/0'/2']%s\n" % (master_fpr, Zpub)
         else:
             # Testnet nested Segwit
-            xpub = bip32.get_xpub_from_path('m/49h/1h/0h')
+            xpub = xpubs[1]
             upub = convert_xpub_prefix(xpub, b'\x04\x4a\x52\x62')
-            xpubs += "[%s/49'/1'/0']%s\n" % (master_fpr, upub)
+            xpubs_str += "[%s/49'/1'/0']%s\n" % (master_fpr, upub)
             # Testnet native Segwit
-            xpub = bip32.get_xpub_from_path('m/84h/1h/0h')
+            xpub = xpubs[2]
             vpub = convert_xpub_prefix(xpub, b'\x04\x5f\x1c\xf6')
-            xpubs += "[%s/84'/1'/0']%s\n" % (master_fpr, vpub)
+            xpubs_str += "[%s/84'/1'/0']%s\n" % (master_fpr, vpub)
             # Testnet multisig nested Segwit
-            xpub = bip32.get_xpub_from_path('m/48h/1h/0h/1h')
+            xpub = xpubs[3]
             Upub = convert_xpub_prefix(xpub, b'\x02\x42\x89\xef')
-            xpubs += "[%s/48'/1'/0'/1']%s\n" % (master_fpr, Upub)
+            xpubs_str += "[%s/48'/1'/0'/1']%s\n" % (master_fpr, Upub)
             # Testnet multisig native Segwit
-            xpub = bip32.get_xpub_from_path('m/48h/1h/0h/2h')
+            xpub = xpubs[4]
             Vpub = convert_xpub_prefix(xpub, b'\x02\x57\x54\x83')
-            xpubs += "[%s/48'/1'/0'/2']%s\n" % (master_fpr, Vpub)
+            xpubs_str += "[%s/48'/1'/0'/2']%s\n" % (master_fpr, Vpub)
 
-        keys, failed = Key.parse_xpubs(xpubs)
+        keys, failed = Key.parse_xpubs(xpubs_str)
         if len(failed) > 0:
-            # TODO: This should never occur, but just in case, we must make sure to catch it properly so it doesn't crash the app no matter what.
+            # TODO: This should never occur, but just in case, 
+            # we must make sure to catch it properly so it 
+            # doesn't crash the app no matter what.
             raise Exception("Failed to parse these xpubs:\n" + "\n".join(failed))
         else:
             self.add_keys(keys)
@@ -115,3 +128,115 @@ class BitcoinCore(Device):
                 shutil.rmtree(os.path.join(wallet_manager.get_default_datadir(), wallet_cli_path))
         except:
             pass # We tried...
+
+# We need to copy it like this because HWI uses it as a dependency, but requires v0.18 which doesn't have this function.
+def seed_to_hd_master_key(seed, testnet=False) -> str:
+    """Converts 64-byte seed to xprv"""
+    if len(seed) != 64:
+        raise ValueError("Provided seed should have length of 64")
+
+    # Compute HMAC-SHA512 of seed
+    seed = hmac.new(b"Bitcoin seed", seed, digestmod=hashlib.sha512).digest()
+
+    # Serialization format can be found at: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#Serialization_format
+    xprv = b"\x04\x88\xad\xe4"  # Version for private mainnet
+    if testnet:
+        xprv = b"\x04\x35\x83\x94"  # Version for private testnet
+    xprv += b"\x00" * 9  # Depth, parent fingerprint, and child number
+    xprv += seed[32:]  # Chain code
+    xprv += b"\x00" + seed[:32]  # Master key
+
+    # Double hash using SHA256
+    hashed_xprv = hashlib.sha256(xprv).digest()
+    hashed_xprv = hashlib.sha256(hashed_xprv).digest()
+
+    # Append 4 bytes of checksum
+    xprv += hashed_xprv[:4]
+
+    # Return base58
+    return b58encode(xprv)
+
+def derive_xpubs_from_xprv(xprv, paths:list, cli):
+    """
+    Derives xpubs from root xprv and list of paths.
+    Requires running BitcoinCLI instance to derive xpub from xprv
+    """
+    derived_xprvs = []
+    for path in paths:
+        derivation = parse_path(path)
+        if len(derivation) == 0:
+            # tuple: (parent, derived)
+            derived_xprvs.append((None, xprv))
+        else:
+            # we need parent for fingerprint
+            parent = xprv
+            for idx in derivation[:-1]:
+                parent = get_child(parent, idx)
+            child = get_child(parent, derivation[-1])
+            derived_xprvs.append((parent, child))
+    xpubs = []
+    for parent, child in derived_xprvs:
+        res = cli.getdescriptorinfo(f"wpkh({child})")
+        xpub = res["descriptor"].split("(")[1].split(")")[0]
+        if parent is not None:
+            res = cli.getdescriptorinfo(f"wpkh({parent})")
+            parent_xpub = res["descriptor"].split("(")[1].split(")")[0]
+            fingerprint = get_xpub_fingerprint(parent_xpub)
+            xpub = swap_fingerprint(xpub, fingerprint)
+        xpubs.append(xpub)
+    return xpubs
+
+def swap_fingerprint(xpub, fingerprint):
+    """Replaces fingerprint in xpub"""
+    raw = decode_base58(xpub)
+    swapped = raw[:5]+fingerprint+raw[9:]
+    return encode_base58_checksum(swapped)
+
+# curve order
+N = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+
+def get_child(xprv, index):
+    """Derives a child from xprv but without fingerprint information"""
+    if index > 0xFFFFFFFF or index < 0:
+        raise ValueError("Index should be between 0 and 2^32")
+    if index < 0x80000000:
+        raise ValueError("Can't do non-hardened")
+
+    stream = BytesIO(decode_base58(xprv))
+    version = stream.read(4)
+    depth = stream.read(1)[0]
+    fingerprint = stream.read(4)
+    child_number = int.from_bytes(stream.read(4), 'big')
+    chain_code = stream.read(32)
+    stream.read(1)
+    secret = stream.read(32)
+
+    data = b'\x00' + secret + index.to_bytes(4, 'big')
+    raw = hmac.new(chain_code, data, digestmod='sha512').digest()
+    tweak = raw[:32]
+    chain_code = raw[32:]
+
+    new_secret = (int.from_bytes(secret, 'big') + int.from_bytes(tweak, 'big')) % N
+    res = version+bytes([depth+1])+fingerprint+index.to_bytes(4, 'big')
+    res += chain_code+b"\x00"+new_secret.to_bytes(32,'big')
+    return encode_base58_checksum(res)
+
+def parse_path(path: str) -> list:
+    """
+    Converts derivation path of the form 
+    m/44h/1'/0'/0/32 to int array
+    """
+    arr = path.split("/")
+    if arr[0] == "m":
+        arr = arr[1:]
+    if len(arr) == 0:
+        return []
+    if arr[-1] == "":
+        # trailing slash
+        arr = arr[:-1]
+    for i, e in enumerate(arr):
+        if e[-1] == "h" or e[-1] == "'":
+            arr[i] = int(e[:-1])+0x80000000
+        else:
+            arr[i] = int(e)
+    return arr

--- a/src/cryptoadvance/specter/devices/bitcoin_core.py
+++ b/src/cryptoadvance/specter/devices/bitcoin_core.py
@@ -136,7 +136,7 @@ def seed_to_hd_master_key(seed, testnet=False) -> str:
         raise ValueError("Provided seed should have length of 64")
 
     # Compute HMAC-SHA512 of seed
-    seed = hmac.new(b"Bitcoin seed", seed, digestmod=hashlib.sha512).digest()
+    seed = hmac.new(b"Bitcoin seed", seed, digestmod='sha512').digest()
 
     # Serialization format can be found at: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#Serialization_format
     xprv = b"\x04\x88\xad\xe4"  # Version for private mainnet
@@ -146,15 +146,7 @@ def seed_to_hd_master_key(seed, testnet=False) -> str:
     xprv += seed[32:]  # Chain code
     xprv += b"\x00" + seed[:32]  # Master key
 
-    # Double hash using SHA256
-    hashed_xprv = hashlib.sha256(xprv).digest()
-    hashed_xprv = hashlib.sha256(hashed_xprv).digest()
-
-    # Append 4 bytes of checksum
-    xprv += hashed_xprv[:4]
-
-    # Return base58
-    return b58encode(xprv)
+    return encode_base58_checksum(xprv)
 
 def derive_xpubs_from_xprv(xprv, paths:list, cli):
     """

--- a/src/cryptoadvance/specter/helpers.py
+++ b/src/cryptoadvance/specter/helpers.py
@@ -375,22 +375,6 @@ def generate_mnemonic(strength=256):
         words = mnemo.generate(strength=strength)
         return words
 
-# From https://github.com/trezor/python-mnemonic/blob/ad06157e21fc2c2145c726efbfdcf69df1350061/mnemonic/mnemonic.py#L246
-# Refactored code segments from <https://github.com/keis/base58>
-def b58encode(v: bytes) -> str:
-    alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
-
-    p, acc = 1, 0
-    for c in reversed(v):
-        acc += p * c
-        p = p << 8
-
-    string = ""
-    while acc:
-        acc, idx = divmod(acc, 58)
-        string = alphabet[idx : idx + 1] + string
-    return string
-
 # Transaction processing helpers
 
 def parse_utxo(wallet, utxo):

--- a/src/cryptoadvance/specter/helpers.py
+++ b/src/cryptoadvance/specter/helpers.py
@@ -390,31 +390,6 @@ def b58encode(v: bytes) -> str:
         acc, idx = divmod(acc, 58)
         string = alphabet[idx : idx + 1] + string
     return string
-# We need to copy it like this because HWI uses it as a dependency, but requires v0.18 which doesn't have this function.
-def seed_to_hd_master_key(seed, testnet=False) -> str:
-    if len(seed) != 64:
-        raise ValueError("Provided seed should have length of 64")
-
-    # Compute HMAC-SHA512 of seed
-    seed = hmac.new(b"Bitcoin seed", seed, digestmod=hashlib.sha512).digest()
-
-    # Serialization format can be found at: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#Serialization_format
-    xprv = b"\x04\x88\xad\xe4"  # Version for private mainnet
-    if testnet:
-        xprv = b"\x04\x35\x83\x94"  # Version for private testnet
-    xprv += b"\x00" * 9  # Depth, parent fingerprint, and child number
-    xprv += seed[32:]  # Chain code
-    xprv += b"\x00" + seed[:32]  # Master key
-
-    # Double hash using SHA256
-    hashed_xprv = hashlib.sha256(xprv).digest()
-    hashed_xprv = hashlib.sha256(hashed_xprv).digest()
-
-    # Append 4 bytes of checksum
-    xprv += hashed_xprv[:4]
-
-    # Return base58
-    return b58encode(xprv)
 
 # Transaction processing helpers
 


### PR DESCRIPTION
bip32 depends on coincurve that doesn't work on ARM like raspberry pi etc.
We only need it to derive child keys from root xprv during setup of the Core hot wallet.
This derivation is pretty easy - it's just addition modulo N.
It's not constant time, but I think that's ok-ish, there are much easier ways to get private key i.e. by sniffing communication with Core.
I also moved `seed_to_hd_master_key` function from helpers to `bitcoin_core.py` because it's used only there and not expected to be used anywhere else in Specter.

Checked against https://iancoleman.io/bip39/ - derives the same keys.