### PR TITLE
switch to PSF's black

### DIFF
--- a/.github/workflows/zblack.yml
+++ b/.github/workflows/zblack.yml
@@ -6,7 +6,8 @@ jobs:
   black:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.2
-      - uses: mflaxman/black-action@v1.0.2
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: psf/black@stable # the default is equivalent to `black . --diff --check`.
         with:
-          args: " --check . "
+          args: ". --diff --check"


### PR DESCRIPTION
I originally had https://github.com/cryptoadvance/specter-desktop/pull/497 merged to make black work on a custom branch I host, but the PSF branch now supports the functionality we need and this PR uses them instead:
https://github.com/lgeiger/black-action/issues/12

Hopefully that should be stable the long term and not cause any problems.