### PR TITLE
add current specter version to sidebar

### DIFF
--- a/src/cryptoadvance/specter/helpers.py
+++ b/src/cryptoadvance/specter/helpers.py
@@ -219,13 +219,17 @@ def get_version_info():
         current_version = current_version[current_version.find('Version:')+8:]
         current_version = current_version[:current_version.find('\\n')].replace(' ','')
         # master?
-        if not re.search(r"v([\d+]).([\d+]).([\d+]).*", current_version):
-            return current_version, latest_version, False
-        return current_version, latest_version, latest_version != current_version
+
+        if current_version == 'vx.y.z-get-replaced-by-release-script':
+            current_version = 'custom'
+
+        if re.search(r"v([\d+]).([\d+]).([\d+]).*", current_version):
+            return current_version, latest_version, latest_version != current_version
+        return current_version, latest_version, False
     except:
         # if pip is not installed or we are using python3.6 or below
         # we just don't show the version
-        return "Unknown version", "Unknown version", False
+        return "unknown", "unknown", False
 
 
 def get_users_json(specter):

--- a/src/cryptoadvance/specter/specter.py
+++ b/src/cryptoadvance/specter/specter.py
@@ -440,5 +440,5 @@ class Specter:
 
     @property
     def get_version(self):
-        return get_version_info()[1]
+        return get_version_info()[0]
 

--- a/src/cryptoadvance/specter/specter.py
+++ b/src/cryptoadvance/specter/specter.py
@@ -46,6 +46,7 @@ class Specter:
         self.cli = None
         self.device_manager = None
         self.wallet_manager = None
+        self._current_version = None
 
         self.file_config = None  # what comes from config file
         self.arg_config = config  # what comes from arguments
@@ -439,6 +440,8 @@ class Specter:
         pass
 
     @property
-    def get_version(self):
-        return get_version_info()[0]
+    def specter_version(self):
+        if not self._current_version:
+            self._current_version = get_version_info()[0]
+        return self._current_version
 

--- a/src/cryptoadvance/specter/specter.py
+++ b/src/cryptoadvance/specter/specter.py
@@ -6,7 +6,7 @@ import random
 import time
 import zipfile
 from io import BytesIO
-from .helpers import deep_update, clean_psbt
+from .helpers import deep_update, clean_psbt, get_version_info
 from .rpc import autodetect_cli_confs, get_default_datadir, RpcError
 from .rpc import BitcoinCLI
 from .device_manager import DeviceManager
@@ -437,3 +437,8 @@ class Specter:
 
     def restore_from_backup(self):
         pass
+
+    @property
+    def get_version(self):
+        return get_version_info()[1]
+

--- a/src/cryptoadvance/specter/static/styles.css
+++ b/src/cryptoadvance/specter/static/styles.css
@@ -344,6 +344,7 @@ button.btn{
     justify-content: flex-end;
     font-size: 0.7em;
     flex-grow: 1;
+    padding-bottom: 10px;
 }
 .footer img{
     width: 85px;

--- a/src/cryptoadvance/specter/templates/includes/sidebar/sidebar.jinja
+++ b/src/cryptoadvance/specter/templates/includes/sidebar/sidebar.jinja
@@ -94,7 +94,15 @@
             <a href="https://github.com/cryptoadvance/" target="_blank">
                 <img src="/static/img/ca.png">
             </a>
-	    <span>Specter v<strong>{{ specter.get_version }}</strong></span>
+	    <span>Specter Version: 
+		<strong>
+		    {% if specter.get_version == 'vx.y.z-get-replaced-by-release-script' %}
+			custom
+    		    {% else %}
+			{{ specter.get_version }}
+		    {% endif %}
+		</strong>
+	    </span>
         </div>
     </nav>
     <div id="side-expand">

--- a/src/cryptoadvance/specter/templates/includes/sidebar/sidebar.jinja
+++ b/src/cryptoadvance/specter/templates/includes/sidebar/sidebar.jinja
@@ -94,6 +94,7 @@
             <a href="https://github.com/cryptoadvance/" target="_blank">
                 <img src="/static/img/ca.png">
             </a>
+	    <span>Specter v<strong>{{ specter.get_version }}</strong></span>
         </div>
     </nav>
     <div id="side-expand">

--- a/src/cryptoadvance/specter/templates/includes/sidebar/sidebar.jinja
+++ b/src/cryptoadvance/specter/templates/includes/sidebar/sidebar.jinja
@@ -94,15 +94,7 @@
             <a href="https://github.com/cryptoadvance/" target="_blank">
                 <img src="/static/img/ca.png">
             </a>
-	    <span>Specter Version: 
-		<strong>
-		    {% if specter.get_version == 'vx.y.z-get-replaced-by-release-script' %}
-			custom
-    		    {% else %}
-			{{ specter.get_version }}
-		    {% endif %}
-		</strong>
-	    </span>
+	    <span>Specter Version: <strong>{{ specter.specter_version }}</strong></span>
         </div>
     </nav>
     <div id="side-expand">


### PR DESCRIPTION
I've been playing around with various features of Specter for a guide I'm writing, and when I stumble on bugs I realized it'd be helpful if the Specter version was visible on screenshots:
![Screen Shot 2020-08-30 at 7 28 23 PM](https://user-images.githubusercontent.com/448644/91672950-12b69a00-eaf7-11ea-871b-50d8161efd70.png)

I'm new to this codebase, so unsure whether to use `{{ current_version }}` in the template instead. Locally, this was displaying `vx.y.z-get-replaced-by-release-script` (I think this comes from [setup.py](https://github.com/cryptoadvance/specter-desktop/blob/f9b04003a13c79465f0e02da20ddfcad9546b070/setup.py#L17)).