### PR TITLE
Add Bitcoin Core node info overview

### DIFF
--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -1267,17 +1267,24 @@ def device(device_alias):
             device=device, device_alias=device_alias, purposes=purposes, wallets=wallets, error=err, specter=app.specter, rand=rand)
 
 
-
 ############### filters ##################
 
 @app.template_filter('datetime')
 def timedatetime(s):
     return format(datetime.fromtimestamp(s), "%d.%m.%Y %H:%M")
 
+
 @app.template_filter('btcamount')
 def btcamount(value):
     value = float(value)
     return "{:.8f}".format(value).rstrip("0").rstrip(".")
+
+
+@app.template_filter('bytessize')
+def bytessize(value):
+    value = float(value)
+    return '{:,.0f}'.format(value / float(1 << 30)) + " GB"
+
 
 def notify_upgrade():
     ''' If a new version is available, notifies the user via flash 

--- a/src/cryptoadvance/specter/rpc.py
+++ b/src/cryptoadvance/specter/rpc.py
@@ -197,10 +197,21 @@ class BitcoinCLI:
             return False
 
     def clone(self):
-        ''' returns a clone of self. Usefull if you want to mess with the properties '''
-        return BitcoinCLI(self.user, self.passwd, self.host, self.port, self.protocol, self.path, self.timeout)
+        """
+            Returns a clone of self.
+            Usefull if you want to mess with the properties
+        """
+        return BitcoinCLI(
+            self.user,
+            self.passwd,
+            self.host,
+            self.port,
+            self.protocol,
+            self.path,
+            self.timeout
+        )
 
-    def multi(self, calls:list, **kwargs):
+    def multi(self, calls: list, **kwargs):
         """Makes batch request to Core"""
         type(self).counter += len(calls)
         # some debug info for optimizations
@@ -210,7 +221,7 @@ class BitcoinCLI:
         headers = {'content-type': 'application/json'}
         payload = [{
             "method": method,
-            "params": args,
+            "params": args if args != [None] else [],
             "jsonrpc": "2.0",
             "id": i,
         } for i, (method, *args) in enumerate(calls)]
@@ -224,7 +235,11 @@ class BitcoinCLI:
             url, data=json.dumps(payload), headers=headers, timeout=timeout)
         self.r = r
         if r.status_code != 200:
-            raise RpcError("Server responded with error code %d: %s" % (r.status_code, r.text), r)
+            raise RpcError(
+                "Server responded with error code %d: %s" % (
+                    r.status_code, r.text
+                ), r
+            )
         r = r.json()
         return r
 
@@ -236,10 +251,15 @@ class BitcoinCLI:
             return r["result"]
         return fn
 
+
 if __name__ == '__main__':
 
-    cli = BitcoinCLI("bitcoinrpc", "foi3uf092ury97iufhjf30982hf928uew9jd209j", port=18443)
-    
+    cli = BitcoinCLI(
+        "bitcoinrpc",
+        "foi3uf092ury97iufhjf30982hf928uew9jd209j",
+        port=18443
+    )
+
     print(cli.url)
 
     print(cli.getmininginfo())

--- a/src/cryptoadvance/specter/specter.py
+++ b/src/cryptoadvance/specter/specter.py
@@ -117,7 +117,8 @@ class Specter:
                             ("getblockchaininfo", None),
                             ("getnetworkinfo", None),
                             ("getmempoolinfo", None),
-                            ("uptime", None)
+                            ("uptime", None),
+                            ("getblockhash", 0),
                         ]
                     )
                 ]
@@ -125,6 +126,11 @@ class Specter:
                 self._network_info = res[1]
                 self._info['mempool_info'] = res[2]
                 self._info['uptime'] = res[3]
+                try:
+                    self.cli.getblockfilter(res[4])
+                    self._info['blockfilterindex'] = True
+                except:
+                    self._info['blockfilterindex'] = False
                 self._is_running = True
             except Exception as e:
                 self._info = {"chain": None}

--- a/src/cryptoadvance/specter/specter.py
+++ b/src/cryptoadvance/specter/specter.py
@@ -78,7 +78,6 @@ class Specter:
         if not os.path.isdir(data_folder):
             os.makedirs(data_folder)
 
-        self._info = {"chain": None}
         self.is_checking = False
         # health check: loads config and tests rpc
         self.check()
@@ -99,22 +98,42 @@ class Specter:
             # otherwise - create one and assign unique id
         else:
             if self.config["uid"] == "":
-                self.config["uid"] = random.randint(0,256**8).to_bytes(8,'big').hex()
+                self.config["uid"] = random.randint(
+                    0, 256 ** 8
+                ).to_bytes(8, 'big').hex()
             self._save()
 
         # init arguments
-        deep_update(self.config, self.arg_config) # override loaded config
-        
+        deep_update(self.config, self.arg_config)  # override loaded config
+
         self.cli = get_cli(self.config["rpc"])
         self._is_configured = (self.cli is not None)
         self._is_running = False
         if self._is_configured:
             try:
-                self._info = self.cli.getblockchaininfo()
+                res = [
+                    r["result"] for r in self.cli.multi(
+                        [
+                            ("getblockchaininfo", None),
+                            ("getnetworkinfo", None),
+                            ("getmempoolinfo", None),
+                            ("uptime", None)
+                        ]
+                    )
+                ]
+                self._info = res[0]
+                self._network_info = res[1]
+                self._info['mempool_info'] = res[2]
+                self._info['uptime'] = res[3]
                 self._is_running = True
             except Exception as e:
+                self._info = {"chain": None}
+                self._network_info = {"subversion": '', "version": 999999}
                 logger.error("Exception %s while specter.check()" % e)
                 pass
+        else:
+            self._info = {"chain": None}
+            self._network_info = {"subversion": '', "version": 999999}
 
         if not self._is_running:
             self._info["chain"] = None
@@ -296,6 +315,20 @@ class Specter:
     @property
     def info(self):
         return self._info
+
+    @property
+    def network_info(self):
+        return self._network_info
+
+    @property
+    def bitcoin_core_version(self):
+        return self.network_info['subversion'].replace(
+            '/',
+            ''
+        ).replace(
+            'Satoshi:',
+            ''
+        )
 
     @property
     def chain(self):

--- a/src/cryptoadvance/specter/templates/includes/sidebar/components/bitcoin_core_info.jinja
+++ b/src/cryptoadvance/specter/templates/includes/sidebar/components/bitcoin_core_info.jinja
@@ -1,0 +1,35 @@
+<div id="bitcoin_core_info" class="hidden"
+style="text-align: left;">
+    <h1>Bitcoin Core Node Info:</h1>
+    {% if specter.chain %}
+        {% if specter.info['pruned'] %}
+            <p class="warning">&#9432;<br>You are using a pruned node.<br>Pruned nodes may not be able to scan for old balances when importing an existing wallet.<br>It is recommended to use Specter with an unpruned node.</p>
+            <br>
+        {% endif %}
+        <table>
+        <tr> <td style="text-align: left;">Network:<td> <td style="text-align: right;">{{specter.chain}}</td> </tr>
+        <tr> <td style="text-align: left; width: 35%;">Bitcoin Core Versoin:<td> <td style="text-align: right;">v{{specter.bitcoin_core_version}} <span class="note">({{specter.network_info['version']}})</span></td> </tr>
+        <tr> <td style="text-align: left;">Connections count:<td> <td style="text-align: right;">{{specter.network_info['connections']}}</td> </tr>
+        <tr> <td style="text-align: left;">Difficulty:<td> <td style="text-align: right;">{{specter.info['difficulty'] | int}}</td> </tr>
+        <tr> <td style="text-align: left;">Size on disk:<td> <td style="text-align: right;">{{specter.info['size_on_disk']|bytessize }}</td> </tr>
+        <tr> <td style="text-align: left;">Blocks count:<td> <td style="text-align: right;">{{specter.info['blocks']}}</td> </tr>
+        <tr> <td style="text-align: left;">Last block hash:<td> <td style="text-align: right"><code style="word-break: break-word;">{{specter.info['bestblockhash']}}</code></td> </tr>
+        <tr> <td style="text-align: left;">Mempool Size:<td> <td style="text-align: right;">{{specter.info['mempool_info'].size}} transactions</td> </tr>
+        <tr> <td style="text-align: left;">Node uptime:<td> <td style="text-align: right;">~ {{(specter.info['uptime'] / 60 // 60) | int }} Hours</td> </tr>
+        {% if specter.info['pruned'] %}
+            <tr> <td style="text-align: left;">Automatic pruning:<td> <td style="text-align: right;">{{specter.info['automatic_pruning']}}</td> </tr>
+            <tr> <td style="text-align: left;">Prune height:<td> <td style="text-align: right;">{{specter.info['pruneheight']}}</td> </tr>
+            <tr> <td style="text-align: left;">Prune target size:<td> <td style="text-align: right;">{{specter.info['prune_target_size']}}</td> </tr>
+        {% endif %}
+        </table>
+        <br>
+        {% if current_user.is_admin %}
+            <div class="row">
+                <a class="btn centered" href="/settings/bitcoin_core">
+                    <img src="/static/img/settings-status-bar.svg" style="width: 18px;"/>
+                    Configure Bitcoin Core RPC Connection
+                </a>
+            </div>
+        {% endif %}
+    {% endif %}
+</div>

--- a/src/cryptoadvance/specter/templates/includes/sidebar/components/bitcoin_core_info.jinja
+++ b/src/cryptoadvance/specter/templates/includes/sidebar/components/bitcoin_core_info.jinja
@@ -5,6 +5,9 @@ style="text-align: left;">
         {% if specter.info['pruned'] %}
             <p class="warning">&#9432;<br>You are using a pruned node.<br>Pruned nodes may not be able to scan for old balances when importing an existing wallet.<br>It is recommended to use Specter with an unpruned node.</p>
             <br>
+        {% elif not specter.info['blockfilterindex'] %}
+            <p class="warning">&#9432;<br>Your node does not have <code>blockfilterindex</code> enabled.<br>Setting <code>blockfilterindex=1</code> in your <code>bitcoin.conf</code> file is recommended as it takes just a few GB of storage<br>and helps to speed-up blockchain rescanning.</p>
+            <br>
         {% endif %}
         <table>
         <tr> <td style="text-align: left;">Network:<td> <td style="text-align: right;">{{specter.chain}}</td> </tr>

--- a/src/cryptoadvance/specter/templates/includes/sidebar/sidebar.jinja
+++ b/src/cryptoadvance/specter/templates/includes/sidebar/sidebar.jinja
@@ -4,11 +4,22 @@
         {% if specter.info["initialblockdownload"] %}
             <p class="warning">&#9432;<br>Bitcoin Core is still syncing...<br>(data might be outdated)</p>
         {% endif %}
-        <a href="/settings/" class="item core">
+        {% if specter.network_info.version < 190000 %}
+            <p class="warning">&#9432;<br>Bitcoin Core version is outdated.<br>Some features might not work...<br>(minimum required: v19.0.0).</p>
+        {% endif %}
+        {% if specter.chain %}
+            <div onclick="showPageOverlay('bitcoin_core_info')" class="item core" style="cursor: pointer;">
+            {% else %}
+            <a href="/settings/" class="item core">
+        {% endif %}
             {% from "components/bitcoin_svg.jinja" import bitcoin_svg %}
             {{ bitcoin_svg(specter.info.chain, 40) }}
+            {% include "includes/sidebar/components/bitcoin_core_info.jinja" %}
             <div>
-                Bitcoin Core<br>
+                Bitcoin Core
+                {% if specter.bitcoin_core_version != '' %}
+                    <span class="note">v{{ specter.bitcoin_core_version }}</span>
+                {% endif %}<br>
                 <small>
                     {% if specter.chain %}
                         {{specter.chain}}:
@@ -22,7 +33,11 @@
                     {% endif %}
                 </small>
             </div>
-        </a>
+        {% if specter.chain %}
+            </div>
+            {% else %}
+            </a>
+        {% endif %}
         <div class="separator">
             <span id="toggle_wallets_list" style="cursor: pointer;">Wallets &nbsp; &#9660;</span>
         </div>

--- a/src/cryptoadvance/specter/templates/includes/sidebar/sidebar.jinja
+++ b/src/cryptoadvance/specter/templates/includes/sidebar/sidebar.jinja
@@ -16,13 +16,13 @@
             {{ bitcoin_svg(specter.info.chain, 40) }}
             {% include "includes/sidebar/components/bitcoin_core_info.jinja" %}
             <div>
-                Bitcoin Core
-                {% if specter.bitcoin_core_version != '' %}
-                    <span class="note">v{{ specter.bitcoin_core_version }}</span>
-                {% endif %}<br>
+                Bitcoin Core<br>
                 <small>
                     {% if specter.chain %}
-                        {{specter.chain}}:
+                        {% if specter.bitcoin_core_version != '' %}
+                            v{{ specter.bitcoin_core_version }}
+                        {% endif %}
+                        ({{specter.chain}}):
                         {% if specter.info["blocks"] %}
                             {{ specter.info.blocks }} blocks
                         {% else %}


### PR DESCRIPTION
- Show Bitcoin Core node version on the sidebar.
- Add Bitcoin Core node info overview popup when clicking on the Bitcoin sidebar logo.
- Add warning if the user is connected to an unsupported Core version (<0.19.0).
- Add recommendation in node info if the node is pruned to use unpruned.

For now, I simply added a few stats I thought might be nice to have about the node/ blockchain etc. Still thinking/ looking for suggestions on stuff to add/ remove/ change so to organize it in a way that makes more sense.