### PR TITLE
Write full integer to prevent jinja exception

### DIFF
--- a/src/cryptoadvance/specter/templates/wallet/send/sign/wallet_send_sign_psbt.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/send/sign/wallet_send_sign_psbt.jinja
@@ -94,8 +94,8 @@
 				<h2 class="tx_details_header">Transaction Info</h2>
 				<p style="text-align: left; background-color: #131a24; padding: 10px; line-height: 2; border-radius: 15px;">
 					<b>Transaction id:</b> {{ psbt['tx']['txid'] }}<br>
-					<b>Total fee:</b> {{ (psbt['fee'] * 1e8) |  btcamount }} sats<br>
-					<b>Fee rate:</b> {{ (psbt['fee'] * 1e8 / psbt['tx']['weight']) |  btcamount }} sats/vbyte<br>
+					<b>Total fee:</b> {{ (psbt['fee'] * 100000000) |  btcamount }} sats<br>
+					<b>Fee rate:</b> {{ (psbt['fee'] * 100000000 / psbt['tx']['weight']) |  btcamount }} sats/vbyte<br>
 					<b>Size:</b> {{ psbt['tx']['vsize'] }} vbytes<br>
 					<b>Inputs count:</b> {{ psbt['tx']['vin'] | length }}<br>
 					<b>Outputs count:</b> {{ psbt['tx']['vout'] | length }}


### PR DESCRIPTION
I noticed that when I create or view a new unsigned transaction, I get the following jinja exception stack trace:
```
Traceback (most recent call last):
  File "/home/hodlwave/specter-desktop/.env/lib/python3.8/site-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/hodlwave/specter-desktop/.env/lib/python3.8/site-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/hodlwave/specter-desktop/.env/lib/python3.8/site-packages/flask_login/utils.py", line 269, in decorated_view
    return func(*args, **kwargs)
  File "/home/hodlwave/specter-desktop/src/cryptoadvance/specter/controller.py", line 1063, in wallet_sendnew
    return render_template("wallet/send/sign/wallet_send_sign_psbt.jinja", psbt=psbt, labels=labels,
  File "/home/hodlwave/specter-desktop/.env/lib/python3.8/site-packages/flask/templating.py", line 138, in render_template
    ctx.app.jinja_env.get_or_select_template(template_name_or_list),
  File "/home/hodlwave/specter-desktop/.env/lib/python3.8/site-packages/jinja2/environment.py", line 869, in get_or_select_template
    return self.get_template(template_name_or_list, parent, globals)
  File "/home/hodlwave/specter-desktop/.env/lib/python3.8/site-packages/jinja2/environment.py", line 830, in get_template
    return self._load_template(name, self.make_globals(globals))
  File "/home/hodlwave/specter-desktop/.env/lib/python3.8/site-packages/jinja2/environment.py", line 804, in _load_template
    template = self.loader.load(self, name, globals)
  File "/home/hodlwave/specter-desktop/.env/lib/python3.8/site-packages/jinja2/loaders.py", line 125, in load
    code = environment.compile(source, name, filename)
  File "/home/hodlwave/specter-desktop/.env/lib/python3.8/site-packages/jinja2/environment.py", line 591, in compile
    self.handle_exception(exc_info, source_hint=source_hint)
  File "/home/hodlwave/specter-desktop/.env/lib/python3.8/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/home/hodlwave/specter-desktop/.env/lib/python3.8/site-packages/jinja2/_compat.py", line 37, in reraise
    raise value.with_traceback(tb)
  File "/home/hodlwave/specter-desktop/src/cryptoadvance/specter/templates/wallet/send/sign/wallet_send_sign_psbt.jinja", line 97, in 
    Total fee: {{ (psbt['fee'] * 1e8) |  btcamount }} sats

  File "/home/hodlwave/specter-desktop/.env/lib/python3.8/site-packages/jinja2/environment.py", line 497, in _parse
    return Parser(self, source, name, encode_filename(filename)).parse()
  File "/home/hodlwave/specter-desktop/.env/lib/python3.8/site-packages/jinja2/parser.py", line 901, in parse
    result = nodes.Template(self.subparse(), lineno=1)
  File "/home/hodlwave/specter-desktop/.env/lib/python3.8/site-packages/jinja2/parser.py", line 883, in subparse
    rv = self.parse_statement()
  File "/home/hodlwave/specter-desktop/.env/lib/python3.8/site-packages/jinja2/parser.py", line 130, in parse_statement
    return getattr(self, 'parse_' + self.stream.current.value)()
  File "/home/hodlwave/specter-desktop/.env/lib/python3.8/site-packages/jinja2/parser.py", line 268, in parse_block
    node.body = self.parse_statements(('name:endblock',), drop_needle=True)
  File "/home/hodlwave/specter-desktop/.env/lib/python3.8/site-packages/jinja2/parser.py", line 165, in parse_statements
    result = self.subparse(end_tokens)
  File "/home/hodlwave/specter-desktop/.env/lib/python3.8/site-packages/jinja2/parser.py", line 875, in subparse
    add_data(self.parse_tuple(with_condexpr=True))
  File "/home/hodlwave/specter-desktop/.env/lib/python3.8/site-packages/jinja2/parser.py", line 620, in parse_tuple
    args.append(parse())
  File "/home/hodlwave/specter-desktop/.env/lib/python3.8/site-packages/jinja2/parser.py", line 432, in parse_expression
    return self.parse_condexpr()
  File "/home/hodlwave/specter-desktop/.env/lib/python3.8/site-packages/jinja2/parser.py", line 437, in parse_condexpr
    expr1 = self.parse_or()
  File "/home/hodlwave/specter-desktop/.env/lib/python3.8/site-packages/jinja2/parser.py", line 450, in parse_or
    left = self.parse_and()
  File "/home/hodlwave/specter-desktop/.env/lib/python3.8/site-packages/jinja2/parser.py", line 459, in parse_and
    left = self.parse_not()
  File "/home/hodlwave/specter-desktop/.env/lib/python3.8/site-packages/jinja2/parser.py", line 470, in parse_not
    return self.parse_compare()
  File "/home/hodlwave/specter-desktop/.env/lib/python3.8/site-packages/jinja2/parser.py", line 474, in parse_compare
    expr = self.parse_math1()
  File "/home/hodlwave/specter-desktop/.env/lib/python3.8/site-packages/jinja2/parser.py", line 496, in parse_math1
    left = self.parse_concat()
  File "/home/hodlwave/specter-desktop/.env/lib/python3.8/site-packages/jinja2/parser.py", line 507, in parse_concat
    args = [self.parse_math2()]
  File "/home/hodlwave/specter-desktop/.env/lib/python3.8/site-packages/jinja2/parser.py", line 517, in parse_math2
    left = self.parse_pow()
  File "/home/hodlwave/specter-desktop/.env/lib/python3.8/site-packages/jinja2/parser.py", line 528, in parse_pow
    left = self.parse_unary()
  File "/home/hodlwave/specter-desktop/.env/lib/python3.8/site-packages/jinja2/parser.py", line 546, in parse_unary
    node = self.parse_primary()
  File "/home/hodlwave/specter-desktop/.env/lib/python3.8/site-packages/jinja2/parser.py", line 577, in parse_primary
    self.stream.expect('rparen')
  File "/home/hodlwave/specter-desktop/.env/lib/python3.8/site-packages/jinja2/lexer.py", line 381, in expect
    raise TemplateSyntaxError("expected token %r, got %r" %
jinja2.exceptions.TemplateSyntaxError: expected token ')', got 'e8'
```

The `1e8` in `Total fee: {{ (psbt['fee'] * 1e8) |  btcamount }} sat` appeared to be the issue since the exception disappeared after making this change. Not sure what to make of it beyond that since I haven't worked with jinja before. 