### PR TITLE
improve dev-tooling

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -81,7 +81,17 @@ Executing the tests is done via `./utils/test-cypress.sh`:
 The test_specifications which get executed are specified in cypress.json which looks something like this:
 
 More details on cypress-testing can be found in [cypress-testing.md](docs/cypress-testing.md).
-
+Make sure to read it. The tooling we created around cypress quite helpful in daily development.
+In short, you can do this and the last command will give you a reliable development-environment which is the very same
+whenever you start it anew:
+```
+./utils/test-cypress.sh snapshot spec_existing_history.js
+./utils/test-cypress.sh dev spec_existing_history.js
+# CTRL-C
+./utils/test-cypress.sh dev spec_existing_history.js
+# CTRL-C
+[...]
+```
 
 # Flask specific stuff
 

--- a/cypress/integration/spec_empty_specter_home.js
+++ b/cypress/integration/spec_empty_specter_home.js
@@ -13,7 +13,7 @@ describe('Completely empty specter-home', () => {
     cy.contains('General settings - Specter Desktop custom')
     cy.get('[href="/settings/auth"]').click()
     cy.contains('Authentication settings - Specter Desktop custom')
-    cy.get('.right').click()
+    cy.get('[href="/settings/hwi"]').click()
     cy.contains('HWI Bridge settings - Specter Desktop custom')
   })
 

--- a/docs/cypress-testing.md
+++ b/docs/cypress-testing.md
@@ -1,6 +1,8 @@
 # Cypress Tests
 
-The UI is tested via [cypress](https://www.cypress.io/) which is built with node.js. The tests are specified in `cypress.json`. One of the challenges here is management of state (specter-folder and state of regtest). cypress is [discouraging](https://docs.cypress.io/guides/references/best-practices.html#Web-Servers) to start/stop the webserver or its prerequisites as part of executing the tests. Therefore we need to manage that ourself. This has been tested in Linux and MacOS. Windows is not supported.
+The UI is tested via [cypress](https://www.cypress.io/) which is built with node.js. The tests are specified in `cypress.json`. One of the challenges here is management of state (specter-folder and state of regtest). cypress is [discouraging](https://docs.cypress.io/guides/references/best-practices.html#Web-Servers) to start/stop the webserver or its prerequisites as part of executing the tests. Therefore we need to manage that ourself. 
+
+The below stuff has been tested on Linux and MacOS. Linux is fully supported. The snapshot functionality unfortunately doesn't work yet on MacOS. Windows is not supported at all.
 
  So the tests in general are designed to run in a strict sequence specified in cypress.json. So later tests might need the state created in former tests.
 

--- a/src/cryptoadvance/specter/bitcoind.py
+++ b/src/cryptoadvance/specter/bitcoind.py
@@ -238,7 +238,7 @@ class BitcoindPlainController(BitcoindController):
                 logger.info(
                     f"Killed bitcoind with pid {self.bitcoind_proc.pid}, Removing {datadir}"
                 )
-                shutil.rmtree(datadir)
+                shutil.rmtree(datadir, ignore_errors=True)
             else:
                 self.bitcoind_proc.terminate()  # might take a bit longer than kill but it'll preserve block-height
                 logger.info(

--- a/src/cryptoadvance/specter/server.py
+++ b/src/cryptoadvance/specter/server.py
@@ -15,16 +15,32 @@ from .util.version import VersionChecker
 
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 env_path = Path(".") / ".flaskenv"
 load_dotenv(env_path)
 
 
-def create_app(config="cryptoadvance.specter.config.DevelopmentConfig"):
-    # Enables injection of a different config via Env-Variable
-    if os.environ.get("SPECTER_CONFIG"):
-        config = os.environ.get("SPECTER_CONFIG")
+def calc_module_name(config):
+    """ tiny helper to make passing configs more convenient """
+    if "." in config:
+        return config
+    else:
+        return "cryptoadvance.specter.config." + config
+
+
+def create_app(config=None):
+
+    # Cmdline has precedence over Env-Var
+    if config is not None:
+        config = calc_module_name(os.environ.get("SPECTER_CONFIG"))
+    else:
+        # Enables injection of a different config via Env-Variable
+        if os.environ.get("SPECTER_CONFIG"):
+            config = calc_module_name(os.environ.get("SPECTER_CONFIG"))
+        else:
+            # Default
+            config = "cryptoadvance.specter.config.DevelopmentConfig"
 
     if getattr(sys, "frozen", False):
 
@@ -38,6 +54,7 @@ def create_app(config="cryptoadvance.specter.config.DevelopmentConfig"):
         )
     else:
         app = Flask(__name__, template_folder="templates", static_folder="static")
+    logger.info(f"Configuration: {config}")
     app.config.from_object(config)
     app.wsgi_app = ProxyFix(
         app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_port=1, x_prefix=1

--- a/utils/test-cypress.sh
+++ b/utils/test-cypress.sh
@@ -67,6 +67,16 @@ function open() {
   esac
 }
 
+exit_if_macos() {
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    echo "Very sorry but this functionality is not yet ready for MacOS :-(."
+    echo "If you can fix that, PRs are very much appreciated!"
+    echo "it's basically the different behaviour of GNU-tools on Linux/MacOS."
+    echo "first step to help is find the calls of \"exit_if_macos\" and deactivate it!"
+    exit 2
+  fi
+}
+
 function send_signal() {
   # use like send_signal <SIGNAL> <PID>
   # whereas SIGNAL is either SIGTERM or SIGKILL
@@ -172,6 +182,7 @@ function restore_snapshot {
     echo "./utils/test-cypress.sh snapshot $spec_file"
     exit 1
   fi
+  exit_if_macos
   ts_snapshot=$(stat --print="%X" ${snapshot_file})
   for file in $(./utils/calc_cypress_test_spec.py --delimiter " " $spec_file) 
   do 


### PR DESCRIPTION
Couldn't resist to improve my dev-tooling: 
The user-story goes like this:
" As a specter-developer, If i already have the cypress-tests, i want to use the very same scenarios in my daily-dev-work. So i'd like to quickly import a snapshot (regtest and specter-folder), start both, regtest and specter and open the browser".

You can do that now like:
```
./utils/test-cypress.sh dev spec_existing_history.js
```

This will hopefully also be an incentive to work a bit more on the cypress-tests.

As a side-effect of this, i fixed the precedence of the cmd-line over env-var if passing --config DevelopmentConfig (while also having an Env-Var pointing to some different config).