### PR TITLE
fixes #256 - btc-node-config via env-vars

### DIFF
--- a/src/cryptoadvance/specter/cli.py
+++ b/src/cryptoadvance/specter/cli.py
@@ -187,6 +187,7 @@ def bitcoind(debug, mining, docker_tag):
     from .bitcoind import (BitcoindDockerController,
                            fetch_wallet_addresses_for_mining)
 
+    logging.getLogger().setLevel(logging.INFO)
     mining_every_x_seconds = 15
     if debug:
         logging.getLogger().setLevel(logging.DEBUG)

--- a/src/cryptoadvance/specter/rpc.py
+++ b/src/cryptoadvance/specter/rpc.py
@@ -20,6 +20,9 @@ def get_default_datadir():
 
 
 def get_rpcconfig(datadir=get_default_datadir()):
+    ''' returns the bitcoin.conf configurations (multiple) in a datastructure
+        for all networks of a specific datadir.
+    ''' 
     config = {
         "bitcoin.conf": {
             "default": {},
@@ -112,13 +115,37 @@ def detect_cli_confs(config=None, datadir=get_default_datadir()):
         cli_arr.append(conf)
     return cli_arr
 
+def detect_cli_confs_via_env():
+    ''' returns an array which might contain one configmap derived from Env-Vars
+        Env-Vars: BTC_RPC_USER, BTC_RPC_PASSWORD, BTC_RPC_HOST, BTC_RPC_PORT
+        configmap: {"user":"user","passwd":"password","host":"host","port":"port","protocol":"https"}
+    '''
+    cli_arr = []
+    if os.getenv("BTC_RPC_USER") and os.getenv("BTC_RPC_PASSWORD") and \
+        os.getenv("BTC_RPC_HOST") and os.getenv("BTC_RPC_PORT") :
+        logger.info("Detected RPC-Config on Environment-Variables")
+        env_conf = {
+            "user"    : os.getenv("BTC_RPC_USER"),
+            "passwd"  : os.getenv("BTC_RPC_PASSWORD"),
+            "host"    : os.getenv("BTC_RPC_HOST"),
+            "port"    : os.getenv("BTC_RPC_PORT"),
+            "protocol": os.getenv("BTC_RPC_PROTOCOL","https") # https by default
+        }
+        cli_arr.append(env_conf)
+    return cli_arr
 
 def autodetect_cli_confs(datadir=get_default_datadir(), port=None):
+    ''' Returns an array of valid and working configurations which
+        got autodetected.
+        autodetection checks env-vars and bitcoin-data-dirs
+    '''
     if port == "":
         port = None
     if port is not None:
         port = int(port)
-    conf_arr = detect_cli_confs(datadir=datadir)
+    conf_arr = []
+    conf_arr.extend(detect_cli_confs_via_env())
+    conf_arr.extend(detect_cli_confs(datadir=datadir))
     available_conf_arr = []
     if len(conf_arr) > 0:
         for conf in conf_arr:

--- a/src/cryptoadvance/specter/templates/settings/bitcoin_core_settings.jinja
+++ b/src/cryptoadvance/specter/templates/settings/bitcoin_core_settings.jinja
@@ -18,9 +18,10 @@
 				<p class="tool-tip__info">
 					<span class="info">
 						<span class="info__title">Setting Bitcoin Core Data Directory<br></span><br>
-						When auto-detect is on, Specter will attempt to automatically locate your Bitcoin data directory and load your node configurations from it.<br><br>
+						When auto-detect is on, Specter will check for Environment-Variables (BTC_RPC_USER, BTC_RPC_PASSWORD, BTC_RPC_HOST, BTC_RPC_PORT) to configure the connection or 
+						attempt to automatically locate your Bitcoin data directory and load your node configurations from it.<br><br>
 						However, if your Bitcoin Core data directory is not located at the default location, you will need to enter its path here so Specter will be able to locate it.<br><br>
-						If you are connecting to a remote node, you can disable the auto-detect feature and enter the node's configurations manually below.
+						If you are connecting to a specific remote node, you can disable the auto-detect feature and enter the node's configurations manually below.
 					</span>
 				</p>
 			</div>


### PR DESCRIPTION
copied from the info-popup below:

When auto-detect is on, Specter will check for Environment-Variables (BTC_RPC_USER, BTC_RPC_PASSWORD, BTC_RPC_HOST, BTC_RPC_PORT) to configure the connection or attempt to automatically locate your Bitcoin data 
directory and load your node configurations from it.