### PR TITLE
change wallet export to use alias instead of name

### DIFF
--- a/src/cryptoadvance/specter/templates/wallet/settings/components/export_wallet_account_map.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/settings/components/export_wallet_account_map.jinja
@@ -5,7 +5,7 @@
     <qr-code value='{{ wallet.account_map }}' width="400"></qr-code>
     <br>
     <h2>Import this JSON file</h2>
-    <a download="{{ wallet.name }}.json" class="btn centered padded" id="export_wallet_file">Download wallet file</a>
+    <a download="{{ wallet.alias }}.json" class="btn centered padded" id="export_wallet_file">Download wallet file</a>
 <pre id="account_map" style="white-space: -moz-pre-wrap; white-space: -o-pre-wrap; word-wrap: break-word; text-align: left;">
 {{ wallet.account_map }}
 </pre>


### PR DESCRIPTION
This is useful because you get filenames like `my_wallet.json` instead of `My Wallet.json`.

These are easier to pass around via CLI tools.