### PR TITLE
move backup file to separate path to avoid pacman

### DIFF
--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -375,6 +375,14 @@ def hwi_settings():
         rand=rand,
     )
 
+@app.route("/specter_backup.zip")
+@login_required
+def backup_file():
+    return send_file(
+        app.specter.specter_backup_file(),
+        attachment_filename="specter-backup.zip",
+        as_attachment=True,
+    )
 
 @app.route("/settings/general", methods=["GET", "POST"])
 @login_required
@@ -402,12 +410,6 @@ def general_settings():
                 validate_bool=validate_merkleproof_bool
             )
             app.specter.check()
-        elif action == "backup":
-            return send_file(
-                app.specter.specter_backup_file(),
-                attachment_filename="specter-backup.zip",
-                as_attachment=True,
-            )
         elif action == "restore":
             restore_devices = []
             restore_wallets = []

--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -375,6 +375,7 @@ def hwi_settings():
         rand=rand,
     )
 
+
 @app.route("/specter_backup.zip")
 @login_required
 def backup_file():
@@ -383,6 +384,7 @@ def backup_file():
         attachment_filename="specter-backup.zip",
         as_attachment=True,
     )
+
 
 @app.route("/settings/general", methods=["GET", "POST"])
 @login_required

--- a/src/cryptoadvance/specter/templates/settings/general_settings.jinja
+++ b/src/cryptoadvance/specter/templates/settings/general_settings.jinja
@@ -19,7 +19,7 @@
 			Specter Data Backup:
 			<br><br>
 			<div class="row">
-				<button type="submit" class="btn" name="action" value="backup" style="width: 100%; margin-top: -5px;">Download Specter backup files</button>
+				<a href="{{ url_for('backup_file') }}" download class="btn" style="width: 100%; margin-top: -5px;">Download Specter backup files</a>
 			</div>
 			<br>
 			<div class="tool-tip" style="float: right; margin-bottom: 5px;">


### PR DESCRIPTION
currently when you try to download specter backup you get an infinite pacman screen.
This PR moves the backup file to a separate path and replaces the button with a simple link