### PR TITLE
fix coldcard wallet export

### DIFF
--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -1731,6 +1731,7 @@ def device(device_alias):
 
 ############### filters ##################
 
+
 @app.template_filter("ascii20")
 def ascii20(name):
     return to_ascii20(name)

--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -37,6 +37,7 @@ from .helpers import (
     generate_mnemonic,
     get_startblock_by_chain,
     fslock,
+    to_ascii20,
 )
 from .specter import Specter
 from .specter_error import SpecterError
@@ -1729,6 +1730,10 @@ def device(device_alias):
 
 
 ############### filters ##################
+
+@app.template_filter("ascii20")
+def ascii20(name):
+    return to_ascii20(name)
 
 
 @app.template_filter("datetime")

--- a/src/cryptoadvance/specter/devices/cobo.py
+++ b/src/cryptoadvance/specter/devices/cobo.py
@@ -7,6 +7,7 @@ from binascii import a2b_base64
 from ..util import bcur
 from ..util.base43 import b43_encode
 from ..util.xpub import get_xpub_fingerprint
+from ..helpers import to_ascii20
 
 
 class Cobo(SDCardDevice):
@@ -51,7 +52,7 @@ Policy: {} of {}
 Derivation: {}
 Format: {}
 """.format(
-            wallet.name,
+            to_ascii20(wallet.name),
             wallet.sigs_required,
             len(wallet.keys),
             derivation,

--- a/src/cryptoadvance/specter/devices/coldcard.py
+++ b/src/cryptoadvance/specter/devices/coldcard.py
@@ -1,7 +1,7 @@
 import urllib
 from .sd_card_device import SDCardDevice
 from ..util.xpub import get_xpub_fingerprint
-
+from ..helpers import to_ascii20
 
 CC_TYPES = {"legacy": "BIP45", "p2sh-segwit": "P2WSH-P2SH", "bech32": "P2WSH"}
 
@@ -40,7 +40,7 @@ Policy: {} of {}
 Derivation: {}
 Format: {}
 """.format(
-            wallet.name,
+            to_ascii20(wallet.name),
             wallet.sigs_required,
             len(wallet.keys),
             derivation,

--- a/src/cryptoadvance/specter/devices/specter.py
+++ b/src/cryptoadvance/specter/devices/specter.py
@@ -4,6 +4,7 @@ from hwilib.serializations import PSBT
 from .hwi.specter_diy import enumerate as specter_enumerate, SpecterClient
 from ..helpers import to_ascii20
 
+
 class Specter(HWIDevice):
     device_type = "specter"
     name = "Specter-DIY"
@@ -40,7 +41,11 @@ class Specter(HWIDevice):
         return psbts
 
     def export_wallet(self, wallet):
-        return to_ascii20(wallet.name.replace(" ","_")) + "&" + get_wallet_qr_descriptor(wallet)
+        return (
+            to_ascii20(wallet.name.replace(" ", "_"))
+            + "&"
+            + get_wallet_qr_descriptor(wallet)
+        )
 
     @classmethod
     def enumerate(cls, *args, **kwargs):

--- a/src/cryptoadvance/specter/devices/specter.py
+++ b/src/cryptoadvance/specter/devices/specter.py
@@ -2,7 +2,7 @@ import hashlib
 from .hwi_device import HWIDevice
 from hwilib.serializations import PSBT
 from .hwi.specter_diy import enumerate as specter_enumerate, SpecterClient
-
+from ..helpers import to_ascii20
 
 class Specter(HWIDevice):
     device_type = "specter"
@@ -40,7 +40,7 @@ class Specter(HWIDevice):
         return psbts
 
     def export_wallet(self, wallet):
-        return wallet.name + "&" + get_wallet_qr_descriptor(wallet)
+        return to_ascii20(wallet.name.replace(" ","_")) + "&" + get_wallet_qr_descriptor(wallet)
 
     @classmethod
     def enumerate(cls, *args, **kwargs):

--- a/src/cryptoadvance/specter/helpers.py
+++ b/src/cryptoadvance/specter/helpers.py
@@ -42,6 +42,13 @@ def locked(customlock=fslock):
     return wrapper
 
 
+def to_ascii20(name: str) -> str:
+    """
+    Converts the name to max 20 ascii-only characters.
+    """
+    return "".join([c for c in name if c.isascii()])[:20]
+
+
 def alias(name):
     """
     Create a filesystem-friendly alias from a string.

--- a/src/cryptoadvance/specter/templates/wallet/settings/wallet_settings.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/settings/wallet_settings.jinja
@@ -169,7 +169,7 @@
 			{% if device.exportable_to_wallet %}
 				{% if device.wallet_export_type == 'file' %}
 					<a 
-					download="{{ wallet.name }}"
+					download="{{ wallet.name | ascii20 }}.txt"
 					href="data:text/plain;charset=US-ASCII,{{ device.export_wallet(wallet) }}"
 					{% if device.device_type == 'coldcard' %}
 						onclick="showNotification('Import wallet file to your ColdCard: Settings -> Multisig Wallets -> Import from SD', 0)"


### PR DESCRIPTION
1. limits wallet name to 20 ascii chars for ColdCard, Cobo and Specter-DIY
2. adds `.txt` extension to the wallet file

Fix https://github.com/cryptoadvance/specter-desktop/issues/358