### PR TITLE
Fix display address on Specter HWI and an error when creating wallets

### DIFF
--- a/src/cryptoadvance/specter/devices/hwi/specter_diy.py
+++ b/src/cryptoadvance/specter/devices/hwi/specter_diy.py
@@ -110,6 +110,7 @@ class SpecterClient(HardwareWalletClient):
         p2sh_p2wpkh: bool,
         bech32: bool,
         redeem_script: Optional[str] = None,
+        descriptor: Optional[str] = None
     ) -> Dict[str, str]:
         """Display and return the address of specified type.
 

--- a/src/cryptoadvance/specter/devices/hwi/specter_diy.py
+++ b/src/cryptoadvance/specter/devices/hwi/specter_diy.py
@@ -110,7 +110,7 @@ class SpecterClient(HardwareWalletClient):
         p2sh_p2wpkh: bool,
         bech32: bool,
         redeem_script: Optional[str] = None,
-        descriptor: Optional[str] = None
+        descriptor: Optional[str] = None,
     ) -> Dict[str, str]:
         """Display and return the address of specified type.
 

--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -656,9 +656,12 @@ class Wallet:
             if index is None:
                 index = self.change_index if change else self.address_index
             desc = self.change_descriptor if change else self.recv_descriptor
-            result["xpubs_descriptor"] = sort_descriptor(
-                self.rpc, desc, index=index, change=change
-            )
+            try:
+                result["xpubs_descriptor"] = sort_descriptor(
+                    self.rpc, desc, index=index, change=change
+                )
+            except Exception:
+                pass
         return result
 
     def get_balance(self):


### PR DESCRIPTION
This fixes an incompatibility in the Specter DIY HWI code with the latest HWI.
Also fixes a potential crash when creating wallets, likely due to get_descriptor being called before the keypool was imported (although a bit strange)