### PR TITLE
Consistent rescan labels

### DIFF
--- a/src/cryptoadvance/specter/templates/wallet/settings/wallet_settings.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/settings/wallet_settings.jinja
@@ -184,7 +184,7 @@
 				{% if specter.info["utxorescan"] %}
 				<div class="row aligned padded">
 					<div style="flex-grow: 1">UTXO rescan in process: <span id="wallet_rescan_percents">{{ "%.2f"|format(specter.info["utxorescan"]) }}</span>%.</div>
-					<button type="submit" name="action" value="abortrescanutxo" class="btn" style="max-width: 130px; margin-left: 20px">Abort</button>
+					<button type="submit" name="action" value="abortrescanutxo" class="btn" style="max-width: 130px; margin-left: 20px">Abort rescan</button>
 				</div>
 				{% else %}
 				<div class="row aligned">


### PR DESCRIPTION
There are two rescan buttons in settings. One says "Abort" and the other says "Abort rescan". This PR makes them both say "Abort rescan".