### PR TITLE
specify python version <3.9 to be compatible with HWI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,5 +37,5 @@ setup(
         "Operating System :: OS Independent",
         "Framework :: Flask",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.6,<3.9",
 )


### PR DESCRIPTION
On the master branch right now I get this error:
```
ERROR: Could not find a version that satisfies the requirement hwi==1.2.0 (from -r requirements.txt (line 122)) (from versions: 1.0.0, 1.0.1, 1.0.2, 1.0.3)
ERROR: No matching distribution found for hwi==1.2.0 (from -r requirements.txt (line 122))
```

This is because hwi v`1.2.0` specifies python `<3.9`:
https://github.com/bitcoin-core/HWI/blob/1.2.0/setup.py#L150