### PR TITLE
escape single quotes that break javascript

### DIFF
--- a/src/cryptoadvance/specter/templates/wallet/components/editable_title.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/components/editable_title.jinja
@@ -30,7 +30,7 @@
                 newtitle.style.display = 'none';
             } else {
                 newtitle.style.fontSize = '1.5em';
-                newtitle.value = '{{ title }}';
+                newtitle.value = '{{ title.replace("'","\\'") }}';
                 newtitle.style.display = 'block';
                 edit.style.display = 'none';
                 cancel.style.display = 'inline-block';

--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -392,7 +392,7 @@ class Wallet():
 
     @property
     def account_map(self):
-        return '{ "label": "' + self.name + '", "blockheight": ' + str(self.blockheight) + ', "descriptor": "' + self.recv_descriptor.replace("/", "\\/") + '" }'
+        return '{ "label": "' + self.name.replace("'","\\'") + '", "blockheight": ' + str(self.blockheight) + ', "descriptor": "' + self.recv_descriptor.replace("/", "\\/") + '" }'
 
     def getnewaddress(self, change=False):
         label = "Change" if change else "Address"


### PR DESCRIPTION
Wallet names with a single quote/apostrophe will break the javascript that enables editing the wallet name on the settings page.

To replicate, change a wallet name to include ' and try re-loading. See javascript console for errors.

This patch escapes any single quotes in the affected fields containing the wallet name. Not sure if this is the best way to do this--I didn't see any jinja filters for escaping js, like django used to have. 