### PR TITLE
Features/pip packages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,7 +43,7 @@ release_pip:
   script:
     - pip3 install setuptools wheel twine
     # verifying the version number follows vx.y.z (e.g. "v1.2.3")
-    - if ! [[ $CI_COMMIT_TAG =~ ^v[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}$ ]]; then exit 1; fi
+    - if ! [[ $CI_COMMIT_TAG =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$ ]]; then exit 1; fi
     # set version number in setup.py
     - echo Releasing $CI_COMMIT_TAG
     - sed -i "s/version=\".*/version=\"$CI_COMMIT_TAG\",/" setup.py

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,8 +51,8 @@ release_pip:
     - python3 setup.py sdist bdist_wheel
     # twine ready the password from the env-var TWINE_PASSWORD
     # Add --repository-url https://test.pypi.org/legacy/ for testing the release procedure
-    - ls -l dist && python3 -m twine upload --verbose --user __token__ dist/*
     - sha256sum dist/cryptoadvance.specter-*.tar.gz > ./dist/SHA256SUMS.txt
+    - ls -l dist && python3 -m twine upload --verbose --user __token__ dist/*
     - echo $GH_BIN_UPLOAD_PW | github-binary-upload -u gitlab_upload_release_binaries cryptoadvance/specter-desktop $CI_COMMIT_TAG ./dist/SHA256SUMS.txt ./dist/cryptoadvance.specter-*.tar.gz
 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,6 +52,9 @@ release_pip:
     # twine ready the password from the env-var TWINE_PASSWORD
     # Add --repository-url https://test.pypi.org/legacy/ for testing the release procedure
     - ls -l dist && python3 -m twine upload --verbose --user __token__ dist/*
+    - sha256sum dist/cryptoadvance.specter-*.tar.gz > ./dist/SHA256SUMS.txt
+    - echo $GH_BIN_UPLOAD_PW | github-binary-upload -u gitlab_upload_release_binaries cryptoadvance/specter-desktop $CI_COMMIT_TAG ./dist/SHA256SUMS.txt ./dist/cryptoadvance.specter-*.tar.gz
+
 
 release_binary_linux:
   image: registry.gitlab.com/cryptoadvance/specter-desktop/bionic-build:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,8 +51,8 @@ release_pip:
     - python3 setup.py sdist bdist_wheel
     # twine ready the password from the env-var TWINE_PASSWORD
     # Add --repository-url https://test.pypi.org/legacy/ for testing the release procedure
-    - sha256sum dist/cryptoadvance.specter-*.tar.gz > ./dist/SHA256SUMS.txt
     - ls -l dist && python3 -m twine upload --verbose --user __token__ dist/*
+    - sha256sum dist/cryptoadvance.specter-*.tar.gz > ./dist/SHA256SUMS.txt
     - echo $GH_BIN_UPLOAD_PW | github-binary-upload -u gitlab_upload_release_binaries cryptoadvance/specter-desktop $CI_COMMIT_TAG ./dist/SHA256SUMS.txt ./dist/cryptoadvance.specter-*.tar.gz
 
 


### PR DESCRIPTION
This PR uploads PIP-Packages to the github-release-page. It also creates sha256-hashes for the tar-package.
In combination with #496 this should make the pip-installation as a workaround for non working binaries much more attractive from a security point of view.

Testing for this is quite difficult but if this fails, at least the twine-upload is happening before that and would not fail.
So there shouldn't be anything existing in danger with this.

The version-number pattern has been adapted to semver as well so that we can at least test this with prereleases.