### PR TITLE
call only device-specific enumerate

### DIFF
--- a/src/cryptoadvance/specter/devices/hwi_device.py
+++ b/src/cryptoadvance/specter/devices/hwi_device.py
@@ -1,5 +1,6 @@
 from ..device import Device
 import hwilib.commands as hwi_commands
+import importlib
 
 class HWIDevice(Device):
 
@@ -14,10 +15,8 @@ class HWIDevice(Device):
 
     @classmethod
     def enumerate(cls, *args, **kwargs):
-        return [ dev for dev
-        		 in hwi_commands.enumerate(*args, **kwargs)
-        		 if dev["type"] == cls.device_type
-        		]
+        mod = importlib.import_module(f"hwilib.devices.{cls.device_type}")
+        return mod.enumerate(*args, **kwargs)
 
     @classmethod
     def get_client(cls, *args, **kwargs):


### PR DESCRIPTION
instead of calling enumerate on all devices and filtering them out just call enumerate for correct device type.

saves a lot of time on Windows where HWI enumerate is extremely slow.