### PR TITLE
cli: allow overriding of bitcoin rpc host during auto-detection

### DIFF
--- a/src/cryptoadvance/specter/cli.py
+++ b/src/cryptoadvance/specter/cli.py
@@ -34,12 +34,26 @@ def cli():
 @click.option("--debug/--no-debug", default=None)
 @click.option("--tor", is_flag=True)
 @click.option("--hwibridge", is_flag=True)
-def server(daemon, stop, restart, force, port, host, cert, key, debug, tor, hwibridge):
+@click.option("--bitcoin-rpc-host")
+def server(
+    daemon,
+    stop,
+    restart,
+    force,
+    port,
+    host,
+    cert,
+    key,
+    debug,
+    tor,
+    hwibridge,
+    bitcoin_rpc_host,
+):
     # create an app to get Specter instance
     # and it's data folder
     app = create_app()
     app.app_context().push()
-    init_app(app, hwibridge=hwibridge)
+    init_app(app, hwibridge=hwibridge, bitcoin_rpc_host=bitcoin_rpc_host)
 
     # we will store our daemon PID here
     pid_file = path.join(app.specter.data_folder, "daemon.pid")

--- a/src/cryptoadvance/specter/rpc.py
+++ b/src/cryptoadvance/specter/rpc.py
@@ -142,7 +142,7 @@ def detect_rpc_confs_via_env():
     return rpc_arr
 
 
-def autodetect_rpc_confs(datadir=get_default_datadir(), port=None):
+def autodetect_rpc_confs(datadir=get_default_datadir(), port=None, host=None):
     """Returns an array of valid and working configurations which
     got autodetected.
     autodetection checks env-vars and bitcoin-data-dirs
@@ -157,6 +157,8 @@ def autodetect_rpc_confs(datadir=get_default_datadir(), port=None):
     available_conf_arr = []
     if len(conf_arr) > 0:
         for conf in conf_arr:
+            if host is not None and "host" not in conf:
+                conf["host"] = host
             rpc = BitcoinRPC(**conf)
             if port is not None:
                 if int(rpc.port) != port:

--- a/src/cryptoadvance/specter/server.py
+++ b/src/cryptoadvance/specter/server.py
@@ -41,14 +41,17 @@ def create_app(config="cryptoadvance.specter.config.DevelopmentConfig"):
     return app
 
 
-def init_app(app, hwibridge=False, specter=None):
+def init_app(app, hwibridge=False, specter=None, bitcoin_rpc_host=None):
     """  see blogpost 19nd Feb 2020 """
     # Login via Flask-Login
     app.logger.info("Initializing LoginManager")
     if specter is None:
         # the default. If not None, then it got injected for testing
         app.logger.info("Initializing Specter")
-        specter = Specter(DATA_FOLDER)
+        conf = {}
+        if bitcoin_rpc_host:
+            conf = {"rpc": {"host": bitcoin_rpc_host}}
+        specter = Specter(DATA_FOLDER, config=conf)
 
     # version checker
     # checks for new versions once per hour

--- a/src/cryptoadvance/specter/specter.py
+++ b/src/cryptoadvance/specter/specter.py
@@ -27,14 +27,11 @@ def get_rpc(conf, old_rpc=None):
         conf["autodetect"] = True
     rpc = None
     if conf["autodetect"]:
-        if "port" in conf:
-            rpc_conf_arr = autodetect_rpc_confs(
-                datadir=os.path.expanduser(conf["datadir"]), port=conf["port"]
-            )
-        else:
-            rpc_conf_arr = autodetect_rpc_confs(
-                datadir=os.path.expanduser(conf["datadir"])
-            )
+        rpc_conf_arr = autodetect_rpc_confs(
+            datadir=os.path.expanduser(conf["datadir"]),
+            port=conf.get("port"),
+            host=conf.get("host"),
+        )
         if len(rpc_conf_arr) > 0:
             rpc = BitcoinRPC(**rpc_conf_arr[0])
     else:


### PR DESCRIPTION
This allows to use the existing auto-detection mechanism from the bitcoin
data dir, but to use a different host than the default 'localhost' that
is used at the moment. This is helpful in docker environments where
specter-desktop and bitcoind run in separate containers, since it is not
possible to connect to another container through localhost (except when
sharing the host network in the containers, which is not recommended).
By providing the hostname of the bitcoind container as `--bitcoin-rpc-host`
and mounting the bitcoind data volume into the specter-desktop container,
auto detection from the bitcoin.conf / cookie file works again without
having to supply rpc user, password, host, and port manually.