### PR TITLE
faster rpc

### DIFF
--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -496,7 +496,7 @@ def bitcoin_core_settings():
                 err = 'Fail to connect to the node configured: {}'.format(e)
         elif action == "save":
             if current_user.is_admin:
-                app.specter.update_rpc(
+                success = app.specter.update_rpc(
                     user=user,
                     password=password,
                     port=port,
@@ -505,6 +505,8 @@ def bitcoin_core_settings():
                     autodetect=autodetect,
                     datadir=datadir
                 )
+                if not success:
+                    flash("Failed connecting to the node","error")
             app.specter.check()
 
     return render_template(

--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -210,7 +210,7 @@ def login():
                 app.logger.info("AUDIT: Failed to check password")
                 return render_template('login.jinja', specter=app.specter, data={'controller':'controller.login'}), 401
             rpc = app.specter.rpc.clone()
-            rpc.passwd = request.form['password']
+            rpc.password = request.form['password']
             if rpc.test_connection():
                 app.login('admin')
                 app.logger.info("AUDIT: Successfull Login via RPC-credentials")
@@ -453,7 +453,7 @@ def bitcoin_core_settings():
         return redirect("/")
     rpc = app.specter.config['rpc']
     user = rpc['user']
-    passwd = rpc['password']
+    password = rpc['password']
     port = rpc['port']
     host = rpc['host']
     protocol = 'http'
@@ -471,7 +471,7 @@ def bitcoin_core_settings():
             if autodetect:
                 datadir = request.form['datadir']
             user = request.form['username']
-            passwd = request.form['password']
+            password = request.form['password']
             port = request.form['port']
             host = request.form['host']
 
@@ -485,7 +485,7 @@ def bitcoin_core_settings():
             try:
                 test = app.specter.test_rpc(
                     user=user,
-                    password=passwd,
+                    password=password,
                     port=port,
                     host=host,
                     protocol=protocol,
@@ -498,7 +498,7 @@ def bitcoin_core_settings():
             if current_user.is_admin:
                 app.specter.update_rpc(
                     user=user,
-                    password=passwd,
+                    password=password,
                     port=port,
                     host=host,
                     protocol=protocol,
@@ -513,7 +513,7 @@ def bitcoin_core_settings():
         autodetect=autodetect,
         datadir=datadir,
         username=user,
-        password=passwd,
+        password=password,
         port=port,
         host=host,
         protocol=protocol,

--- a/src/cryptoadvance/specter/rpc.py
+++ b/src/cryptoadvance/specter/rpc.py
@@ -162,10 +162,10 @@ def autodetect_rpc_confs(datadir=get_default_datadir(), port=None):
             try:
                 rpc.getmininginfo()
                 available_conf_arr.append(conf)
-            except requests.exceptions.RequestException:
-                pass
+            except requests.exceptions.RequestException as e:
+                logger.info(f"requests exception: {rpc.host}:{rpc.port} {e}")
             except Exception as e:
-                pass
+                logger.info(f"exception: {rpc.host}:{rpc.port} {e}")
     return available_conf_arr
 
 class RpcError(Exception):

--- a/src/cryptoadvance/specter/specter.py
+++ b/src/cryptoadvance/specter/specter.py
@@ -275,9 +275,10 @@ class Specter:
                 self.config["rpc"][k] = kwargs[k]
                 need_update = True
         if need_update:
-            self.rpc = get_rpc(self.config["rpc"], self.rpc)
+            self.rpc = get_rpc(self.config["rpc"], None)
             self._save()
             self.check()
+        return self.rpc is not None
 
     def update_auth(self, auth):
         ''' simply persisting the current auth-choice '''

--- a/src/cryptoadvance/specter/specter.py
+++ b/src/cryptoadvance/specter/specter.py
@@ -128,8 +128,9 @@ class Specter:
         # init arguments
         deep_update(self.config, self.arg_config)  # override loaded config
 
-        # update rpc if something changed
-        self.rpc = get_rpc(self.config["rpc"], self.rpc)
+        # update rpc if something doesn't work
+        if self.rpc is None or not self.rpc.test_connection():
+            self.rpc = get_rpc(self.config["rpc"], self.rpc)
         self._is_configured = (self.rpc is not None)
         self._is_running = False
         if self._is_configured:
@@ -274,6 +275,7 @@ class Specter:
                 self.config["rpc"][k] = kwargs[k]
                 need_update = True
         if need_update:
+            self.rpc = get_rpc(self.config["rpc"], self.rpc)
             self._save()
             self.check()
 


### PR DESCRIPTION
reuse of requests session makes communication with Bitcoin Core faster.
In most cases it's not very noticeable, but sometimes it gives a huge improvement - only first call is slow, following are much faster.
I was able to reproduce such "slow connection" and had 5s requests times without session reuse whereas with session reuse only first call was slow and all others were within a few milliseconds.
It may solve problems for some people if specter's page loads are extremely slow.

It doesn't solve all issues, but at least some improvement.

Also renamed passwd to password.