### PR TITLE
Allow toggle passphrase when adding new device

### DIFF
--- a/src/cryptoadvance/specter/device_manager.py
+++ b/src/cryptoadvance/specter/device_manager.py
@@ -1,17 +1,14 @@
 import os
 import json
 import logging
-import time
-import zipfile
-from io import BytesIO
 from .helpers import alias, load_jsons, fslock
 from .rpc import get_default_datadir
 
+from .devices import __all__ as device_classes
+from .devices.generic import GenericDevice  # default device type
+
 logger = logging.getLogger(__name__)
 
-from .devices import __all__ as device_classes
-# default device type
-from .devices.generic import GenericDevice
 
 def get_device_class(device_type):
     """Look up device class by its type"""
@@ -19,6 +16,7 @@ def get_device_class(device_type):
         if device_type == cls.device_type:
             return cls
     return GenericDevice
+
 
 class DeviceManager:
     ''' A DeviceManager mainly manages the persistence of a device-json-structures
@@ -96,4 +94,3 @@ class DeviceManager:
     @property
     def supported_devices(self):
         return device_classes
-    

--- a/src/cryptoadvance/specter/templates/device/device.jinja
+++ b/src/cryptoadvance/specter/templates/device/device.jinja
@@ -51,7 +51,7 @@
 	<div class="spacer"></div>
 	<div class="row">
 		{% if device.supports_hwi_toggle_passphrase %}
-		<button type="button" class="btn centered" onclick="togglePassphrase()">Toggle device passphrase</button>
+		<button type="button" class="btn centered" onclick="togglePassphrase('{{ device.device_type }}')">Toggle device passphrase</button>
 		&nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp;
 		{% endif %}
 		{% if device.device_type != 'bitcoincore' %}
@@ -100,37 +100,5 @@
 				}
 			}, false);
 		});
-
-		async function togglePassphrase(){
-        	let devices = await enumerate('{{ device.device_type }}');
-			if(devices == null || devices.length == 0){
-				return;
-			}
-			let device = await selectDevice(devices, '');
-        	showHWIProgress("Processing...", `Keep your ${capitalize(device.type)} connected.`);
-			let result = null;
-			try {
-				result = await hwi.togglePassphrase(device);
-			} catch (error) {
-				handleHWIError(error);
-				return null;
-			}
-			if(!overlayIsActive()){
-				showNotification("HWI is ready again", 10000);
-				// no need to proceed at all
-				return null;
-			}
-			hidePageOverlay();
-			if (device.type == "keepkey") {
-				result = await enterPin(device, false);
-				if(result == null){
-					return null;
-				}
-				if(!('success' in result) || !result.success){
-					throw "Failed to unlock device! Invalid PIN code?";
-				}
-			}
-			showNotification("{{ device.name }} passphrase toggled successfuly", 5000)
-		}
 	</script>
 {% endblock %}

--- a/src/cryptoadvance/specter/templates/device/new_device.jinja
+++ b/src/cryptoadvance/specter/templates/device/new_device.jinja
@@ -18,6 +18,12 @@
 				<br>
 				{% include "device/components/device_type.jinja" %}
 				<p class="warning hidden" id="type_reminder">&#9432;<br>Please make sure to choose the device type before continuing</p>
+				<div id="toggle_passphrase_container" class="hidden">
+					<p>Device Management:</p>
+					<div class="row">
+						<button type="button" class="btn centered" onclick="togglePassphrase(document.getElementById('device_type').value)">Toggle device passphrase</button>
+					</div>
+				</div>
 			{% endif %}
 			<div id="cold_device">
 				<br>
@@ -171,6 +177,7 @@ upub5En4f7k8gaG2KDHvBeEYox...rFpJRHpiZ4DE
 		}
 		return false;
 	}
+
 	document.addEventListener("DOMContentLoaded", function(){
 		function setPubkeysView() {
 			var coldDevice = document.getElementById("cold_device");
@@ -182,6 +189,16 @@ upub5En4f7k8gaG2KDHvBeEYox...rFpJRHpiZ4DE
 				coldDevice.style.display = 'block';
 				hotDevice.style.display = 'none';
 			}
+			{% for cls in specter.device_manager.supported_devices %}
+            	if (deviceType.value == '{{ cls.device_type }}') {
+					if ('{{ cls.supports_hwi_toggle_passphrase }}' === 'True') {
+						document.getElementById('toggle_passphrase_container').style.display = 'block';
+					} else {
+						document.getElementById('toggle_passphrase_container').style.display = 'none';
+					}
+				}
+            {% endfor %}
+			
 		}
 		var deviceType = document.getElementById("device_type");
 		var typeReminder = document.getElementById("type_reminder");

--- a/src/cryptoadvance/specter/templates/includes/hwi/components/select_device.jinja
+++ b/src/cryptoadvance/specter/templates/includes/hwi/components/select_device.jinja
@@ -92,4 +92,36 @@
         }
         return null;
     }
+
+    async function togglePassphrase(deviceType){
+        let devices = await enumerate(deviceType);
+        if(devices == null || devices.length == 0){
+            return;
+        }
+        let device = await selectDevice(devices, '');
+        showHWIProgress("Processing...", `Keep your ${capitalize(device.type)} connected.`);
+        let result = null;
+        try {
+            result = await hwi.togglePassphrase(device);
+        } catch (error) {
+            handleHWIError(error);
+            return null;
+        }
+        if(!overlayIsActive()){
+            showNotification("HWI is ready again", 10000);
+            // no need to proceed at all
+            return null;
+        }
+        hidePageOverlay();
+        if (device.type == "keepkey") {
+            result = await enterPin(device, false);
+            if(result == null){
+                return null;
+            }
+            if(!('success' in result) || !result.success){
+                throw "Failed to unlock device! Invalid PIN code?";
+            }
+        }
+        showNotification(device.type + " passphrase toggled successfuly", 5000)
+    }
 </script>


### PR DESCRIPTION
Allow toggling Trezor and Keepkey passphrase before adding them, as a user might want to add passphrase protected keys but might not have passphrase enabled.