### PR TITLE
Bitcoind without docker

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -15,3 +15,4 @@ pysocks==1.7.1
 six==1.12.0
 stem==1.8.0
 embit==0.1.1
+psutil==5.7.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -209,6 +209,19 @@ protobuf==3.13.0 \
     --hash=sha256:e7662437ca1e0c51b93cadb988f9b353fa6b8013c0385d63a70c8a77d84da5f9 \
     --hash=sha256:f68eb9d03c7d84bd01c790948320b768de8559761897763731294e3bc316decb \
     # via bitbox02
+psutil==5.7.3 \
+    --hash=sha256:01bc82813fbc3ea304914581954979e637bcc7084e59ac904d870d6eb8bb2bc7 \
+    --hash=sha256:1cd6a0c9fb35ece2ccf2d1dd733c1e165b342604c67454fd56a4c12e0a106787 \
+    --hash=sha256:2cb55ef9591b03ef0104bedf67cc4edb38a3edf015cf8cf24007b99cb8497542 \
+    --hash=sha256:56c85120fa173a5d2ad1d15a0c6e0ae62b388bfb956bb036ac231fbdaf9e4c22 \
+    --hash=sha256:5d9106ff5ec2712e2f659ebbd112967f44e7d33f40ba40530c485cc5904360b8 \
+    --hash=sha256:6a3e1fd2800ca45083d976b5478a2402dd62afdfb719b30ca46cd28bb25a2eb4 \
+    --hash=sha256:ade6af32eb80a536eff162d799e31b7ef92ddcda707c27bbd077238065018df4 \
+    --hash=sha256:af73f7bcebdc538eda9cc81d19db1db7bf26f103f91081d780bbacfcb620dee2 \
+    --hash=sha256:e02c31b2990dcd2431f4524b93491941df39f99619b0d312dfe1d4d530b08b4b \
+    --hash=sha256:fa38ac15dbf161ab1e941ff4ce39abd64b53fec5ddf60c23290daed2bc7d1157 \
+    --hash=sha256:fbcac492cb082fa38d88587d75feb90785d05d7e12d4565cbf1ecc727aff71b7 \
+    # via -r requirements.in
 pyaes==1.6.1 \
     --hash=sha256:02c1b1405c38d3c370b085fb952dd8bea3fadcee6411ad99f312cc129c536d8f \
     # via hwi

--- a/src/cryptoadvance/specter/__main__.py
+++ b/src/cryptoadvance/specter/__main__.py
@@ -7,12 +7,12 @@ if __name__ == "__main__":
     # https://flask.palletsprojects.com/en/1.1.x/logging/#basic-configuration
     # However the dictConfig doesn't work, so let's do something similiar programatically
     ch = logging.StreamHandler()
-    ch.setLevel(logging.INFO)
+    ch.setLevel(logging.DEBUG)
     formatter = logging.Formatter(
         "[%(asctime)s] %(levelname)s in %(module)s: %(message)s"
     )
     ch.setFormatter(formatter)
     logging.getLogger().addHandler(ch)
     # However initially, we'll set the root-logger to INFO:
-    logging.getLogger().setLevel(logging.INFO)
+    logging.getLogger("cryptoadvance").setLevel(logging.INFO)
     cli()

--- a/src/cryptoadvance/specter/bitcoind.py
+++ b/src/cryptoadvance/specter/bitcoind.py
@@ -253,7 +253,8 @@ class BitcoindDockerController(BitcoindController):
 
     def _start_bitcoind(self, cleanup_at_exit, datadir=None):
         if datadir != None:
-            raise Exception("Cannot specify datadir in BitcoindDockerController!")
+            # ignored
+            pass
         bitcoind_path = self.construct_bitcoind_cmd(self.rpcconn)
         dclient = docker.from_env()
         logger.debug("Running (in docker): {}".format(bitcoind_path))

--- a/src/cryptoadvance/specter/bitcoind.py
+++ b/src/cryptoadvance/specter/bitcoind.py
@@ -196,7 +196,7 @@ class BitcoindPlainController(BitcoindController):
         self.bitcoind_path = bitcoind_path
         self.rpcconn.ipaddress = "localhost"
 
-    def _start_bitcoind(self, cleanup_at_exit=False, datadir=None):
+    def _start_bitcoind(self, cleanup_at_exit=True, datadir=None):
         if datadir == None:
             datadir = tempfile.mkdtemp(prefix="bitcoind_plain_datadir_")
         bitcoind_cmd = self.construct_bitcoind_cmd(
@@ -213,12 +213,10 @@ class BitcoindPlainController(BitcoindController):
         )
 
         def cleanup_bitcoind():
-            self.bitcoind_proc.kill()  # much faster then terminate() and speed is key here over being nice
+            self.bitcoind_proc.terminate()  # might take a bit longer than kill but it'll preserve block-height
             logger.info(
                 "Killed bitcoind-process with pid {}".format(self.bitcoind_proc.pid)
             )
-            shutil.rmtree(datadir)
-            logger.info("removed temp-dir")
 
         if cleanup_at_exit:
             logger.debug("REGISTERING EXIT FUNCTIONS")

--- a/src/cryptoadvance/specter/cli.py
+++ b/src/cryptoadvance/specter/cli.py
@@ -209,9 +209,8 @@ class Echo():
 @click.option("--data-dir", default="/tmp/bitcoind_plain_datadir", help="specify a (maybe not yet existing) datadir. Works only in --nodocker (Default:/tmp/bitcoind_plain_datadir) ")
 @click.option("--mining/--no-mining", default=True, help="Turns on mining (default)")
 @click.option("--mining-period", default="15", help="Every mining-period (in seconds), a block gets mined (default 15sec)")
-@click.option("--cleanup/--no-cleanup", default=False, help="CTRL-C will kill the bitcoind and the Datadir (default:false)")
 @click.option("--reset", is_flag=True, default=False, help="Will kill the bitcoind. Datadir will get lost.")
-def bitcoind(debug, quiet, nodocker, docker_tag, data_dir, mining, mining_period, cleanup, reset):
+def bitcoind(debug, quiet, nodocker, docker_tag, data_dir, mining, mining_period, reset):
     ''' This will start a bitcoind regtest and mines a block every mining-period. 
         If a bitcoind is already running on port 18443, it won't start another one. If you CTRL-C this, the bitcoind will 
         still continue to run. You have to shut it down.
@@ -259,7 +258,7 @@ def bitcoind(debug, quiet, nodocker, docker_tag, data_dir, mining, mining_period
         echo("starting or detecting container")
         my_bitcoind = BitcoindDockerController(docker_tag=docker_tag)
     try:
-        my_bitcoind.start_bitcoind(cleanup_at_exit=cleanup, datadir=data_dir)
+        my_bitcoind.start_bitcoind(cleanup_at_exit=True, datadir=data_dir)
     except docker.errors.ImageNotFound:
         echo(f"Image with tag {docker_tag} does not exist!")
         echo(

--- a/src/cryptoadvance/specter/cli.py
+++ b/src/cryptoadvance/specter/cli.py
@@ -1,6 +1,8 @@
 import logging
 from logging.config import dictConfig
 import os
+from os import path
+import subprocess
 import sys
 import time
 from stem.control import Controller
@@ -10,7 +12,6 @@ import click
 from .server import create_app, init_app
 from .helpers import set_loglevel
 
-from os import path
 import signal
 
 logger = logging.getLogger(__name__)
@@ -186,58 +187,97 @@ def server(daemon, stop, restart, force, port, host, cert, key, debug, tor, hwib
             debug = app.config["DEBUG"]
         run(debug=debug)
 
+class Echo():
+    def __init__(self,quiet):
+        self.quiet = quiet
+
+    def echo(self, mystring, prefix=True, **kwargs):
+        if self.quiet:
+            pass
+        else:
+            if prefix:
+                click.echo(f"    --> ",nl=False)
+            click.echo(f"{mystring}",**kwargs)
 
 @cli.command()
-@click.option("--debug/--no-debug", default=False)
-@click.option("--mining/--no-mining", default=True)
-@click.option("--docker-tag", "docker_tag", default="latest")
-def bitcoind(debug, mining, docker_tag):
+@click.option("--debug/--no-debug", default=False, help="Turns on debug-logging")
+@click.option("--quiet/--no-quiet", default=False, help="as less output as possible")
+@click.option("--nodocker", default=False, is_flag=True, help="use without docker (non-default)")
+@click.option("--docker-tag", "docker_tag", default="latest", help="Use a specific docker-tag")
+@click.option("--mining/--no-mining", default=True, help="Turns on mining (default)")
+@click.option("--mining-period", default="15", help="Every mining-period (in seconds), a block gets mined (default 15sec)")
+@click.option("--reset", is_flag=True, default=False, help="Will kill the bitcoind. Datadir will get lost.")
+def bitcoind(debug, quiet, nodocker, docker_tag, mining, mining_period, reset):
+    ''' This will start a bitcoind regtest and mines a block every mining-period. 
+        If a bitcoind is already running on port 18443, it won't start another one. If you CTRL-C this, the bitcoind will 
+        still continue to run. You have to shut it down.
+    '''
+    # In order to avoid these dependencies for production use, we're importing them here:
     import docker
+    from .bitcoind import BitcoindDockerController, BitcoindPlainController, fetch_wallet_addresses_for_mining
+    echo = Echo(quiet).echo
 
-    from .bitcoind import BitcoindDockerController, fetch_wallet_addresses_for_mining
-
+    if reset:
+        if not nodocker:
+            echo("ERROR: --reset only works in conjunction with --nodocker currently")
+            return
+        echo("bitcoind-process gets killed ...")
+            
+        p = subprocess.Popen(['ps', '-A'], stdout=subprocess.PIPE)
+        out, err = p.communicate()
+        for line in out.decode("utf8").splitlines():
+            if 'bitcoind' in line:
+                pid = int(line.split(None, 1)[0])
+                try:
+                    os.kill(pid, signal.SIGTERM)
+                except PermissionError:
+                    echo(f"Pid {pid} not owned by us. Might be a docker-process? {line}")
+        return
     logging.getLogger().setLevel(logging.INFO)
-    mining_every_x_seconds = 15
+    mining_every_x_seconds = float(mining_period)
     if debug:
         logging.getLogger().setLevel(logging.DEBUG)
-    click.echo("    --> starting or detecting container")
-    my_bitcoind = BitcoindDockerController(docker_tag=docker_tag)
+    if nodocker:
+        echo("starting plain bitcoind")
+        my_bitcoind = BitcoindPlainController()
+    else:
+        echo("starting or detecting container")
+        my_bitcoind = BitcoindDockerController(docker_tag=docker_tag)
     try:
         my_bitcoind.start_bitcoind()
     except docker.errors.ImageNotFound:
-        click.echo(f"    --> Image with tag {docker_tag} does not exist!")
-        click.echo(
-            f"    --> Try to download first with docker pull \
+        echo(f"Image with tag {docker_tag} does not exist!")
+        echo(
+            f"Try to download first with docker pull \
                      registry.gitlab.com/cryptoadvance/specter-desktop\
                      /python-bitcoind:{docker_tag}"
         )
         sys.exit(1)
-    tags_of_image = [
-        image.split(":")[-1] for image in my_bitcoind.btcd_container.image.tags
-    ]
-    if docker_tag not in tags_of_image:
-        click.echo(
-            "    --> The running docker container is not \
-                            the tag you requested!"
-        )
-        click.echo(
-            "    --> please stop first with docker stop {}".format(
-                my_bitcoind.btcd_container.id
+    if not nodocker:
+        tags_of_image = [
+            image.split(":")[-1] for image in my_bitcoind.btcd_container.image.tags
+        ]
+        if docker_tag not in tags_of_image:
+            echo(
+                "The running docker container is not \
+                                the tag you requested!"
             )
-        )
-        sys.exit(1)
-    click.echo("    --> containerImage: %s" % my_bitcoind.btcd_container.image.tags)
-    click.echo("    -->            url: %s" % my_bitcoind.rpcconn.render_url())
-    click.echo("    --> user, password: bitcoin, secret")
-    click.echo("    -->     host, port: localhost, 18443")
-    click.echo(
-        "    -->    bitcoin-cli: bitcoin-cli -regtest -rpcuser=bitcoin \
-            -rpcpassword=secret getblockchaininfo "
+            echo(
+                "please stop first with docker stop {}".format(
+                    my_bitcoind.btcd_container.id
+                )
+            )
+            sys.exit(1)
+        echo("containerImage: %s" % my_bitcoind.btcd_container.image.tags)
+    echo("           url: %s" % my_bitcoind.rpcconn.render_url())
+    echo("user, password: bitcoin, secret")
+    echo("    host, port: localhost, 18443")
+    echo(
+        "   bitcoin-cli: bitcoin-cli -regtest -rpcuser=bitcoin -rpcpassword=secret getblockchaininfo "
     )
     if mining:
-        click.echo(
-            "    --> Now, mining a block every %i seconds. \
-            Avoid it via --no-mining"
+        echo(
+            "Now, mining a block every %f seconds, avoid it via --no-mining"
             % mining_every_x_seconds
         )
         # Get each address some coins
@@ -250,18 +290,19 @@ def bitcoind(debug, mining, docker_tag):
 
         # make them spendable
         my_bitcoind.mine(block_count=100)
-        click.echo("    --> ", nl=False)
-        i = 0
+        echo(f"height: {my_bitcoind.rpcconn.get_rpc().getblockchaininfo()['blocks']} | ",nl=False)
+        i,j = 0,0
         while True:
             my_bitcoind.mine()
-            click.echo("%i" % (i % 10), nl=False)
+            echo("%i" % (i % 10), prefix=False, nl=False)
             if i % 10 == 9:
-                click.echo(" ", nl=False)
+                echo(" ", prefix=False, nl=False)
             i += 1
             if i >= 50:
+                j = i
                 i = 0
-                click.echo(" ")
-                click.echo("    --> ", nl=False)
+                echo("",prefix=False)
+                echo(f"height: {my_bitcoind.rpcconn.get_rpc().getblockchaininfo()['blocks']} | ",nl=False)
             time.sleep(mining_every_x_seconds)
 
 


### PR DESCRIPTION
This contains some improvements, some of them necessary for better cypress-testing:
* You can now run bitcoind without docker (`--nodocker`) if you have bitcoind on the PATH somewhere
* If you want the process to be quiet, run it with `--quiet`
* adjust the mining period, so `--mining-period 0.5` will mine a block every half a second
* `--datadir` can now be specified and the default is /tmp/bitcoind_plain_datadir. We no longer create new temp-directories
* A CTRL-C will now always terminate the process/container. In The case of docker, the datadir will be lost as well. In the case of a plain bitcoind, we now have -reset` 
* `--reset` remove the datadir
* the blockheight is now printed in the output
* All options are now properly documented

Here is an example-output:
```
(.env) ➜  specter-desktop git:(bitcoind_without_docker) ✗ python3 -m cryptoadvance.specter bitcoind --nodocker --mining-period 0.1 
Initializing HWI...
    --> starting plain bitcoind
    -->            url: http://bitcoin:secret@localhost:18443/wallet/
    --> user, password: bitcoin, secret
    -->     host, port: localhost, 18443
    -->    bitcoin-cli: bitcoin-cli -regtest -rpcuser=bitcoin -rpcpassword=secret getblockchaininfo 
    --> Now, mining a block every 0.100000 seconds, avoid it via --no-mining
    --> height: 619 | 0123456789 01^V2345^C
Aborted!
[2020-11-22 14:55:13,599] INFO in bitcoind: Killed bitcoind-process with pid 22058
(.env) ➜  specter-desktop git:(bitcoind_without_docker) ✗ python3 -m cryptoadvance.specter bitcoind --nodocker --reset             
Initializing HWI...
    --> Purging Datadirectory /tmp/bitcoind_plain_datadir ...
(.env) ➜  specter-desktop git:(bitcoind_without_docker) ✗ python3 -m cryptoadvance.specter bitcoind --nodocker --mining-period 0.1 
Initializing HWI...
    --> starting plain bitcoind
    -->            url: http://bitcoin:secret@localhost:18443/wallet/
    --> user, password: bitcoin, secret
    -->     host, port: localhost, 18443
    -->    bitcoin-cli: bitcoin-cli -regtest -rpcuser=bitcoin -rpcpassword=secret getblockchaininfo 
    --> Now, mining a block every 0.100000 seconds, avoid it via --no-mining
    --> height: 200 | 012^C
Aborted!
[2020-11-22 14:55:21,874] INFO in bitcoind: Killed bitcoind-process with pid 22113
(.env) ➜  specter-desktop git:(bitcoind_without_docker) ✗
```