### PR TITLE
Enable macOS dock icon

### DIFF
--- a/pyinstaller/specter_desktop.spec
+++ b/pyinstaller/specter_desktop.spec
@@ -89,7 +89,8 @@ if sys.platform == 'darwin':
             'NSAppleScriptEnabled': False,
             'NSHighResolutionCapable': 'True',
             'NSRequiresAquaSystemAppearance': 'True',
-            'LSUIElement': 1
+            'LSUIElement': 'False',
+            'LSBackgroundOnly': 'False'
         }
     )
 if sys.platform == 'linux':


### PR DESCRIPTION
Prior to this change, Specter desktop had no dock icon on macOS, only a
menu bar icon. This meant that users were forced to navigate with the
cursor to the menu bar icon and select 'Open Specter App' in order to
focus the Specter desktop window, resulting in a confusing and
cumbersome user experience.

The original commit of `specter_desktop.spec` in commit 2a799dde set the
macOS launch services `LSUIElement` key to `1` for unknown reasons.
This, along with what appears to be a default value of `False` for the
`LSBackgroundOnly` key have the effect of disabling the dock icon.

This change sets the value for both of these keys to to `False`,
enabling the dock icon to appear as expected. Experimentation showed
that eliminating one or both keys was not enough; they both must
explicitly be set to `False`.

See the Apple Information Property List Launch Services Keys developer
documentation for further details.

Fixes #455.

## References

 - https://www.cnet.com/news/prevent-an-applications-dock-icons-from-showing-in-os-x/
 - https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/LaunchServicesKeys.html

## Testing

I have not tested this by actually building the macOS DMG and installing it. I have only tested it by modifying my local Specter `Info.plist` and re-running the Specter app to see which configuration enables the dock icon. I then reflected that configuration in `specter_desktop.spec`. Please do test an actual build and install before merging.

This is the before and after diff of my `Info.plist`:

```
$ diff -C1 /Applications/Specter.app/Contents/Info.plist.before /Applications/Specter.app/Contents/Info.plist
*** /Applications/Specter.app/Contents/Info.plist.before	2020-10-16 12:32:37.000000000 +0200
--- /Applications/Specter.app/Contents/Info.plist	2020-10-16 12:32:42.000000000 +0200
***************
*** 21,25 ****
  	<key>LSBackgroundOnly</key>
! 	<true/>
  	<key>LSUIElement</key>
! 	<integer>1</integer>
  	<key>NSAppleScriptEnabled</key>
--- 21,25 ----
  	<key>LSBackgroundOnly</key>
! 	<false/>
  	<key>LSUIElement</key>
! 	<false/>
  	<key>NSAppleScriptEnabled</key>
```