### PR TITLE
bump embit version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -14,5 +14,5 @@ requests==2.25.0
 pysocks==1.7.1
 six==1.12.0
 stem==1.8.0
-embit==0.1.1
+embit==0.1.2
 psutil==5.7.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -94,8 +94,8 @@ ecdsa==0.13.3 \
     --hash=sha256:163c80b064a763ea733870feb96f9dd9b92216cfcacd374837af18e4e8ec3d4d \
     --hash=sha256:9814e700890991abeceeb2242586024d4758c8fc18445b194a49bd62d85861db \
     # via bitbox02, hwi
-embit==0.1.1 \
-    --hash=sha256:15ab4f35036113e35cfcddd786a4123cecb2059ca2417c12ee52eba68bd91615 \
+embit==0.1.2 \
+    --hash=sha256:d88e74eafdd26280c298bb572ac28e7913abbc2c91e99df0ebb9139c626bc4d3 \
     # via -r requirements.in
 flask-cors==3.0.8 \
     --hash=sha256:72170423eb4612f0847318afff8c247b38bd516b7737adfc10d1c2cdbb382d16 \


### PR DESCRIPTION
Bump embit version with a few changes and bugfixes:
- signet uses `tb` hrp
- Witness parsing in psbt is fixed (missing import)

Close https://github.com/cryptoadvance/specter-desktop/issues/706