### PR TITLE
add hwibridge binary

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,5 @@
 ## v0.6.0 August 4, 2020
-- Build: Create `specterd` binaries (#258) (@stepansnigirev)
+- Build: Create `specterd` and `hwibridge` binaries (#258, #271) (@stepansnigirev)
 - Devices: [Cobo Valut](https://cobo.com/hardware-wallet/cobo-vault) multisig support (#268) (@stepansnigirev)
 - Bugfix: Fix issues and improve performance by removing local caching (#242) (@ben-kaufman)
 - Bugfix: Fix installation issue on ARM machines by removing the BIP32 dependency (#259) (@stepansnigirev)

--- a/pyinstaller/hwibridge.py
+++ b/pyinstaller/hwibridge.py
@@ -1,0 +1,31 @@
+from logging.config import dictConfig
+from cryptoadvance.specter.cli import server
+import sys
+
+if __name__ == "__main__":
+    # central and early configuring of logging see
+    # https://flask.palletsprojects.com/en/1.1.x/logging/#basic-configuration
+    dictConfig({
+        'version': 1,
+        'formatters': {'default': {
+            'format': '[%(asctime)s] %(levelname)s in %(module)s: %(message)s',
+        }},
+        'handlers': {'wsgi': {
+            'class': 'logging.StreamHandler',
+            'stream': 'ext://flask.logging.wsgi_errors_stream',
+            'formatter': 'default'
+        }},
+        'root': {
+            'level': 'INFO',
+            'handlers': ['wsgi']
+        }
+    })
+    if "--daemon" in sys.argv:
+        print("Daemon mode is not supported in binaries yet")
+        sys.exit(1)
+    if "--debug" in sys.argv:
+        print("Debug mode is useless in binary mode, don't use it")
+        sys.exit(1)
+    if "--hwibridge" not in sys.argv:
+        sys.argv.append("--hwibridge")
+    server()

--- a/pyinstaller/hwibridge.spec
+++ b/pyinstaller/hwibridge.spec
@@ -1,0 +1,60 @@
+# -*- mode: python ; coding: utf-8 -*-
+import platform
+import subprocess
+import mnemonic, os
+
+mnemonic_path = os.path.join(mnemonic.__path__[0], "wordlist")
+
+block_cipher = None
+
+binaries = []
+if platform.system() == 'Windows':
+    binaries = [("./windll/libusb-1.0.dll", ".")]
+elif platform.system() == 'Linux':
+    if platform.processor() == 'aarch64': #ARM 64 bit
+        binaries = [("/lib/aarch64-linux-gnu/libusb-1.0.so.0", ".")]
+    else:
+        binaries = [("/lib/x86_64-linux-gnu/libusb-1.0.so.0", ".")]
+elif platform.system() == 'Darwin':
+    find_brew_libusb_proc = subprocess.Popen(['brew', '--prefix', 'libusb'], stdout=subprocess.PIPE)
+    libusb_path = find_brew_libusb_proc.communicate()[0]
+    binaries = [(libusb_path.rstrip().decode() + "/lib/libusb-1.0.dylib", ".")]
+
+a = Analysis(['hwibridge.py'],
+             binaries=binaries,
+             datas=[('../src/cryptoadvance/specter/templates', 'templates'), 
+                    ('../src/cryptoadvance/specter/static', 'static'),
+                    (mnemonic_path, 'mnemonic/wordlist'),
+             ],
+             hiddenimports=[
+                'pkg_resources.py2_warn',
+                'cryptoadvance.specter.config'
+             ],
+             hookspath=['hooks/'],
+             runtime_hooks=[],
+             excludes=[],
+             win_no_prefer_redirects=False,
+             win_private_assemblies=False,
+             cipher=block_cipher,
+             noarchive=False)
+
+if platform.system() == 'Linux':
+    import hwilib
+    a.datas += Tree('../udev', prefix='hwilib/udev')
+
+pyz = PYZ(a.pure, a.zipped_data,
+             cipher=block_cipher)
+exe = EXE(pyz,
+          a.scripts,
+          a.binaries,
+          a.zipfiles,
+          a.datas,
+          [],
+          name='hwibridge',
+          debug=False,
+          bootloader_ignore_signals=False,
+          strip=False,
+          upx=True,
+          upx_exclude=[],
+          runtime_tmpdir=None,
+          console=True )

--- a/src/cryptoadvance/specter/cli.py
+++ b/src/cryptoadvance/specter/cli.py
@@ -113,7 +113,8 @@ def server(daemon, stop, restart, force,
     if hwibridge:
         print(
             " * Running HWI Bridge mode.\n"
-            " * You can configure access to the API at: %s://%s:%d/hwi/settings"
+            " * You can configure access to the API "
+            "at: %s://%s:%d/hwi/settings"
             % (protocol, host, port)
         )
 

--- a/src/cryptoadvance/specter/cli.py
+++ b/src/cryptoadvance/specter/cli.py
@@ -111,9 +111,9 @@ def server(daemon, stop, restart, force,
         protocol = "https"
 
     if hwibridge:
-        app.logger.info(
-            "Running HWI Bridge mode, you can configure access \
-            to the API at: %s://%s:%d/hwi/settings"
+        print(
+            " * Running HWI Bridge mode.\n"
+            " * You can configure access to the API at: %s://%s:%d/hwi/settings"
             % (protocol, host, port)
         )
 


### PR DESCRIPTION
With this PR we will have `specterd` and `hwibridge` binaries in the release.
`specterd` can run on the node, `hwibridge` can run on the laptop.

I changed logger to print in the main file because logger doesn't work in production mode, and here we actually want to print.