### PR TITLE
Create specterd.service

### DIFF
--- a/docs/specterd.service
+++ b/docs/specterd.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=SpecterDesktop
+Wants=bitcoind.service
+After=bitcoind.service
+
+[Service]
+ExecStart=/usr/bin/python3 -m cryptoadvance.specter server --host 0.0.0.0 --cert=/path/to/cert.pem --key=/path/to/key.pem
+User=bitcoin
+TimeoutSec=120
+Restart=always
+RestartSec=60
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
specterd.service file for those running specter-desktop on a linux server. Ensures specterd starts on boot directly after bitcoind. uses host 0.0.0.0 for all IP's to connect to it and caters for https to ensure users are able to use webcams for QR code scanning in the browser.