### PR TITLE
first tx might be unconfirmed still

### DIFF
--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -833,7 +833,7 @@ class Wallet:
             first_tx[0].get("blockheight", None) if first_tx else None
         )
         if first_tx:
-            if first_tx_blockheight - 101 > 0:
+            if first_tx_blockheight and first_tx_blockheight - 101 > 0:
                 return (
                     first_tx_blockheight - 101
                 )  # Give tiny margin to catch edge case of mined coins


### PR DESCRIPTION
If the first tx is unconfirmed, this might fail like such:

```
[2020-12-28 12:31:06,892] WARNING in wallet_manager: Failed to load wallet pennytest: unsupported operand type(s) for -: 'NoneType' and 'int'
[2020-12-28 12:31:06,893] WARNING in wallet_manager: Traceback (most recent call last):
  File "/home/kim/tmp/specter-desktop/.env/lib/python3.8/site-packages/cryptoadvance/specter/wallet_manager.py", line 130, in update
    loaded_wallet = Wallet.from_json(
  File "/home/kim/tmp/specter-desktop/.env/lib/python3.8/site-packages/cryptoadvance/specter/wallet.py", line 315, in from_json
    return cls(
  File "/home/kim/tmp/specter-desktop/.env/lib/python3.8/site-packages/cryptoadvance/specter/wallet.py", line 105, in __init__
    self.update()
  File "/home/kim/tmp/specter-desktop/.env/lib/python3.8/site-packages/cryptoadvance/specter/wallet.py", line 175, in update
    self.check_addresses()
  File "/home/kim/tmp/specter-desktop/.env/lib/python3.8/site-packages/cryptoadvance/specter/wallet.py", line 218, in check_addresses
    self.getnewaddress(change=False, save=False)
  File "/home/kim/tmp/specter-desktop/.env/lib/python3.8/site-packages/cryptoadvance/specter/wallet.py", line 861, in getnewaddress
    address = self.get_address(index, change=change)
  File "/home/kim/tmp/specter-desktop/.env/lib/python3.8/site-packages/cryptoadvance/specter/wallet.py", line 874, in get_address
    self.keypoolrefill(pool, index + self.GAP_LIMIT, change=change)
  File "/home/kim/tmp/specter-desktop/.env/lib/python3.8/site-packages/cryptoadvance/specter/wallet.py", line 1066, in keypoolrefill
    self.save_to_file()
  File "/home/kim/tmp/specter-desktop/.env/lib/python3.8/site-packages/cryptoadvance/specter/wallet.py", line 421, in save_to_file
    write_json_file(self.to_json(), self.fullpath)
  File "/home/kim/tmp/specter-desktop/.env/lib/python3.8/site-packages/cryptoadvance/specter/wallet.py", line 411, in to_json
    "blockheight": self.blockheight,
  File "/home/kim/tmp/specter-desktop/.env/lib/python3.8/site-packages/cryptoadvance/specter/wallet.py", line 836, in blockheight
    if first_tx_blockheight - 101 > 0:
TypeError: unsupported operand type(s) for -: 'NoneType' and 'int'

```