### PR TITLE
Fix failing to write backup causing wallet to disapear

### DIFF
--- a/src/cryptoadvance/specter/persistence.py
+++ b/src/cryptoadvance/specter/persistence.py
@@ -75,7 +75,7 @@ def _write_json_file(content, path, lock=None):
             if os.path.isfile(path):
                 os.remove(path)
             os.rename(bkp, path)
-            raise RuntimeError(f"Failed to write to file {path}")
+            logger.error(f"Failed to write to file {path}")
 
 
 def write_json_file(content, path, lock=None):


### PR DESCRIPTION
Sometimes after using Specter for a while wallets seem to disappear suddenly. I suspect the issue is that the write fails for some reason and raises the error I turned to a log now. I think this shouldn't raise an error bug just log it or there might be problems like the one I have.