### PR TITLE
fix available

### DIFF
--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -881,6 +881,7 @@ class Wallet:
                 else:
                     available["trusted"] -= delta
                     available["trusted"] = round(available["trusted"], 8)
+            available["untrusted_pending"] = round(available["untrusted_pending"], 8)
             balance["available"] = available
         except:
             balance = {
@@ -888,7 +889,6 @@ class Wallet:
                 "untrusted_pending": 0,
                 "available": {"trusted": 0, "untrusted_pending": 0},
             }
-            available["untrusted_pending"] = round(available["untrusted_pending"], 8)
         self.balance = balance
         return self.balance
 


### PR DESCRIPTION
Not sure what caused the first exception, but the second one is definitely a bug.
```
Traceback (most recent call last):
  File "/home/zdekstop/.local/lib/python3.8/site-packages/cryptoadvance/specter/wallet.py", line 870, in get_balance
    balance = self.rpc.getbalances()["watchonly"]
KeyError: 'watchonly'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/zdekstop/.local/lib/python3.8/site-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/zdekstop/.local/lib/python3.8/site-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/zdekstop/.local/lib/python3.8/site-packages/flask_login/utils.py", line 269, in decorated_view
    return func(*args, **kwargs)
  File "/home/zdekstop/.local/lib/python3.8/site-packages/cryptoadvance/specter/server_endpoints/wallets.py", line 206, in new_wallet
    wallet = app.specter.wallet_manager.create_wallet(
  File "/home/zdekstop/.local/lib/python3.8/site-packages/cryptoadvance/specter/wallet_manager.py", line 195, in create_wallet
    w = Wallet(
  File "/home/zdekstop/.local/lib/python3.8/site-packages/cryptoadvance/specter/wallet.py", line 107, in __init__
    self.update()
  File "/home/zdekstop/.local/lib/python3.8/site-packages/cryptoadvance/specter/wallet.py", line 157, in update
    self.get_balance()
  File "/home/zdekstop/.local/lib/python3.8/site-packages/cryptoadvance/specter/wallet.py", line 891, in get_balance
    available["untrusted_pending"] = round(available["untrusted_pending"], 8)
UnboundLocalError: local variable 'available' referenced before assignment
```