### PR TITLE
update coldcard instructions to generic json

### DIFF
--- a/src/cryptoadvance/specter/templates/device/new_device.jinja
+++ b/src/cryptoadvance/specter/templates/device/new_device.jinja
@@ -61,7 +61,7 @@
 								<span class="info">
 									<span class="info__title">Using an airgapped ColdCard with MicroSD<br><br></span>
 									Export extended public keys for single-key wallets to the SD card from<br>
-									<b>Advanced → MicroSD Card → Export Wallet → Electrum Wallet</b><br><br>
+									<b>Advanced → MicroSD → Export Wallet → Generic JSON</b><br><br>
 									To export multisignature pubkeys go to <br>
 									<b>Settings → Multisig Wallets → Export XPUB</b>
 									We recommend using Native Segwit.


### PR DESCRIPTION
Generic json is better because it contains all single-sig keys in one file.
Also, electrum format is causing troubles sometimes as Electrum itself is changing the file format in a way that fingerprint and derivation path becomes unavailable.