### PR TITLE
fix for proper namespace package cryptoadvance

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from glob import glob
 
-from setuptools import find_packages, setup
+from setuptools import find_namespace_packages, setup
 
 with open("requirements.txt") as f:
     install_reqs = f.read().strip().split("\n")
@@ -26,7 +26,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/cryptoadvance/specter-desktop",
-    packages=find_packages("src"),
+    packages=find_namespace_packages("src", include=["cryptoadvance.*"]),
     package_dir={"": "src"},
     # take METADATA.in into account, include that stuff as well (static/templates)
     include_package_data=True,


### PR DESCRIPTION
In #69 we have created the proper layout and infrastructure to do pip-releases. We decided to have "cryptoadvance.specter" as the package name and used src/cryptoadvance/specter as the directory-layout in order to maybe later have other packages within the namespace "cryptoadvance".

However, i didn't properly did this as a "namespace" package. The [dot is fine](https://www.python.org/dev/peps/pep-0423/#use-a-single-name) for the package-name but for a proper [native namespace-package](https://packaging.python.org/guides/packaging-namespace-packages/) we need to remove the __init__.py from the cryptoadvance-package and help the setup-procedure a bit with finding the package.

Not doing that results in the inability to have any other subpackage below "cryptoadvance". I've tested this on a clean checkout and the package-creation (and installation in a virtualenv) works.