### PR TITLE
Use descriptor wallet for Bitcoin Core >= v0.21.0

### DIFF
--- a/src/cryptoadvance/specter/addresslist.py
+++ b/src/cryptoadvance/specter/addresslist.py
@@ -177,6 +177,13 @@ class AddressList(dict):
         if need_save:
             self.save()
 
+    def max_index(self, change=False):
+        return max(
+            -1,
+            -1,
+            *[addr.index for addr in self.values() if addr.change == change],
+        )
+
     def max_used_index(self, change=False):
         return max(
             -1,

--- a/src/cryptoadvance/specter/helpers.py
+++ b/src/cryptoadvance/specter/helpers.py
@@ -178,12 +178,15 @@ def get_devices_with_keys_by_type(app, cosigners, wallet_type):
             allowed_types += ["sh-wpkh", "wpkh"]
         elif wallet_type == "multisig":
             allowed_types += ["sh-wsh", "wsh"]
-        device.keys = [
-            key
-            for key in device.keys
-            if key.xpub.startswith(prefix)
-            and (key.key_type in allowed_types or wallet_type == "*")
-        ]
+        device.keys = sorted(
+            [
+                key
+                for key in device.keys
+                if key.xpub.startswith(prefix)
+                and (key.key_type in allowed_types or wallet_type == "*")
+            ],
+            key=lambda k: k.original == k.xpub,
+        )
         devices.append(device)
     return devices
 

--- a/src/cryptoadvance/specter/specter.py
+++ b/src/cryptoadvance/specter/specter.py
@@ -268,6 +268,7 @@ class Specter:
             or wallet_manager.chain != self.chain
         ):
             wallet_manager = WalletManager(
+                self.bitcoin_core_version_raw,
                 wallets_folder,
                 self.rpc,
                 self.chain,
@@ -653,6 +654,10 @@ class Specter:
     @property
     def bitcoin_core_version(self):
         return self.network_info["subversion"].replace("/", "").replace("Satoshi:", "")
+
+    @property
+    def bitcoin_core_version_raw(self):
+        return self.network_info["version"]
 
     @property
     def chain(self):

--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -25,7 +25,7 @@ LISTTRANSACTIONS_BATCH_SIZE = 1000
 class Wallet:
     # if the wallet is old we import 300 addresses
     IMPORT_KEYPOOL = 300
-    # a gap of 20 addresses is what many wallets do
+    # a gap of 20 addresses is what many wallets do (not used with descriptor wallets)
     GAP_LIMIT = 20
     # minimal fee rate is slightly above 1 sat/vbyte
     # to avoid rounding errors
@@ -966,60 +966,79 @@ class Wallet:
         return self.balance
 
     def keypoolrefill(self, start, end=None, change=False):
+        # Descriptor wallets were introduced in v0.21.0, but upgraded nodes may
+        # still have legacy wallets. Use getwalletinfo to check the wallet type.
+        # The "keypool" for desciptor wallets is automatically refilled
+        if self.use_descriptors and start > 0:
+            return
+
         if end is None:
+            # end is ignored for descriptor wallets
             end = start + self.GAP_LIMIT
+
         desc = self.recv_descriptor if not change else self.change_descriptor
         args = [
             {
                 "desc": desc,
                 "internal": change,
-                "range": [start, end],
                 "timestamp": "now",
-                "keypool": True,
                 "watchonly": True,
             }
         ]
-        addresses = [
-            dict(
-                address=self.get_address(idx, change=change, check_keypool=False),
-                index=idx,
-                change=change,
-            )
-            for idx in range(start, end)
-        ]
-        self._addresses.add(addresses, check_rpc=False)
+        if self.use_descriptors:
+            args[0]["active"] = True
+        else:
+            args[0]["keypool"] = True
+            args[0]["range"] = [start, end]
+
+        if not self.use_descriptors:
+            addresses = [
+                dict(
+                    address=self.get_address(idx, change=change, check_keypool=False),
+                    index=idx,
+                    change=change,
+                )
+                for idx in range(start, end)
+            ]
+            self._addresses.add(addresses, check_rpc=False)
 
         if not self.is_multisig:
-            r = self.rpc.importmulti(args, {"rescan": False})
+            if self.use_descriptors:
+                r = self.rpc.importdescriptors(args)
+            else:
+                r = self.rpc.importmulti(args, {"rescan": False})
         # bip67 requires sorted public keys for multisig addresses
         else:
-            # try if sortedmulti is supported
-            r = self.rpc.importmulti(args, {"rescan": False})
-            # doesn't raise, but instead returns "success": False
-            if not r[0]["success"]:
-                # first import normal multi
-                # remove checksum
-                desc = desc.split("#")[0]
-                # switch to multi
-                desc = desc.replace("sortedmulti", "multi")
-                # add checksum
-                desc = AddChecksum(desc)
-                # update descriptor
-                args[0]["desc"] = desc
+            if self.use_descriptors:
+                self.rpc.importdescriptors(args)
+            else:
+                # try if sortedmulti is supported
                 r = self.rpc.importmulti(args, {"rescan": False})
-                # make a batch of single addresses to import
-                arg = args[0]
-                # remove range key
-                arg.pop("range")
-                batch = []
-                for i in range(start, end):
-                    sorted_desc = sort_descriptor(desc, index=i)
-                    # create fresh object
-                    obj = {}
-                    obj.update(arg)
-                    obj.update({"desc": sorted_desc})
-                    batch.append(obj)
-                r = self.rpc.importmulti(batch, {"rescan": False})
+                # doesn't raise, but instead returns "success": False
+                if not r[0]["success"]:
+                    # first import normal multi
+                    # remove checksum
+                    desc = desc.split("#")[0]
+                    # switch to multi
+                    desc = desc.replace("sortedmulti", "multi")
+                    # add checksum
+                    desc = AddChecksum(desc)
+                    # update descriptor
+                    args[0]["desc"] = desc
+                    r = self.rpc.importmulti(args, {"rescan": False})
+                    # make a batch of single addresses to import
+                    arg = args[0]
+                    # remove range key
+                    arg.pop("range")
+                    batch = []
+                    for i in range(start, end):
+                        sorted_desc = sort_descriptor(desc, index=i)
+                        # create fresh object
+                        obj = {}
+                        obj.update(arg)
+                        obj.update({"desc": sorted_desc})
+                        batch.append(obj)
+                    r = self.rpc.importmulti(batch, {"rescan": False})
         if change:
             self.change_keypool = end
         else:

--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -449,6 +449,12 @@ class Wallet:
         delete_file(self._transactions.path)
 
     @property
+    def use_descriptors(self):
+        if not hasattr(self, "info") or self.info != {}:
+            self.get_info()
+        return "descriptors" in self.info and self.info["descriptors"] == True
+
+    @property
     def is_multisig(self):
         return len(self.keys) > 1
 

--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -573,7 +573,11 @@ class Wallet:
         ):
             self.fetch_transactions()
         try:
-            _transactions = [tx.__dict__().copy() for tx in self._transactions.values()]
+            _transactions = [
+                tx.__dict__().copy()
+                for tx in self._transactions.values()
+                if tx["ismine"]
+            ]
             transactions = sorted(
                 _transactions, key=lambda tx: tx["time"], reverse=True
             )

--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -936,7 +936,11 @@ class Wallet:
 
     def get_balance(self):
         try:
-            balance = self.rpc.getbalances()["watchonly"]
+            balance = (
+                self.rpc.getbalances()["mine"]
+                if self.use_descriptors
+                else self.rpc.getbalances()["watchonly"]
+            )
             # calculate available balance
             locked_utxo = self.rpc.listlockunspent()
             available = {}

--- a/src/cryptoadvance/specter/wallet_manager.py
+++ b/src/cryptoadvance/specter/wallet_manager.py
@@ -212,8 +212,13 @@ Silently ignored! Wallet error: {e}"
             change_descriptor = "%s(%s)" % (el, change_descriptor)
         recv_descriptor = AddChecksum(recv_descriptor)
         change_descriptor = AddChecksum(change_descriptor)
-
-        self.rpc.createwallet(os.path.join(self.rpc_path, wallet_alias), True)
+        if self.bitcoin_core_version_raw >= 210000:
+            # Use descriptor wallet
+            self.rpc.createwallet(
+                os.path.join(self.rpc_path, wallet_alias), True, True, "", False, True
+            )
+        else:
+            self.rpc.createwallet(os.path.join(self.rpc_path, wallet_alias), True)
 
         w = Wallet(
             name,

--- a/src/cryptoadvance/specter/wallet_manager.py
+++ b/src/cryptoadvance/specter/wallet_manager.py
@@ -35,7 +35,15 @@ addrtypes = {
 
 class WalletManager:
     # chain is required to manage wallets when bitcoind is not running
-    def __init__(self, data_folder, rpc, chain, device_manager, path="specter"):
+    def __init__(
+        self,
+        bitcoin_core_version_raw,
+        data_folder,
+        rpc,
+        chain,
+        device_manager,
+        path="specter",
+    ):
         self.data_folder = data_folder
         self.chain = chain
         self.rpc = rpc
@@ -43,6 +51,7 @@ class WalletManager:
         self.device_manager = device_manager
         self.is_loading = False
         self.wallets = {}
+        self.bitcoin_core_version_raw = bitcoin_core_version_raw
         self.update(data_folder, rpc, chain)
 
     def update(self, data_folder=None, rpc=None, chain=None):

--- a/tests/test_device_manager.py
+++ b/tests/test_device_manager.py
@@ -107,7 +107,11 @@ def test_DeviceManager(empty_data_folder):
 
 def test_device_wallets(bitcoin_regtest, devices_filled_data_folder, device_manager):
     wm = WalletManager(
-        devices_filled_data_folder, bitcoin_regtest.get_rpc(), "regtest", device_manager
+        200100,
+        devices_filled_data_folder,
+        bitcoin_regtest.get_rpc(),
+        "regtest",
+        device_manager,
     )
     device = device_manager.get_by_alias("trezor")
     assert len(device.wallets(wm)) == 0

--- a/tests/test_wallet_manager.py
+++ b/tests/test_wallet_manager.py
@@ -8,7 +8,11 @@ from cryptoadvance.specter.wallet_manager import WalletManager
 
 def test_WalletManager(bitcoin_regtest, devices_filled_data_folder, device_manager):
     wm = WalletManager(
-        devices_filled_data_folder, bitcoin_regtest.get_rpc(), "regtest", device_manager
+        200100,
+        devices_filled_data_folder,
+        bitcoin_regtest.get_rpc(),
+        "regtest",
+        device_manager,
     )
     # A wallet-creation needs a device
     device = device_manager.get_by_alias("trezor")
@@ -70,7 +74,11 @@ def test_WalletManager(bitcoin_regtest, devices_filled_data_folder, device_manag
 
 def test_wallet_createpsbt(bitcoin_regtest, devices_filled_data_folder, device_manager):
     wm = WalletManager(
-        devices_filled_data_folder, bitcoin_regtest.get_rpc(), "regtest", device_manager
+        200100,
+        devices_filled_data_folder,
+        bitcoin_regtest.get_rpc(),
+        "regtest",
+        device_manager,
     )
     # A wallet-creation needs a device
     device = device_manager.get_by_alias("specter")
@@ -163,7 +171,11 @@ def test_wallet_sortedmulti(
     bitcoin_regtest, devices_filled_data_folder, device_manager
 ):
     wm = WalletManager(
-        devices_filled_data_folder, bitcoin_regtest.get_rpc(), "regtest", device_manager
+        200100,
+        devices_filled_data_folder,
+        bitcoin_regtest.get_rpc(),
+        "regtest",
+        device_manager,
     )
     device = device_manager.get_by_alias("trezor")
     second_device = device_manager.get_by_alias("specter")
@@ -213,7 +225,11 @@ def test_wallet_sortedmulti(
 
 def test_wallet_labeling(bitcoin_regtest, devices_filled_data_folder, device_manager):
     wm = WalletManager(
-        devices_filled_data_folder, bitcoin_regtest.get_rpc(), "regtest", device_manager
+        200100,
+        devices_filled_data_folder,
+        bitcoin_regtest.get_rpc(),
+        "regtest",
+        device_manager,
     )
     # A wallet-creation needs a device
     device = device_manager.get_by_alias("specter")
@@ -269,7 +285,11 @@ def test_wallet_change_addresses(
     bitcoin_regtest, devices_filled_data_folder, device_manager
 ):
     wm = WalletManager(
-        devices_filled_data_folder, bitcoin_regtest.get_rpc(), "regtest", device_manager
+        200100,
+        devices_filled_data_folder,
+        bitcoin_regtest.get_rpc(),
+        "regtest",
+        device_manager,
     )
     # A wallet-creation needs a device
     device = device_manager.get_by_alias("specter")


### PR DESCRIPTION
First part of #707.

This PR checks if Bitcoin Core is v0.21.0 or above. If so it creates a descriptor wallet.

We then check for each wallet if it's a descriptor wallet (since the node may have been upgraded after a wallet was created), using `getwalletinfo`.

Descriptor wallets use `importdescriptors` instead of `importmulti`. This means the `getnewaddress` RPC works as well as the Receive tab in the Bitcoin Core GUI.

Balance is checked with `mine` rather than `watchonly` for descriptor wallets.

For descriptor wallets we no longer refill the keypool. There's a bunch of other address management code that can probably be skipped, but I don't know how it works. I bypassed the `self._addresses.add` stuff in `keypoolrefill`, which seems to work.