### PR TITLE
add .DS_Store to .gitignore for MacOS developers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ key.pem
 *.dmg
 pyinstaller/specterd
 pyinstaller/release
+.DS_Store


### PR DESCRIPTION
MacOS creates these hidden `.DS_Store` files that shouldn't be committed and makes using git annoying (they pollute `$ git status` and `$ git add .` will not end well).