### PR TITLE
Bugfix/pyinstaller2

### DIFF
--- a/pyinstaller/requirements.in
+++ b/pyinstaller/requirements.in
@@ -1,1 +1,4 @@
 pyinstaller
+pefile
+macholib
+pywin32-ctypes

--- a/pyinstaller/requirements.txt
+++ b/pyinstaller/requirements.txt
@@ -8,16 +8,26 @@ altgraph==0.17 \
     --hash=sha256:1f05a47122542f97028caf78775a095fbe6a2699b5089de8477eb583167d69aa \
     --hash=sha256:c623e5f3408ca61d4016f23a681b9adb100802ca3e3da5e718915a9e4052cebe \
     # via macholib, pyinstaller
+future==0.18.2 \
+    --hash=sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d \
+    # via pefile
 macholib==1.14 \
     --hash=sha256:0c436bc847e7b1d9bda0560351bf76d7caf930fb585a828d13608839ef42c432 \
     --hash=sha256:c500f02867515e6c60a27875b408920d18332ddf96b4035ef03beddd782d4281 \
-    # via pyinstaller
+    # via -r requirements.in
+pefile==2019.4.18 \
+    --hash=sha256:a5d6e8305c6b210849b47a6174ddf9c452b2888340b8177874b862ba6c207645 \
+    # via -r requirements.in
 pyinstaller-hooks-contrib==2020.9 \
     --hash=sha256:a5fd45a920012802e3f2089e1d3501ef2f49265dfea8fc46c3310f18e3326c91 \
     --hash=sha256:c382f3ac1a42b45cfecd581475c36db77da90e479b2f5bcb6d840d21fa545114 \
     # via pyinstaller
 pyinstaller==4.0 \
     --hash=sha256:970beb07115761d5e4ec317c1351b712fd90ae7f23994db914c633281f99bab0 \
+    # via -r requirements.in
+pywin32-ctypes==0.2.0 \
+    --hash=sha256:24ffc3b341d457d48e8922352130cf2644024a4ff09762a2261fd34c36ee5942 \
+    --hash=sha256:9dc2d991b3479cc2df15930958b674a48a227d5361d413827a4cfd0b5876fc98 \
     # via -r requirements.in
 
 # WARNING: The following packages were not pinned, but pip requires them to be


### PR DESCRIPTION
For some reason, the 
`pip-compile --generate-hashes requirements.in` in the pyinstaller-directory did not pick up the indirect dependencies from pyinstaller.

As a workaround, i've added them to the `requirements.in`