### PR TITLE
Fix issue with wrong btc amount

### DIFF
--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -232,7 +232,7 @@ def login():
 
 def redirect_login(request):
     flash('Logged in successfully.',"info")
-    if request.form.get('next'):
+    if request.form.get('next') and request.form.get('next') != 'None':
         response = redirect(request.form['next'])
     else:
         response = redirect(url_for('index'))

--- a/src/cryptoadvance/specter/templates/wallet/send/new/wallet_send.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/send/new/wallet_send.jinja
@@ -66,7 +66,7 @@
 		function addRecipient() {
 			let i = amounts.length;
 			amounts.push(0.0);
-			units.push('{% if specter.unit == "sat" %}sat{% else %}BTC{% endif %}');
+			units.push('{% if specter.unit == "sat" %}sat{% else %}btc{% endif %}');
 
 			let recipientForm = `
 			<div id="recipient_${i}" style="border-bottom: 1px solid var(--cmap-border); padding-bottom: 10px; margin-bottom: 10px;">
@@ -151,7 +151,7 @@
 
 		function toggleUnit(unitSelected, i) {
 			units[i] = unitSelected.value;
-			document.getElementById('converted_unit_label_' + i).innerHTML = (units[i] == 'sat' ? 'BTC' : 'sat');
+			document.getElementById('converted_unit_label_' + i).innerHTML = (units[i] == 'sat' ? 'btc' : 'sat');
 			calculateConvertedUnit(i);
 		}
 
@@ -235,7 +235,7 @@
 				}
 			}
 
-			if (!validateAmount('BTC', totalAmount)) {
+			if (!validateAmount('btc', totalAmount)) {
 				createPSBTButton.setAttribute('type', 'button');
 				return;
 			}


### PR DESCRIPTION
Seems like currently, when doing send, if BTC is chosen as the default unit and the user doesn't change it to sat (if he changes to sats then back to BTC everything works), the unit will still be sats.