### PR TITLE
fix logging: set root-logger, not local one

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
     - [Using the Specter Desktop app](#using-the-specter-desktop-app)
     - [Installing Specter from Pip](#installing-specter-from-pip)
   - [Detailed instructions](#detailed-instructions)
+  - [Errors, doubts.. Read our FAQ!](#errors-doubts-read-our-faq)
   - [A few screenshots](#a-few-screenshots)
     - [Adding a new device](#adding-a-new-device)
     - [Creating a new wallet](#creating-a-new-wallet)

--- a/src/cryptoadvance/specter/helpers.py
+++ b/src/cryptoadvance/specter/helpers.py
@@ -189,7 +189,7 @@ def set_loglevel(app, loglevel_string):
         "DEBUG" : logging.DEBUG
     }
     app.logger.setLevel(loglevels[loglevel_string])
-    logger.setLevel(loglevels[loglevel_string])
+    logging.getLogger().setLevel(loglevels[loglevel_string])
 
 
 def get_loglevel(app):


### PR DESCRIPTION
Another fix for logging. At least this fixes messages like "DEBUG in connectionpool" but i still have "INFO in _internal" which somehow doesn't seem to be impacted by this change.
At least a slight improvement.