### PR TITLE
set logger level to INFO by default

### DIFF
--- a/pyinstaller/specterd.py
+++ b/pyinstaller/specterd.py
@@ -8,11 +8,11 @@ if __name__ == "__main__":
     # https://flask.palletsprojects.com/en/1.1.x/logging/#basic-configuration
     
     ch = logging.StreamHandler()
-    ch.setLevel(logging.DEBUG)
+    ch.setLevel(logging.INFO)
     formatter = logging.Formatter('[%(asctime)s] %(levelname)s in %(module)s: %(message)s')
     ch.setFormatter(formatter)
     logging.getLogger().addHandler(ch)
-    logging.getLogger().setLevel(logging.DEBUG)
+    logging.getLogger().setLevel(logging.INFO)
     logging.getLogger(__name__).info("Logging configured")
         
     if "--daemon" in sys.argv:

--- a/src/cryptoadvance/specter/__main__.py
+++ b/src/cryptoadvance/specter/__main__.py
@@ -7,10 +7,10 @@ if __name__ == "__main__":
     # https://flask.palletsprojects.com/en/1.1.x/logging/#basic-configuration
     # However the dictConfig doesn't work, so let's do something similiar programatically
     ch = logging.StreamHandler()
-    ch.setLevel(logging.DEBUG)
+    ch.setLevel(logging.INFO)
     formatter = logging.Formatter('[%(asctime)s] %(levelname)s in %(module)s: %(message)s')
     ch.setFormatter(formatter)
     logging.getLogger().addHandler(ch)
-    logging.getLogger().setLevel(logging.DEBUG)
+    logging.getLogger().setLevel(logging.INFO)
     logging.getLogger(__name__).info("Logging configured")
     cli()


### PR DESCRIPTION
Otherwise we get a huuuuge number of debug messages from requests module.
If someone wants to see debug messages, we should be able to configure it from general settings of Specter.