### PR TITLE
remove purpose from bip44 legacy keys, set default key to mainnet if not connected to Core 

### DIFF
--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -34,6 +34,7 @@ from .helpers import (
     generate_mnemonic,
     get_startblock_by_chain,
     to_ascii20,
+    is_testnet,
 )
 from .util.shell import run_shell
 from .specter import Specter
@@ -763,7 +764,7 @@ def new_wallet(wallet_type):
             try:
                 descriptor = Descriptor.parse(
                     AddChecksum(recv_descriptor.split("#")[0]),
-                    testnet=app.specter.chain != "main",
+                    testnet=is_testnet(app.specter.chain),
                 )
                 if descriptor is None:
                     flash("Invalid wallet descriptor.", "error")
@@ -1135,7 +1136,7 @@ def device_setup_wizard():
                         paths,
                         file_password,
                         app.specter.wallet_manager,
-                        app.specter.chain != "main",
+                        is_testnet(app.specter.chain),
                         keys_range=[range_start, range_end],
                         keys_purposes=keys_purposes,
                     )
@@ -1151,7 +1152,7 @@ def device_setup_wizard():
                     paths,
                     file_password,
                     app.specter.wallet_manager,
-                    app.specter.chain != "main",
+                    is_testnet(app.specter.chain),
                     keys_range=[range_start, range_end],
                     keys_purposes=keys_purposes,
                 )
@@ -1720,7 +1721,7 @@ def new_device():
                     paths,
                     file_password,
                     app.specter.wallet_manager,
-                    app.specter.chain != "main",
+                    is_testnet(app.specter.chain),
                     keys_range=[range_start, range_end],
                 )
                 return redirect(url_for("device", device_alias=device.alias))
@@ -1819,7 +1820,7 @@ def device(device_alias):
                         paths,
                         file_password,
                         app.specter.wallet_manager,
-                        app.specter.chain != "main",
+                        is_testnet(app.specter.chain),
                         keys_range=[range_start, range_end],
                     )
             else:

--- a/src/cryptoadvance/specter/device.py
+++ b/src/cryptoadvance/specter/device.py
@@ -2,6 +2,7 @@ import json
 from .key import Key
 from .persistence import read_json_file, write_json_file
 import logging
+from .helpers import is_testnet
 
 logger = logging.getLogger()
 
@@ -93,7 +94,7 @@ class Device:
         self.manager.update()
 
     def key_types(self, network="main"):
-        test = network != "main"
+        test = is_testnet(network)
         return [key.key_type for key in self.keys if (key.is_testnet == test)]
 
     def has_key_types(self, wallet_type, network="main"):

--- a/src/cryptoadvance/specter/helpers.py
+++ b/src/cryptoadvance/specter/helpers.py
@@ -27,6 +27,7 @@ defaultlock = threading.Lock()
 def is_testnet(chain):
     return chain not in ["main", "", None]
 
+
 def locked(customlock=defaultlock):
     """
     @locked(lock) decorator.

--- a/src/cryptoadvance/specter/helpers.py
+++ b/src/cryptoadvance/specter/helpers.py
@@ -24,6 +24,9 @@ logger = logging.getLogger(__name__)
 defaultlock = threading.Lock()
 
 
+def is_testnet(chain):
+    return chain not in ["main", "", None]
+
 def locked(customlock=defaultlock):
     """
     @locked(lock) decorator.

--- a/src/cryptoadvance/specter/helpers.py
+++ b/src/cryptoadvance/specter/helpers.py
@@ -25,7 +25,7 @@ defaultlock = threading.Lock()
 
 
 def is_testnet(chain):
-    return chain not in ["main", "", None]
+    return chain in ["test", "regtest", "signet"]
 
 
 def locked(customlock=defaultlock):

--- a/src/cryptoadvance/specter/hwi_rpc.py
+++ b/src/cryptoadvance/specter/hwi_rpc.py
@@ -1,7 +1,7 @@
 from hwilib.serializations import PSBT
 import hwilib.commands as hwi_commands
 from hwilib import bech32
-from .helpers import locked
+from .helpers import locked, is_testnet
 from .util.xpub import convert_xpub_prefix
 from .util.json_rpc import JSONRPC
 import threading
@@ -210,10 +210,13 @@ class HWIBridge(JSONRPC):
             # Client will be configured for testnet if our Specter instance is
             #   currently connected to testnet. This will prevent us from
             #   getting mainnet xpubs unless we set is_testnet here:
-            try:
-                client.is_testnet = derivation.split("/")[2].startswith("1")
-            except:
-                client.is_testnet = False
+            if not chain:
+                try:
+                    client.is_testnet = derivation.split("/")[2].startswith("1")
+                except:
+                    client.is_testnet = False
+            else:
+                client.is_testnet = is_testnet(chain)
 
             network = networks.NETWORKS["test" if client.is_testnet else "main"]
 
@@ -351,7 +354,7 @@ class HWIBridge(JSONRPC):
                     "The device was identified but could not be reached.  Please check it is properly connected and try again"
                 )
             try:
-                client.is_testnet = chain != "main"
+                client.is_testnet = is_testnet(chain)
                 yield client
             finally:
                 client.close()

--- a/src/cryptoadvance/specter/key.py
+++ b/src/cryptoadvance/specter/key.py
@@ -9,10 +9,8 @@ purposes = OrderedDict(
         "": "General",
         "wpkh": "Single (Segwit)",
         "sh-wpkh": "Single (Nested)",
-        "pkh": "Single (Legacy)",
         "wsh": "Multisig (Segwit)",
         "sh-wsh": "Multisig (Nested)",
-        "sh": "Multisig (Legacy)",
     }
 )
 
@@ -43,8 +41,8 @@ class Key:
         if derivation is None:
             derivation = ""
         if key_type not in purposes:
-            raise Exception("Invalid key type specified: {}.")
-        if not purpose:
+            key_type = ""
+        if not purpose or purpose not in list(purposes.values()):
             purpose = purposes[key_type]
         self.original = original
         self.fingerprint = fingerprint
@@ -55,12 +53,12 @@ class Key:
 
     @classmethod
     def from_json(cls, key_dict):
-        original = key_dict["original"] if "original" in key_dict else ""
-        fingerprint = key_dict["fingerprint"] if "fingerprint" in key_dict else ""
-        derivation = key_dict["derivation"] if "derivation" in key_dict else ""
-        key_type = key_dict["type"] if "type" in key_dict else ""
-        purpose = key_dict["purpose"] if "purpose" in key_dict else ""
-        xpub = key_dict["xpub"] if "xpub" in key_dict else ""
+        original = key_dict.get("original", "")
+        fingerprint = key_dict.get("fingerprint", "")
+        derivation = key_dict.get("derivation", "")
+        key_type = key_dict.get("type", "")
+        purpose = key_dict.get("purpose", "")
+        xpub = key_dict.get("xpub", "")
         return cls(original, fingerprint, derivation, key_type, purpose, xpub)
 
     @classmethod
@@ -123,14 +121,10 @@ class Key:
         if derivation != "" and key_type == "":
             derivation_path = derivation.split("/")
             derivation_type = derivation_path[1]
-            if derivation_type == "44h":
-                key_type = "pkh"
-            elif derivation_type == "49h":
+            if derivation_type == "49h":
                 key_type = "sh-wpkh"
             elif derivation_type == "84h":
                 key_type = "wpkh"
-            elif derivation_type == "45h":
-                key_type = "sh"
             elif derivation_type == "48h":
                 if len(derivation_path) >= 5:
                     if derivation_path[4] == "1h":

--- a/src/cryptoadvance/specter/specter.py
+++ b/src/cryptoadvance/specter/specter.py
@@ -7,7 +7,7 @@ import random
 import time
 import zipfile
 from io import BytesIO
-from .helpers import deep_update, clean_psbt
+from .helpers import deep_update, clean_psbt, is_testnet
 from .util.checker import Checker
 from .rpc import autodetect_rpc_confs, get_default_datadir, RpcError
 from urllib3.exceptions import NewConnectionError
@@ -565,6 +565,10 @@ class Specter:
     @property
     def chain(self):
         return self._info["chain"]
+
+    @property
+    def is_testnet(self):
+        return is_testnet(self.chain)
 
     @property
     def user_config(self):

--- a/src/cryptoadvance/specter/static/hwi.js
+++ b/src/cryptoadvance/specter/static/hwi.js
@@ -121,7 +121,7 @@ class HWIBridge {
         });
     }
 
-    async getXpubs(device, account=0, passphrase=""){
+    async getXpubs(device, account=0, passphrase="", chain=""){
         if(!('passphrase' in device)){
             device.passphrase = passphrase;
         }
@@ -130,11 +130,12 @@ class HWIBridge {
             account: account,
             path: device.path,
             passphrase: device.passphrase,
+            chain: chain,
         });
     }
 
 
-    async getXpub(device, derivation="", passphrase=""){
+    async getXpub(device, derivation="", passphrase="", chain=""){
         if(!('passphrase' in device)){
             device.passphrase = passphrase;
         }
@@ -143,6 +144,7 @@ class HWIBridge {
             derivation: derivation,
             path: device.path,
             passphrase: device.passphrase,
+            chain: chain,
         });
     }
 

--- a/src/cryptoadvance/specter/templates/device/new_device.jinja
+++ b/src/cryptoadvance/specter/templates/device/new_device.jinja
@@ -304,7 +304,7 @@ m/48h/{{ 0 if specter.info.chain == "main" else 1 }}h/0h/2h</textarea>
 		}
 		
 		let account = document.getElementById('usb_account_number').value;
-		let xpubs = await getXpubs(device, account);
+		let xpubs = await getXpubs(device, account, "", "{specter.chain}");
 		if(xpubs == null){
 			return;
 		}

--- a/src/cryptoadvance/specter/templates/wallet/new_wallet/new_wallet_keys.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/new_wallet/new_wallet_keys.jinja
@@ -127,7 +127,7 @@
 							</tr>
 						</thead>
 						<tbody id="device{{ loop.index0 }}">
-							{% for key in device.keys if key.is_testnet == (specter.chain != "main") %}
+							{% for key in device.keys if key.is_testnet == specter.chain.is_testnet %}
 								<tr>
 									<td>
 										{% from "components/bitcoin_svg.jinja" import bitcoin_svg %}

--- a/src/cryptoadvance/specter/templates/wizards/device_setup_wizard.jinja
+++ b/src/cryptoadvance/specter/templates/wizards/device_setup_wizard.jinja
@@ -287,10 +287,10 @@
         function addAccountXpubs() {
             let accountNumberField = document.getElementById('account_number_xpubs')
             let accountNumber = accountNumberField.value;
-            addXpub('#' + accountNumber + ' Single Sig (Nested)', 'm/49h/{{ 0 if specter.info.chain == "main" else 1 }}h/' + accountNumber + 'h');
-            addXpub('#' + accountNumber + ' Single Sig (Segwit)', 'm/84h/{{ 0 if specter.info.chain == "main" else 1 }}h/' + accountNumber + 'h');
-            addXpub('#' + accountNumber + ' Multisig Sig (Nested)', 'm/48h/{{ 0 if specter.info.chain == "main" else 1 }}h/' + accountNumber + 'h/1h');
-            addXpub('#' + accountNumber + ' Multisig Sig (Segwit)', 'm/48h/{{ 0 if specter.info.chain == "main" else 1 }}h/' + accountNumber + 'h/2h');
+            addXpub('#' + accountNumber + ' Single Sig (Nested)', 'm/49h/{{ specter.is_testnet | int }}h/' + accountNumber + 'h');
+            addXpub('#' + accountNumber + ' Single Sig (Segwit)', 'm/84h/{{ specter.is_testnet | int }}h/' + accountNumber + 'h');
+            addXpub('#' + accountNumber + ' Multisig Sig (Nested)', 'm/48h/{{ specter.is_testnet | int }}h/' + accountNumber + 'h/1h');
+            addXpub('#' + accountNumber + ' Multisig Sig (Segwit)', 'm/48h/{{ specter.is_testnet | int }}h/' + accountNumber + 'h/2h');
             document.getElementById('edit_add_account').style.display = 'none';
             accountNumberField.value = 0;
             for (let el of document.getElementsByClassName('xpubs_edit')) {
@@ -658,7 +658,11 @@
                     continue
                 }
 
-                let xpub = await getXpub(device, document.getElementById(xpubRow.id + '-derivation').innerHTML);
+                let xpub = await getXpub(device,
+                    document.getElementById(xpubRow.id + '-derivation').innerHTML,
+                    "",
+                    "{specter.chain}"
+                );
                 if(xpub == null){
                     showError('Failed to retrive device data. Please try again.');
                     return;

--- a/src/cryptoadvance/specter/txlist.py
+++ b/src/cryptoadvance/specter/txlist.py
@@ -86,10 +86,7 @@ class TxList(dict):
                 tx["time"] = tx["timereceived"]
             return tx
         tx = self[txid]
-        return {
-            "hex": tx["hex"],
-            "time": tx["time"],
-        }
+        return {"hex": tx["hex"], "time": tx["time"]}
 
     def add(self, txs):
         """


### PR DESCRIPTION
we don't support legacy keys (m/44h/...) - we don't import them by default and don't show them in the wizard.
It's bad because for all other custom derivations we at least show them as an option in wallet creation, so we kinda blacklist m/44h.
This PR treats legacy derivation path as "custom" so it can be used in any wallet type.

Also if Specter is not conected to Core we currently import keys from the device as testnet keys, but we should import mainnet keys instead, as most of the people use Specter on mainnet.
