### PR TITLE
fix invalid last_block, logging etc

### DIFF
--- a/src/cryptoadvance/specter/server.py
+++ b/src/cryptoadvance/specter/server.py
@@ -13,7 +13,7 @@ from .hwi_server import hwi_server
 from .user import User
 from .config import DATA_FOLDER
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 env_path = Path('.') / '.flaskenv'
 load_dotenv(env_path)
@@ -44,7 +44,6 @@ def create_app(config="cryptoadvance.specter.config.DevelopmentConfig"):
 
 def init_app(app, hwibridge=False, specter=None):
     '''  see blogpost 19nd Feb 2020 '''
-    app.logger.info("Initializing QRcode")
     # Login via Flask-Login
     app.logger.info("Initializing LoginManager")
     if specter is None:

--- a/src/cryptoadvance/specter/static/styles.css
+++ b/src/cryptoadvance/specter/static/styles.css
@@ -383,6 +383,10 @@ input, textarea, .input, select{
     min-width: 170px;
     color: #fff;
 }
+select option{
+    background: var(--cmap-bg);
+    color: #fff;
+}
 .input{
     text-align: left;
     background: rgba(255,255,255,0.05);

--- a/src/cryptoadvance/specter/wallet_manager.py
+++ b/src/cryptoadvance/specter/wallet_manager.py
@@ -8,7 +8,7 @@ from .specter_error import SpecterError
 from .wallet import Wallet
 
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 purposes = OrderedDict({
     None: "General",
@@ -209,7 +209,7 @@ Silently ignored!" % wallet_alias)
 
         self.cli.createwallet(os.path.join(self.cli_path, wallet_alias), True)
 
-        self.wallets[name] = Wallet(
+        w = Wallet(
             name,
             wallet_alias,
             "{} of {} {}".format(
@@ -235,9 +235,10 @@ Silently ignored!" % wallet_alias)
         )
         # save wallet file to disk
         if self.working_folder is not None:
-            self.wallets[name].save_to_file()
+            w.save_to_file()
         # get Wallet class instance
-        return self.wallets[name]
+        self.wallets[name] = w
+        return w
 
     def delete_wallet(self, wallet, bitcoin_datadir=get_default_datadir(), chain='main'):
         logger.info("Deleting {}".format(wallet.alias))


### PR DESCRIPTION
A few fixes:
- last_block sometimes is invalid (i.e. blockchain is reorged, or something else could happen), in this case use empty value of last_block. Seems to be the problem causing https://github.com/cryptoadvance/specter-desktop/issues/295 https://github.com/cryptoadvance/specter-desktop/issues/287 and https://github.com/cryptoadvance/specter-desktop/issues/284
- fix logging so it actually logs
- minor style change - select in chrome on linux was white-on-white
- other minor changes
