### PR TITLE
Update README.md with note about setting server=1 for Bitcoin Core GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,11 @@ An example how to run specter server in the background (`--daemon`) with ssl cer
 python3 -m cryptoadvance.specter server --tor --cert=./cert.pem --key=./key.pem --daemon
 ```
 
-If your Bitcoin Core is using a default data folder the app should detect it automatically. If not, consider setting `rpcuser` and `rpcpassword` in the `bitcoin.conf` file or set in directly in the specter-app settings.
+### Connect Specter to Bitcoin Core
+
+If your Bitcoin Core is using a default data folder the app should detect it automatically. If not, consider setting `rpcuser` and `rpcpassword` in the `bitcoin.conf` file or set in directly in the specter-app settings. 
+
+If you are using Bitcoin Core with GUI, set `server=1` in `bitcoin.conf`. This setting allows other programs to talk to the rpc server of Bitcoin Core. It's automatically enabled when you are using bitcoind, but disabled in bitcoin-qt.
 
 If you use Specter from a remote machine and want to use it with hardware wallets connected via USB, please read [this guide on setting up HWIBridge](docs/hwibridge.md) to facilitate such connection to hardware wallets. 
 


### PR DESCRIPTION
I ran into the issue of needing to set `server=1` when connecting the Bitcoin Core GUI to Specter. I found the answer in the Telegram group along with some related info. This pull request adds that info to the Readme so that others can find the info there.