### PR TITLE
Fix bug in `der_to_bytes` helper function

### DIFF
--- a/src/cryptoadvance/specter/helpers.py
+++ b/src/cryptoadvance/specter/helpers.py
@@ -291,7 +291,7 @@ def der_to_bytes(derivation):
         return b''
     if items[0] == 'm':
         items = items[1:]
-    if items[-1] == '':
+    if len(items) > 0 and items[-1] == '':
         items = items[:-1]
     res = b''
     for item in items:


### PR DESCRIPTION
This commit fixes the bug where the function fails on input: `derivation == 'm'`, which results in the following error:
```
IndexError: list index out of range
```