### PR TITLE
Allow build-unix.sh to work on Arch Linux

### DIFF
--- a/pyinstaller/build-unix.sh
+++ b/pyinstaller/build-unix.sh
@@ -28,9 +28,9 @@ mkdir release
 cd dist
 cp -r ../../udev ./udev
 echo "Don't forget to set up udev rules! Check out udev folder for instructions." > README.md
-zip -r ../release/specterd-$1-`arch`-linux-gnu.zip specterd udev README.md
+zip -r ../release/specterd-"$1"-"$(uname -m)"-linux-gnu.zip specterd udev README.md
 
 cp ../electron/dist/Specter-* ./
-tar -czvf ../release/specter_desktop-$1-`arch`-linux-gnu.tar.gz Specter-* udev README.md
+tar -czvf ../release/specter_desktop-"$1"-"$(uname -m)"-linux-gnu.tar.gz Specter-* udev README.md
 
 cd ..

--- a/pyinstaller/specterd.spec
+++ b/pyinstaller/specterd.spec
@@ -14,7 +14,17 @@ elif platform.system() == 'Linux':
     if platform.processor() == 'aarch64': #ARM 64 bit
         binaries = [("/lib/aarch64-linux-gnu/libusb-1.0.so.0", ".")]
     else:
-        binaries = [("/lib/x86_64-linux-gnu/libusb-1.0.so.0", ".")]
+        candidates = [
+                "/usr/lib/libusb-1.0.so.0",
+                "/lib/x86_64-linux-gnu/libusb-1.0.so.0",
+                "/lib/aarch64-linux-gnu/libusb-1.0.so.0",
+                "/lib/arm-linux-gnueabihf/libusb-1.0.so.0",
+        ]
+        binaries = []
+        for p in candidates:
+            if os.path.isfile(p):
+                binaries = [(p, ".")]
+                break
 elif platform.system() == 'Darwin':
     find_brew_libusb_proc = subprocess.Popen(['brew', '--prefix', 'libusb'], stdout=subprocess.PIPE)
     libusb_path = find_brew_libusb_proc.communicate()[0]


### PR DESCRIPTION
Changes shell script and python script to allow `build-unix.sh` to work on Arch Linux based distros.