### PR TITLE
fix load_jsons and wallet manager update

### DIFF
--- a/src/cryptoadvance/specter/helpers.py
+++ b/src/cryptoadvance/specter/helpers.py
@@ -60,19 +60,26 @@ def deep_update(d, u):
 
 
 def load_jsons(folder, key=None):
-    files = [f for f in os.listdir(folder) if f.endswith(".json")]
+    # get all json files (not hidden)
+    files = [f for f in os.listdir(folder)
+             if f.endswith(".json") and
+             not f.startswith(".")
+            ]
     files.sort(key=lambda x: os.path.getmtime(os.path.join(folder, x)))
     dd = OrderedDict()
     for fname in files:
-        with fslock:
-            with open(os.path.join(folder, fname)) as f:
-                d = json.load(f)
-        if key is None:
-            dd[fname[:-5]] = d
-        else:
-            d["fullpath"] = os.path.join(folder, fname)
-            d["alias"] = fname[:-5]
-            dd[d[key]] = d
+        try:
+            with fslock:
+                with open(os.path.join(folder, fname)) as f:
+                    d = json.load(f)
+            if key is None:
+                dd[fname[:-5]] = d
+            else:
+                d["fullpath"] = os.path.join(folder, fname)
+                d["alias"] = fname[:-5]
+                dd[d[key]] = d
+        except:
+            logger.error(f"Can't load json file {fname}")
     return dd
 
 

--- a/src/cryptoadvance/specter/wallet_manager.py
+++ b/src/cryptoadvance/specter/wallet_manager.py
@@ -130,10 +130,10 @@ class WalletManager:
                                                 psbt
                                             ]["tx"]["vin"]]
                                         )
-                            except RpcError:
+                            except RpcError as e:
                                 logger.warn(
-                                    "Couldn't load wallet %s into core.\
-Silently ignored!" % wallet_alias)
+                                    f"Couldn't load wallet {wallet_alias} into core.\
+Silently ignored! RPC error: {e}")
                         else:
                             if wallet_name not in existing_names:
                                 # ok wallet is already there
@@ -151,8 +151,9 @@ Silently ignored!" % wallet_alias)
                         logger.warn(
                             "Couldn't find wallet %s in core's wallets.\
 Silently ignored!" % wallet_alias)
-        except Exception as e:
-            logger.warn("Failed updating wallet manager: %s" % e)
+        # only ignore rpc errors
+        except RpcError as e:
+            logger.error(f"Failed updating wallet manager. RPC error: {e}")
         # add new wallets
         for k in wallets:
             self.wallets[k] = wallets[k]


### PR DESCRIPTION
load_jsons was failing even if only one of the json files is damaged.
wallet manager was ignoring all errors.
This caused problems when a single empty json file was preventing all wallets from appearing in Specter.

With this PR load_jsons will load all files it can even if some of them are damaged.
Wallet manager will only ignore RPC errors (i.e. Core is not running).