### PR TITLE
Show HWIBriddge note if device detection takes more than 5 sec

### DIFF
--- a/docs/hwibridge.md
+++ b/docs/hwibridge.md
@@ -6,16 +6,22 @@ you may also prefer to run Specter on that same remote machine.
 In such case, Specter will not be able to connect to USB devices connected to the local machine you use to access Specter.
 This is because Specter uses HWI for hardware wallets integration, which can only access devices connected directly to the machine it is running on.
 
-The following steps will help you set up a local `Specter HWIBridge`, which you could connect to the remote server and will make it detect devices connected to your local machine:
+If you have physical access to the machine Specter is running on, like with RaspiBlitz or myNode, the easiest solution is to connect your hardware wallet by USB directly to that machine's USB port.
+This will allow Specter to detect the device and continue normally.
 
-1. Run Specter normally on the remote server machine.
-2. On the local machine you are accessing Specter from, [install Specter](../README.md#how-to-run) as well and run it with the `--hwibridge` flag.
-(Note, if you are running Specter as a Tor hidden service, you will have to set up the local HWIBridge Specter as a [Tor hidden service](tor.md) as well)
-3. Then open `YOUR_LOCAL_SPECTER_URL:PORT/hwi/settings` (i.e. `http://127.0.0.1:25441/hwi/settings`).
-4. In the `Whitelisted domains` form field, enter the domain of your remote Specter server you are connecting to and click update.
-5. Now open the remote Specter server URL and go to settings.
-6. In the bottom, find `HWI Bridge URL`, and enter there the URL of your local Specter HWIBridge along with `/hwi/api/` (i.e. `http://127.0.0.1:25441/hwi/api/`), then click save.
-7. You should now be able to use hardware wallets connected via USB to your local node with the Specter running on the remote server.
+However, if you don't have physical access to the machine Specter is running on, you will need to set up a `Specter HWIBridge`.
+The following steps will help you set up a local `Specter HWIBridge`, which you could connect to the remote server and will allow it to detect devices connected to your local machine:
+
+1. On the local machine you are accessing Specter from, [install Specter](../README.md#how-to-run) and run it with the `--hwibridge` flag.
+<br><b>You could do that by downloading the binary from the [Specter's GitHub releases page](https://github.com/cryptoadvance/specter-desktop/releases), and double clicking it.</b>
+2. Then open `http://127.0.0.1:25441/hwi/settings` in your browser.
+3. In the `Whitelisted domains` form field, enter the domain of your remote Specter server you are connecting to and click update.
+4. Now open the remote Specter server you wish to use and go to settings.
+5. In the bottom, find `HWI Bridge URL`, and enter there the URL of your local Specter HWIBridge along with `/hwi/api/` (i.e. `http://127.0.0.1:25441/hwi/api/`), then click save.
+
+Now you should now be able to use hardware wallets connected via USB to your local node with the Specter running on the remote server.
 
 We are currently working to make this process much easier and simpler.
 In the meantime, if you have any further questions or need help, please either open a GitHub issue, or ask in the [Specter Telegram group](https://t.me/spectersupport).
+
+<i>(Note, if you are running Specter as a Tor hidden service and want to use HWIBridge, you will have to set up the HWIBridge as a [Tor hidden service](tor.md) as well).<i>

--- a/src/cryptoadvance/specter/templates/includes/hwi/hwi.jinja
+++ b/src/cryptoadvance/specter/templates/includes/hwi/hwi.jinja
@@ -9,11 +9,35 @@
 {# === wallet specific stuff ==== #}
 {% include 'includes/hwi/components/wallet.jinja' %}
 
-<div id="hwi_progress" class="hidden">
+<div id="hwi_progress" class="hidden" style="width: 250px;">
     <h1 id="hwi_progress_title">Processing...</h1>
     <div class="flex-center" id="hwi_progress_text">Keep your wallet connected.</div><br>
     <img src="/static/img/loader_boxes.svg">
+    <div class="flex-center hidden" id="hwi_progress_note" style="cursor: pointer;">
+        Running Specter on a remote machine? &#9654
+    </div>
+    <div id="hwi_progress_note_expand" class="hidden">
+        <br>
+        <a target="_blank" style="color: #fff;" href="https://github.com/cryptoadvance/specter-desktop/blob/master/docs/hwibridge.md">Follow this guide</a> to learn more about using hardware wallets with a remote Specter.
+    </div>
+    <br>
 </div>
+
+<script type="text/javascript">
+    document.addEventListener("DOMContentLoaded", function(){
+        let note = document.getElementById('hwi_progress_note');
+        note.addEventListener('click', (e) => {
+            let noteDetails = document.getElementById('hwi_progress_note_expand');
+            if (noteDetails.style.display == 'block') {
+                noteDetails.style.display = 'none';
+                note.innerHTML = note.innerText.substring(0, note.innerText.length - 1) + '&#9654;';
+            } else {
+                noteDetails.style.display = 'block';
+                note.innerHTML = note.innerText.substring(0, note.innerText.length - 1) + '&#9660;';
+            }
+        })
+    });
+</script>
 
 <script type="text/javascript">
     let hwiURL = '/hwi/api/';
@@ -51,6 +75,7 @@
             showHWIProgress("Detecting...", "Plug in your device");
         }
         let result = [];
+        let retryCounter = 0;
         try {
             result = await hwi.enumerate(passphrase);
             if(result!=null && deviceTypes!=null){
@@ -75,6 +100,10 @@
                 if(result!=null && devicePath!=null){
                     result = result.filter(dev => dev.path == devicePath);
                 }
+                if (retryCounter > 5) {
+                    document.getElementById('hwi_progress_note').style.display = 'block';
+                }
+                retryCounter++;
             }
         } catch (error) {
             handleHWIError(error);


### PR DESCRIPTION
This issue of using Specter with a remote node causes quite a bit of confusion, so in case the detection takes a bit long, I added here a note directing the users to our HWI Bridge doc page, which I have improved a bit as well.
Ideally, it would be best to have in that doc page a video tutorial to show how to set this up, but I guess doing that is an open task for now along...