### PR TITLE
Added persistent tor setting.

### DIFF
--- a/src/cryptoadvance/specter/cli/cli_server.py
+++ b/src/cryptoadvance/specter/cli/cli_server.py
@@ -222,7 +222,7 @@ def server(
                       Starting in production mode instead."
                 )
                 debug = False
-            if tor or os.getenv("CONNECT_TOR") == "True":
+            if tor or os.getenv("CONNECT_TOR") == "True" or app.specter.config["tor_status"] == True:
                 try:
                     app.tor_enabled = True
                     start_hidden_service(app)

--- a/src/cryptoadvance/specter/cli/cli_server.py
+++ b/src/cryptoadvance/specter/cli/cli_server.py
@@ -230,6 +230,8 @@ def server(
                 try:
                     app.tor_enabled = True
                     start_hidden_service(app)
+                    if app.specter.config["tor_status"] == False:
+                        app.specter.toggle_tor_status()
                 except Exception as e:
                     print(f" * Failed to start Tor hidden service: {e}")
                     print(" * Continuing process with Tor disabled")

--- a/src/cryptoadvance/specter/cli/cli_server.py
+++ b/src/cryptoadvance/specter/cli/cli_server.py
@@ -222,7 +222,11 @@ def server(
                       Starting in production mode instead."
                 )
                 debug = False
-            if tor or os.getenv("CONNECT_TOR") == "True" or app.specter.config["tor_status"] == True:
+            if (
+                tor
+                or os.getenv("CONNECT_TOR") == "True"
+                or app.specter.config["tor_status"] == True
+            ):
                 try:
                     app.tor_enabled = True
                     start_hidden_service(app)

--- a/src/cryptoadvance/specter/server_endpoints/settings.py
+++ b/src/cryptoadvance/specter/server_endpoints/settings.py
@@ -295,10 +295,12 @@ def tor():
                             current_hidden_services = []
                         if len(current_hidden_services) != 0:
                             stop_hidden_services(app)
+                            app.specter.toggle_tor_status()
                             flash("Tor hidden service turn off successfully", "info")
                         else:
                             try:
                                 start_hidden_service(app)
+                                app.specter.toggle_tor_status()
                                 flash("Tor hidden service turn on successfully", "info")
                             except Exception as e:
                                 flash(

--- a/src/cryptoadvance/specter/specter.py
+++ b/src/cryptoadvance/specter/specter.py
@@ -119,6 +119,7 @@ class Specter:
             "proxy_url": "socks5h://localhost:9050",  # Tor proxy URL
             "only_tor": False,
             "tor_control_port": "",
+            "tor_status": "false",
             "hwi_bridge_url": "/hwi/api/",
             # unique id that will be used in wallets path in Bitcoin Core
             # empty by default for backward-compatibility
@@ -458,6 +459,11 @@ class Specter:
         if self.config["proxy_url"] != proxy_url:
             self.config["proxy_url"] = proxy_url
             self._save()
+
+    def toggle_tor_status(self):
+        """ toggle the Tor status """
+        self.config["tor_status"] = not self.config["tor_status"]
+        self._save()
 
     def update_only_tor(self, only_tor, user):
         """ switch whatever to use Tor for all calls """

--- a/src/cryptoadvance/specter/specter.py
+++ b/src/cryptoadvance/specter/specter.py
@@ -119,7 +119,7 @@ class Specter:
             "proxy_url": "socks5h://localhost:9050",  # Tor proxy URL
             "only_tor": False,
             "tor_control_port": "",
-            "tor_status": "false",
+            "tor_status": False,
             "hwi_bridge_url": "/hwi/api/",
             # unique id that will be used in wallets path in Bitcoin Core
             # empty by default for backward-compatibility


### PR DESCRIPTION
Fixes #710 

Tried to do it minimally. 

- adds a `tor_status` flag (default `false`) to `app.specter.config`. 
- `Start` button in tor settings page toggles this flag.
- app reads the flag at launch and starts tor if the flag is set `true` in the last session.

Problem:

- Doesn't work on the first init run (no clue why, need help)

debugged so far:

- In the first run when the `Start` tor button is clicked in tor seeting, `toggle_tor_status` is hit.
- Status is read as `false 
- `config.json` file updates. 
- But the status flag doesn't change state. It remains `false`... weird. 

Then It works as expected from the subsequent runs without any issue. So the user will see expected behaviour when they run the app second time and starts tor again. Then the flag changes and tor will run automatically for next runs until stopped.   