### PR TITLE
Use Tor to get pruned node blockchain data and connect to remote Core node

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,6 @@ hwi==1.1.2
 pyserial==3.4
 python-dotenv==0.13.0
 requests==2.23.0
+pysocks==1.7.1
 six==1.12.0
 stem==1.8.0

--- a/src/cryptoadvance/specter/rpc.py
+++ b/src/cryptoadvance/specter/rpc.py
@@ -265,7 +265,7 @@ class BitcoinRPC:
         if "wallet" in kwargs:
             url = url+"/wallet/{}".format(kwargs["wallet"])
         r = None
-        if 'localhost:' not in url and '127.0.0.1:' not in url:
+        if '.onion' in url:
             try:
                 requests_session = requests.Session()
                 requests_session = requests.Session()

--- a/src/cryptoadvance/specter/rpc.py
+++ b/src/cryptoadvance/specter/rpc.py
@@ -264,8 +264,29 @@ class BitcoinRPC:
         url = self.url
         if "wallet" in kwargs:
             url = url+"/wallet/{}".format(kwargs["wallet"])
-        r = requests.post(
-            url, data=json.dumps(payload), headers=headers, timeout=timeout)
+        r = None
+        if 'localhost:' not in url and '127.0.0.1:' not in url:
+            try:
+                requests_session = requests.Session()
+                requests_session = requests.Session()
+                requests_session.proxies = {}
+                requests_session.proxies['http'] = 'socks5h://localhost:9050'
+                requests_session.proxies['https'] = 'socks5h://localhost:9050'
+                r = requests_session.post(
+                    url,
+                    data=json.dumps(payload),
+                    headers=headers,
+                    timeout=timeout
+                )
+            except Exception:
+                pass  # Tor call failed
+        if r is None:
+            r = requests.post(
+                url,
+                data=json.dumps(payload),
+                headers=headers,
+                timeout=timeout
+            )
         self.r = r
         if r.status_code != 200:
             raise RpcError(

--- a/src/cryptoadvance/specter/rpc.py
+++ b/src/cryptoadvance/specter/rpc.py
@@ -268,7 +268,6 @@ class BitcoinRPC:
         if '.onion' in url:
             try:
                 requests_session = requests.Session()
-                requests_session.proxies = {}
                 requests_session.proxies['http'] = 'socks5h://localhost:9050'
                 requests_session.proxies['https'] = 'socks5h://localhost:9050'
                 r = requests_session.post(

--- a/src/cryptoadvance/specter/rpc.py
+++ b/src/cryptoadvance/specter/rpc.py
@@ -268,7 +268,6 @@ class BitcoinRPC:
         if '.onion' in url:
             try:
                 requests_session = requests.Session()
-                requests_session = requests.Session()
                 requests_session.proxies = {}
                 requests_session.proxies['http'] = 'socks5h://localhost:9050'
                 requests_session.proxies['https'] = 'socks5h://localhost:9050'

--- a/src/cryptoadvance/specter/templates/includes/sidebar/components/bitcoin_core_info.jinja
+++ b/src/cryptoadvance/specter/templates/includes/sidebar/components/bitcoin_core_info.jinja
@@ -1,5 +1,4 @@
-<div id="bitcoin_core_info" class="hidden"
-style="text-align: left;">
+<div id="bitcoin_core_info" class="hidden" style="text-align: left; max-width: 500px;">
     <h1>Bitcoin Core Node Info:</h1>
     {% if specter.chain %}
         {% if specter.info['pruned'] %}

--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -432,18 +432,26 @@ class Wallet():
             for tx in existing
         ])
         # handle missing transactions now
-        # TODO: do it over Tor
+        # if Tor is running, requests will be sent over Tor
         if explorer is not None:
+            try:
+                requests_session = requests.Session()
+                requests_session.proxies = {}
+                requests_session.proxies['http'] = 'socks5h://localhost:9050'
+                requests_session.proxies['https'] = 'socks5h://localhost:9050'
+                requests_session.get(explorer)
+            except Exception:
+                requests_session = requests.Session()
             # make sure there is no trailing /
             explorer = explorer.rstrip("/")
             try:
                 # get raw transactions
-                raws = [requests.get(
+                raws = [requests_session.get(
                             f"{explorer}/api/tx/{tx['txid']}/hex"
                             ).text
                         for tx in missing]
                 # get proofs
-                proofs = [requests.get(
+                proofs = [requests_session.get(
                             f"{explorer}/api/tx/{tx['txid']}/merkleblock-proof"
                             ).text
                           for tx in missing]

--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -436,7 +436,6 @@ class Wallet():
         if explorer is not None:
             try:
                 requests_session = requests.Session()
-                requests_session.proxies = {}
                 requests_session.proxies['http'] = 'socks5h://localhost:9050'
                 requests_session.proxies['https'] = 'socks5h://localhost:9050'
                 requests_session.get(explorer)


### PR DESCRIPTION
Fix #363 

Notes:
- Not tested yet, should work in theory though (if Tor is running) and should anyway not break anything if Tor couldn't be connected to. But needs to first be tested (I'll try to check connecting to remote Tor node, @stepansnigirev can you try maybe the rescan UTXO on a pruned node, can set explorer to Blockstream's `http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion/`)
- I made connecting to remote Bitcoin Core node use Tor by default, since Tor will cause calls to be significantly slower, it might make more sense to add this as an option in settings? Or only for `.onion`s?

Edit:

Tested connecting to myNode Bitcoin Core over Tor, works.