### PR TITLE
isascii for py3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The easiest way to run Specter Desktop is by installing the Specter Desktop app,
 With this method, all you need to do is just download the right file for your operating system and install it like a normal desktop app.
 
 ### Installing Specter from Pip
-* Specter requires version 3.7 or 3.8
+* Specter requires Python version 3.6 to 3.8. We will support python 3.9 when HWI adds support for it.
 * HWI support requires `libusb` 
   * Ubuntu/Debian: `sudo apt install libusb-1.0-0-dev libudev-dev`
   * macOS: `brew install libusb`

--- a/setup.py
+++ b/setup.py
@@ -37,5 +37,5 @@ setup(
         "Operating System :: OS Independent",
         "Framework :: Flask",
     ],
-    python_requires=">=3.7,<3.9",
+    python_requires=">=3.6,<3.9",
 )

--- a/src/cryptoadvance/specter/helpers.py
+++ b/src/cryptoadvance/specter/helpers.py
@@ -46,7 +46,9 @@ def to_ascii20(name: str) -> str:
     """
     Converts the name to max 20 ascii-only characters.
     """
-    return "".join([c for c in name if c.isascii()])[:20]
+    # ascii characters have codes from 0 to 127
+    # but 127 is "delete" and we don't want it
+    return "".join([c for c in name if ord(c)<127])[:20]
 
 
 def alias(name):

--- a/src/cryptoadvance/specter/helpers.py
+++ b/src/cryptoadvance/specter/helpers.py
@@ -48,7 +48,7 @@ def to_ascii20(name: str) -> str:
     """
     # ascii characters have codes from 0 to 127
     # but 127 is "delete" and we don't want it
-    return "".join([c for c in name if ord(c)<127])[:20]
+    return "".join([c for c in name if ord(c) < 127])[:20]
 
 
 def alias(name):


### PR DESCRIPTION
We don't officially support python3.6, but maybe we could make it working.
@k9ert do you remember what issues aside from isascii did we have with python3.6?