### PR TITLE
remove bitbox support

### DIFF
--- a/src/cryptoadvance/specter/devices/__init__.py
+++ b/src/cryptoadvance/specter/devices/__init__.py
@@ -1,6 +1,7 @@
 from .coldcard import ColdCard
 from .trezor import Trezor
 from .ledger import Ledger
+
 # from .bitbox02 import BitBox02
 from .keepkey import Keepkey
 from .specter import Specter

--- a/src/cryptoadvance/specter/devices/__init__.py
+++ b/src/cryptoadvance/specter/devices/__init__.py
@@ -1,7 +1,7 @@
 from .coldcard import ColdCard
 from .trezor import Trezor
 from .ledger import Ledger
-from .bitbox02 import BitBox02
+# from .bitbox02 import BitBox02
 from .keepkey import Keepkey
 from .specter import Specter
 from .cobo import Cobo
@@ -13,7 +13,7 @@ from .bitcoin_core import BitcoinCore
 __all__ = [
     Trezor,
     Ledger,
-    BitBox02,
+    # BitBox02,
     Specter,
     ColdCard,
     Keepkey,


### PR DESCRIPTION
BitBox updated something in their python lib so now they require pairing to the device.
This pairing requires entering "y" to the stdin that is obviously not available from the GUI directly.
We need to go through the API of bitbox lib and see how we can do it without stdin.
This obviously requires some time so we can't include them in this release. Too bad.
Maybe we should postpone it until HWI supports bitbox with multisig.

So in this PR we temporary disable bitbox2 and remove from the GUI.