### PR TITLE
Trick ColdCard and Cobo to sign a PSBT transaction if some of the co-signers have different derivation path

### DIFF
--- a/src/cryptoadvance/specter/devices/coldcard.py
+++ b/src/cryptoadvance/specter/devices/coldcard.py
@@ -49,7 +49,9 @@ class ColdCard(SDCardDevice):
 
     def create_psbts(self, base64_psbt, wallet):
         psbts = SDCardDevice.create_psbts(self, base64_psbt, wallet)
-        psbts["sdcard"] = wallet.fill_psbt(psbts["sdcard"], non_witness=False, xpubs=True)
+        psbts["sdcard"] = wallet.fill_psbt(
+            psbts["sdcard"], non_witness=False, xpubs=True
+        )
         self.replace_derivations(wallet, psbts)
         return psbts
 

--- a/src/cryptoadvance/specter/devices/coldcard.py
+++ b/src/cryptoadvance/specter/devices/coldcard.py
@@ -2,6 +2,9 @@ import urllib
 from .sd_card_device import SDCardDevice
 from ..util.xpub import get_xpub_fingerprint
 from ..helpers import to_ascii20
+from embit.psbt import PSBT, DerivationPath
+from embit import bip32
+from binascii import b2a_base64, a2b_base64
 
 CC_TYPES = {"legacy": "BIP45", "p2sh-segwit": "P2WSH-P2SH", "bech32": "P2WSH"}
 
@@ -18,8 +21,33 @@ class ColdCard(SDCardDevice):
     def __init__(self, name, alias, keys, fullpath, manager):
         SDCardDevice.__init__(self, name, alias, keys, fullpath, manager)
 
+    def replace_derivations(self, wallet, psbts):
+        fgp = None
+        derivation = None
+        for k in wallet.keys:
+            if k in self.keys and k.fingerprint and k.derivation:
+                fgp = k.fingerprint
+                derivation = k.derivation
+                break
+        if not fgp:
+            return
+        # cc wants everyone to use the same derivation?
+        # or just correct depth is enough?
+        # TODO: check with xpub of different depth
+        path = bip32.parse_path(derivation)
+        for kk in list(psbts.keys()):
+            psbt = PSBT.parse(a2b_base64(psbts[kk]))
+            for xpub in psbt.xpubs:
+                psbt.xpubs[xpub].derivation = list(path)
+            for scope in psbt.inputs + psbt.outputs:
+                for k in list(scope.bip32_derivations.keys()):
+                    original = scope.bip32_derivations[k].derivation
+                    scope.bip32_derivations[k].derivation = path + original[-2:]
+            psbts[kk] = b2a_base64(psbt.serialize())
+
     def create_psbts(self, base64_psbt, wallet):
         psbts = SDCardDevice.create_psbts(self, base64_psbt, wallet)
+        self.replace_derivations(wallet, psbts)
         return psbts
 
     def export_wallet(self, wallet):

--- a/src/cryptoadvance/specter/devices/sd_card_device.py
+++ b/src/cryptoadvance/specter/devices/sd_card_device.py
@@ -11,5 +11,5 @@ class SDCardDevice(HWIDevice):
 
     def create_psbts(self, base64_psbt, wallet):
         psbts = super().create_psbts(base64_psbt, wallet)
-        psbts["sdcard"] = wallet.fill_psbt(base64_psbt, non_witness=False, xpubs=True)
+        psbts["sdcard"] = wallet.fill_psbt(base64_psbt, non_witness=True, xpubs=True)
         return psbts


### PR DESCRIPTION
Trick ColdCard and Cobo to sign a PSBT transaction if some of the co-signers have different derivation path.

P.S. Coldcard crashes on my 9-of-9 multisig, but works fine on 2-of-4 or so.