### PR TITLE
Add .python-version to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist
 cert.pem
 key.pem
 *.dmg
+.python-version
 pyinstaller/specterd
 pyinstaller/release
 pyinstaller/release-linux


### PR DESCRIPTION
This lets me specify a local Python version, e.g. using `pyenv local 3.8.6`.