### PR TITLE
Show price in alternative currency specified

### DIFF
--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -383,10 +383,14 @@ def general_settings():
     explorer = app.specter.explorer
     loglevel = get_loglevel(app)
     unit = app.specter.unit
+    alt_rate = app.specter.alt_rate
+    alt_symbol = app.specter.alt_symbol
     if request.method == "POST":
         action = request.form["action"]
         explorer = request.form["explorer"]
         unit = request.form["unit"]
+        alt_rate = request.form["alt_rate"]
+        alt_symbol = request.form["alt_symbol"]
         validate_merkleproof_bool = request.form.get("validatemerkleproof") == "on"
 
         if current_user.is_admin:
@@ -398,6 +402,8 @@ def general_settings():
 
             app.specter.update_explorer(explorer, current_user)
             app.specter.update_unit(unit, current_user)
+            app.specter.update_alt_rate(alt_rate, current_user)
+            app.specter.update_alt_symbol(alt_symbol, current_user)
             app.specter.update_merkleproof_settings(
                 validate_bool=validate_merkleproof_bool
             )
@@ -483,6 +489,8 @@ This may take a few hours to complete.",
         loglevel=loglevel,
         validate_merkle_proofs=app.specter.config.get("validate_merkle_proofs") is True,
         unit=unit,
+        alt_rate=alt_rate,
+        alt_symbol=alt_symbol,
         specter=app.specter,
         current_version=current_version,
         rand=rand,
@@ -1780,6 +1788,18 @@ def btcunitamount(value):
         return btcamount(value)
     value = float(value)
     return "{:,.0f}".format(round(value * 1e8))
+
+
+@app.template_filter("altunit")
+def altunit(value):
+    if app.specter.alt_rate and app.specter.alt_symbol:
+        return (
+            "{:,.2f}".format(float(value) * float(app.specter.alt_rate))
+            .rstrip("0")
+            .rstrip(".")
+            + app.specter.alt_symbol
+        )
+    return ""
 
 
 @app.template_filter("bytessize")

--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -389,8 +389,8 @@ def general_settings():
         action = request.form["action"]
         explorer = request.form["explorer"]
         unit = request.form["unit"]
-        alt_rate = request.form["alt_rate"]
-        alt_symbol = request.form["alt_symbol"]
+        alt_rate = request.form.get("alt_rate", 0)
+        alt_symbol = request.form.get("alt_symbol", "")
         validate_merkleproof_bool = request.form.get("validatemerkleproof") == "on"
 
         if current_user.is_admin:

--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -399,7 +399,7 @@ def general_settings():
         action = request.form["action"]
         explorer = request.form["explorer"]
         unit = request.form["unit"]
-        alt_rate = request.form.get("alt_rate", 0)
+        alt_rate = float(request.form.get("alt_rate", 0))
         alt_symbol = request.form.get("alt_symbol", "")
         validate_merkleproof_bool = request.form.get("validatemerkleproof") == "on"
 
@@ -1798,7 +1798,7 @@ def btcunitamount(value):
 def altunit(value):
     if app.specter.alt_rate and app.specter.alt_symbol:
         return (
-            "{:,.2f}".format(float(value) * float(app.specter.alt_rate))
+            "{:,.2f} ".format(float(value) * float(app.specter.alt_rate))
             .rstrip("0")
             .rstrip(".")
             + app.specter.alt_symbol

--- a/src/cryptoadvance/specter/specter.py
+++ b/src/cryptoadvance/specter/specter.py
@@ -150,6 +150,8 @@ class Specter:
             # empty by default for backward-compatibility
             "uid": "",
             "unit": "btc",
+            "alt_rate": 0,
+            "alt_symbol": "",
             "validate_merkle_proofs": False,
         }
 
@@ -477,6 +479,20 @@ class Specter:
         else:
             user.set_unit(self, unit)
 
+    def update_alt_rate(self, alt_rate, user):
+        if user.is_admin:
+            self.config["alt_rate"] = alt_rate
+            self._save()
+        else:
+            user.set_alt_rate(self, alt_rate)
+
+    def update_alt_symbol(self, alt_symbol, user):
+        if user.is_admin:
+            self.config["alt_symbol"] = alt_symbol
+            self._save()
+        else:
+            user.set_alt_symbol(self, alt_symbol)
+
     def update_merkleproof_settings(self, validate_bool):
         if validate_bool is True and self.info.get("pruned") is True:
             validate_bool = False
@@ -577,6 +593,14 @@ class Specter:
     @property
     def unit(self):
         return self.user_config.get("unit", "btc")
+
+    @property
+    def alt_rate(self):
+        return self.user_config.get("alt_rate", 0)
+
+    @property
+    def alt_symbol(self):
+        return self.user_config.get("alt_symbol", "")
 
     @property
     def admin(self):

--- a/src/cryptoadvance/specter/specter.py
+++ b/src/cryptoadvance/specter/specter.py
@@ -481,7 +481,7 @@ class Specter:
 
     def update_alt_rate(self, alt_rate, user):
         if user.is_admin:
-            self.config["alt_rate"] = alt_rate
+            self.config["alt_rate"] = float(alt_rate)
             self._save()
         else:
             user.set_alt_rate(self, alt_rate)

--- a/src/cryptoadvance/specter/templates/settings/general_settings.jinja
+++ b/src/cryptoadvance/specter/templates/settings/general_settings.jinja
@@ -53,6 +53,12 @@
 				<option value="sat" {% if unit=="sat" %} selected="selected"{% endif %}>sats</option>
 			</select>
 			<br><br>
+			<span>Alternative currency rate (per BTC):</span>
+			<input type="number" min="0" step="0.01" name="alt_rate" value="{{ alt_rate }}" placeholder="Set the price of bitcoin in your chosen currency">
+			<br><br>
+			Alternative currency symbol:
+			<input type="text" name="alt_symbol" value="{{ alt_symbol }}" placeholder="eg. $/€/£">
+			<br><br>
 			Block explorer URL ({{ specter.chain }}):<br>
 			<input type="text" name="explorer" value="{{ explorer }}">
 			<div class="warning">

--- a/src/cryptoadvance/specter/templates/settings/general_settings.jinja
+++ b/src/cryptoadvance/specter/templates/settings/general_settings.jinja
@@ -54,10 +54,11 @@
 			</select>
 			<br><br>
 			<span>Alternative currency rate (per BTC):</span>
-			<input type="number" min="0" step="0.01" name="alt_rate" value="{{ alt_rate }}" placeholder="Set the price of bitcoin in your chosen currency">
-			<br><br>
-			Alternative currency symbol:
-			<input type="text" name="alt_symbol" value="{{ alt_symbol }}" placeholder="eg. $/€/£">
+			<div class="row">
+				<input type="number" min="0" step="0.01" name="alt_rate" value="{{ alt_rate }}" placeholder="Set the price of bitcoin in your chosen currency" style="flex-grow: 1">
+				&nbsp;
+				<input type="text" name="alt_symbol" value="{{ alt_symbol }}" placeholder="eg. $/€/£" style="max-width: 30px">
+			</div>
 			<br><br>
 			Block explorer URL ({{ specter.chain }}):<br>
 			<input type="text" name="explorer" value="{{ explorer }}">

--- a/src/cryptoadvance/specter/templates/wallet/history/components/total_wallet_balances.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/history/components/total_wallet_balances.jinja
@@ -15,7 +15,8 @@
 			{% else %}
 				{% if specter.chain !='main' %}t{%endif%}BTC
 			{% endif %}
-        </span>
+        </span><br>
+        <span class="note">{{ wallet.fullbalance | altunit }}</span>
         {% if wallet.balance["untrusted_pending"] > 0 %}<br>
             <small>( {{ wallet.balance["trusted"] | btcunitamount }} confirmed, {{ wallet.balance["untrusted_pending"] | btcunitamount }} pending )</small>
         {% endif %}

--- a/src/cryptoadvance/specter/templates/wallet/history/components/tx_item.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/history/components/tx_item.jinja
@@ -28,7 +28,7 @@
             {{ explorer_link('address', tx['address'], tx['address'] if wallet == none else wallet.get_address_name(tx['address'], -1), specter.explorer) }}
         </td>
         <td>
-            {{ tx['amount'] | btcunitamount }}
+            {{ tx['amount'] | btcunitamount }} {% if specter.alt_rate and specter.alt_symbol %}<span class="note">&nbsp;({{ tx['amount'] | altunit }})</span>{% endif %}
         </td>
         <td>
             {%if tx['confirmations'] == 0 %}
@@ -67,7 +67,7 @@
             {% endif %}
             {{ explorer_link('address', tx['address'], tx['address'] if wallet == none else wallet.get_address_name(tx['address'], -1), specter.explorer) }}
         </p>
-        <p>Amount: {{ tx['amount'] | btcunitamount }}</p>
+        <p>Amount: {{ tx['amount'] | btcunitamount }}{% if specter.alt_rate and specter.alt_symbol %}<span class="note">{{ tx['amount'] | altunit }}{% endif %}</span></p>
         <p>Status:
         {%if tx['confirmations'] == 0 %}
             Pending.

--- a/src/cryptoadvance/specter/templates/wallet/history/utxo/wallet_utxo.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/history/utxo/wallet_utxo.jinja
@@ -95,6 +95,9 @@
 					{% else %}
 						{% if specter.chain !='main' %}t{%endif%}BTC
 					{% endif %}
+					{% if specter.alt_rate and specter.alt_symbol %}
+						<span class="note">&nbsp;({{ balance | altunit }})</span>
+					{% endif %}
 				</p>
 				<br><br>
 				{{ 

--- a/src/cryptoadvance/specter/templates/wallet/send/new/wallet_send.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/send/new/wallet_send.jinja
@@ -30,6 +30,9 @@
 				sats
 			{% else %}
 				{% if specter.chain !='main' %}t{%endif%}BTC
+			{% endif %}<br>
+			{% if specter.alt_rate and specter.alt_symbol %}
+				<span class="note">{{ wallet.full_available_balance | altunit }}</span>
 			{% endif %}
 		</p>
 		{% if wallet.locked_amount > 0 %}
@@ -115,7 +118,7 @@
 				<label><input type="radio" class="inline" style="margin: 0 5px;" name="amount_unit_${i}" value="btc" onchange="toggleUnit(this, ${i})" {% if specter.unit != 'sat' %}checked{% endif %}>BTC</label>
 				<span class="note max-btn" style="margin-left: 5px;" onclick="setMaxAmount(${i})">(send max)</span>
 				<div>
-					<span class="note" id="converted_unit_amount_${i}">-</span> <span class="note" id="converted_unit_label_${i}">{% if specter.unit == "sat" %}BTC{% else %}sat{% endif %}</span>
+					<span class="note" id="converted_unit_amount_${i}">-</span> <span class="note" id="converted_unit_label_${i}">{% if specter.unit == "sat" %}BTC{% else %}sat{% endif %}</span> <span class="note" id="converted_unit_alt_${i}"></span>
 				</div>
 			<div>
 			`
@@ -208,8 +211,16 @@
 				convertedAmount = '-'
 			}
 			document.getElementById('converted_unit_amount_' + i).innerHTML = (isNaN(convertedAmount) ? '-' : convertedAmount);
-
 			document.getElementById('btc_amount_' + i).value = (units[i] == 'btc' ? amounts[i] : amounts[i] / 1e8);
+
+			let altRate = parseFloat('{{ specter.alt_rate }}');
+			let altSymbol = '{{ specter.alt_symbol }}';
+			let altAmount = parseFloat((altRate * parseFloat(document.getElementById('btc_amount_' + i).value)).toFixed(2))
+			if (!isNaN(altAmount) && (altSymbol && altRate)) {
+				document.getElementById('converted_unit_alt_' + i).innerHTML = '&nbsp;(' + altAmount + altSymbol + ')';
+			} else {
+				document.getElementById('converted_unit_alt_' + i).innerHTML = '';
+			}
 
 			validateForm();
 		}

--- a/src/cryptoadvance/specter/templates/wallet/send/pending/components/pending_psbt_item.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/send/pending/components/pending_psbt_item.jinja
@@ -18,7 +18,7 @@
             {% endif %}
         </td>
         <td>
-            {{ (pending_psbt['amount'] | sum) | btcunitamount }}
+            {{ (pending_psbt['amount'] | sum) | btcunitamount }}{% if specter.alt_rate and specter.alt_symbol %}<span class="note">&nbsp;({{ (pending_psbt['amount'] | sum) | altunit }})</span>{% endif %}
         </td>
         <td>
             {{ pending_psbt['time'] | datetime }}

--- a/src/cryptoadvance/specter/templates/wallet/send/sign/wallet_send_sign_psbt.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/send/sign/wallet_send_sign_psbt.jinja
@@ -74,6 +74,9 @@
 					{% else %}
 						{% if specter.chain !='main' %}t{%endif%}BTC
 					{% endif %}
+					{% if specter.alt_rate and specter.alt_symbol %}
+						<span class="note">({{ psbt["amount"][i] | altunit }})</span>
+					{% endif %}
 					to<b>
 					{{ explorer_link('address', psbt['address'][i], wallet.get_address_name(psbt["address"][i], -1), specter.explorer) }}
 					</b><br><br>

--- a/src/cryptoadvance/specter/templates/wallet/wallets_overview.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/wallets_overview.jinja
@@ -24,13 +24,15 @@
     <h1>
         <small style="line-height:30px">Total balance:</small><br>
         <span style="color: #fff">
-            {{ specter.wallet_manager.wallets.values() | sum(attribute='fullbalance') | btcunitamount }}
+			{% set fullbalance = specter.wallet_manager.wallets.values() | sum(attribute='fullbalance') %}
+            {{ fullbalance | btcunitamount }}
             {% if specter.unit == 'sat' %}
 				sats
 			{% else %}
 				{% if specter.chain !='main' %}t{%endif%}BTC
 			{% endif %}
-        </span>
+        </span><br>
+		<span class="note">{{ fullbalance | altunit }}</span>
         {% if specter.wallet_manager.wallets.values() | sum(attribute='balance.untrusted_pending') > 0 %}<br>
             <small>( {{ specter.wallet_manager.wallets.values() | sum(attribute='balance.trusted') | btcunitamount }} confirmed, {{ specter.wallet_manager.wallets.values() | sum(attribute='balance.untrusted_pending') | btcunitamount }} pending )</small>
         {% endif %}

--- a/src/cryptoadvance/specter/user.py
+++ b/src/cryptoadvance/specter/user.py
@@ -108,6 +108,14 @@ class User(UserMixin):
         self.config["unit"] = unit
         self.save_info(specter)
 
+    def set_alt_rate(self, specter, alt_rate):
+        self.config["alt_rate"] = alt_rate
+        self.save_info(specter)
+
+    def set_alt_symbol(self, specter, alt_symbol):
+        self.config["alt_symbol"] = alt_symbol
+        self.save_info(specter)
+
     def delete(self, specter):
         # we delete wallet manager and device manager in save_info
         self.save_info(specter, delete=True)

--- a/src/cryptoadvance/specter/user.py
+++ b/src/cryptoadvance/specter/user.py
@@ -109,7 +109,7 @@ class User(UserMixin):
         self.save_info(specter)
 
     def set_alt_rate(self, specter, alt_rate):
-        self.config["alt_rate"] = alt_rate
+        self.config["alt_rate"] = float(alt_rate)
         self.save_info(specter)
 
     def set_alt_symbol(self, specter, alt_symbol):


### PR DESCRIPTION
Close #546 

Allow user to specify (in the general settings page) a currency symbol and price of BTC and display that next to amounts we show on Specter.