### PR TITLE
update communication with Specter-DIY

### DIFF
--- a/src/cryptoadvance/specter/devices/specter.py
+++ b/src/cryptoadvance/specter/devices/specter.py
@@ -1,9 +1,10 @@
 import hashlib
 from .hwi_device import HWIDevice
-from hwilib.serializations import PSBT
 from .hwi.specter_diy import enumerate as specter_enumerate, SpecterClient
 from ..helpers import to_ascii20
-
+from embit import bip32
+from embit.psbt import PSBT
+from binascii import a2b_base64, b2a_base64
 
 class Specter(HWIDevice):
     device_type = "specter"
@@ -22,29 +23,33 @@ class Specter(HWIDevice):
 
     def create_psbts(self, base64_psbt, wallet):
         psbts = super().create_psbts(base64_psbt, wallet)
-        qr_psbt = PSBT()
         # remove non-witness utxo if they are there to reduce QR code size
         updated_psbt = wallet.fill_psbt(base64_psbt, non_witness=False, xpubs=False)
-        qr_psbt.deserialize(updated_psbt)
-        # replace with compressed wallet information
+        qr_psbt = PSBT.parse(a2b_base64(updated_psbt))
+        # find my key
+        fgp = None
+        derivation = None
+        for k in wallet.keys:
+            if k in self.keys and k.fingerprint and k.derivation:
+                fgp = bytes.fromhex(k.fingerprint)
+                derivation = bip32.parse_path(k.derivation)
+                break
+        # remove unnecessary derivations from inputs and outputs
         for inp in qr_psbt.inputs + qr_psbt.outputs:
-            inp.witness_script = b""
-            inp.redeem_script = b""
-            if len(inp.hd_keypaths) > 0:
-                k = list(inp.hd_keypaths.keys())[0]
-                # proprietary field - wallet derivation path
-                # only contains two last derivation indexes - change and index
-                wallet_key = b"\xfc\xca\x01" + get_wallet_fingerprint(wallet)
-                inp.unknown[wallet_key] = b"".join(
-                    [i.to_bytes(4, "little") for i in inp.hd_keypaths[k][-2:]]
-                )
-                inp.hd_keypaths = {}
-        psbts["qrcode"] = qr_psbt.serialize()
+            # keep only my derivation
+            for k in list(inp.bip32_derivations.keys()):
+                if inp.bip32_derivations[k].fingerprint != fgp:
+                    inp.bip32_derivations.pop(k, None)
+        # remove scripts from outputs (DIY should know about the wallet)
+        for out in qr_psbt.outputs:
+            inp.witness_script = None
+            inp.redeem_script = None
+        psbts["qrcode"] = b2a_base64(qr_psbt.serialize()).strip().decode()
         return psbts
 
     def export_wallet(self, wallet):
-        return (
-            to_ascii20(wallet.name.replace(" ", "_"))
+        return ("addwallet "
+            + to_ascii20(wallet.name)
             + "&"
             + get_wallet_qr_descriptor(wallet)
         )

--- a/src/cryptoadvance/specter/devices/specter.py
+++ b/src/cryptoadvance/specter/devices/specter.py
@@ -45,6 +45,9 @@ class Specter(HWIDevice):
         for out in qr_psbt.outputs:
             inp.witness_script = None
             inp.redeem_script = None
+        # remove partial sigs from inputs
+        for inp in qr_psbt.inputs:
+            inp.partial_sigs = {}
         psbts["qrcode"] = b2a_base64(qr_psbt.serialize()).strip().decode()
         return psbts
 

--- a/src/cryptoadvance/specter/devices/specter.py
+++ b/src/cryptoadvance/specter/devices/specter.py
@@ -6,6 +6,7 @@ from embit import bip32
 from embit.psbt import PSBT
 from binascii import a2b_base64, b2a_base64
 
+
 class Specter(HWIDevice):
     device_type = "specter"
     name = "Specter-DIY"
@@ -48,7 +49,8 @@ class Specter(HWIDevice):
         return psbts
 
     def export_wallet(self, wallet):
-        return ("addwallet "
+        return (
+            "addwallet "
             + to_ascii20(wallet.name)
             + "&"
             + get_wallet_qr_descriptor(wallet)

--- a/src/cryptoadvance/specter/devices/specter.py
+++ b/src/cryptoadvance/specter/devices/specter.py
@@ -43,8 +43,8 @@ class Specter(HWIDevice):
                     inp.bip32_derivations.pop(k, None)
         # remove scripts from outputs (DIY should know about the wallet)
         for out in qr_psbt.outputs:
-            inp.witness_script = None
-            inp.redeem_script = None
+            out.witness_script = None
+            out.redeem_script = None
         # remove partial sigs from inputs
         for inp in qr_psbt.inputs:
             inp.partial_sigs = {}


### PR DESCRIPTION
This PR fixes a few issues with Specter-DIY:
- import wallet now works properly if the wallet name contains spaces
- signing of the multisig transaction is possible even if the wallet is not imported to the device - DIY shows a warning and doesn't verify change addresses, but at least it can sign.

