### PR TITLE
Release fix python version2

### DIFF
--- a/docker/electron-builder/Dockerfile
+++ b/docker/electron-builder/Dockerfile
@@ -1,3 +1,4 @@
 FROM electronuserland/builder:wine
 
-RUN apt-get update && apt-get install -y python3-pip zip unzip file apt libusb-1.0-0-dev libudev-dev
+RUN apt-get update && apt-get install -y python3.8 python3.8-dev python3-pip zip unzip file apt libusb-1.0-0-dev libudev-dev
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1


### PR DESCRIPTION
Making sure the electron-builder is using python 3.8 and not 3.6.