### PR TITLE
Fix wizard ignoring passphase on Trezor One and Keepkey

### DIFF
--- a/src/cryptoadvance/specter/templates/wizards/singlesig_setup_wizard.jinja
+++ b/src/cryptoadvance/specter/templates/wizards/singlesig_setup_wizard.jinja
@@ -367,7 +367,10 @@
             let device;
             if (devices.length == 1) {
                 device = devices[0];
-                await unlockDevice(device);
+                let passphrase = await unlockDevice(device);
+                if (passphrase != null){
+                    device.passphrase = passphrase;
+                }
             } else {
                 // first only for now
                 device = await selectDevice(devices);


### PR DESCRIPTION
There was a mistake in the new wizard which made it ignore the passphrase when entered on the host like Trezor One and Keepkey do.