### PR TITLE
[ADD] SLIP-132 switch for PDF backup key format

### DIFF
--- a/src/cryptoadvance/specter/templates/includes/overlay/key_export_qr.jinja
+++ b/src/cryptoadvance/specter/templates/includes/overlay/key_export_qr.jinja
@@ -23,7 +23,7 @@
             </td>
             <td style="border: none;">
                 <label class="switch">
-                    <input type="checkbox" id="show_der_path" onchange="toggleKeyDisplay()" checked>
+                    <input type="checkbox" id="show_der_path" onchange="toggleKeyDisplay()">
                     <span class="slider"></span>
                 </label>
             </td>
@@ -34,7 +34,7 @@
             </td>
             <td style="border: none;">
                 <label class="switch">
-                    <input type="checkbox" id="use_slip_132" onchange="toggleKeyDisplay()" checked>
+                    <input type="checkbox" id="use_slip_132" onchange="toggleKeyDisplay()">
                     <span class="slider"></span>
                 </label>
             </td>

--- a/src/cryptoadvance/specter/templates/wallet/components/wallet_pdf.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/components/wallet_pdf.jinja
@@ -1,13 +1,12 @@
 <qr-code value='{{ wallet.account_map }}' width="400" id="export-wallet-qr-code" class="hidden"></qr-code>
 <script	type="module">
     import { jsPDF } from "{{ url_for('static', filename='pdf/jspdf.es.min.js') }}";
-
     document.getElementById('pdf-wallet-download').onclick = () => {
         // Default export is a4 paper, portrait, using millimeters for units
         const doc = new jsPDF();
         const pageHeight = 297;
         const pageWidth = 210;
-
+        let useSlip132 = document.getElementById("use_slip_132_pdf").checked;
         let currentHeight = 15;
         doc.setFontSize(18);
         doc.text('Specter Backup File', 105, currentHeight, {align: 'center'});
@@ -53,7 +52,7 @@
         currentHeight += 7;
         doc.text('or any other compatible wallet.', 105, currentHeight, {align: 'center'});
         currentHeight += 11;
-
+        
         doc.setFontSize(16)
         let deviceName = '';
         let deviceType = '';
@@ -84,7 +83,12 @@
             currentHeight += 8
             doc.text("Derivation path:       {{ key.derivation }}", 15, currentHeight);
             currentHeight += 8
-            xpubLines = "{{ key.xpub }}".split(/(.{40})/g);
+
+            if (useSlip132)
+                xpubLines = "{{ key.original }}".split(/(.{40})/g);
+            else 
+                xpubLines = "{{ key.xpub }}".split(/(.{40})/g);
+            
             xpubLines = xpubLines.filter(line => line !== '');
             doc.text('Master public key:   ' + xpubLines[0], 15, currentHeight);
             for (var i = 1; i < xpubLines.length; i++) {

--- a/src/cryptoadvance/specter/templates/wallet/receive/wallet_receive.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/receive/wallet_receive.jinja
@@ -186,6 +186,14 @@
 			</div>
 			{% include 'wallet/components/wallet_pdf.jinja' %}
 		</div>
+		<div style="margin: 0 auto;" class="center">
+			<label style="font-size: 1em;"">Use SLIP-132:&nbsp;</label>
+			<label class="switch">
+				<input type="checkbox" id="use_slip_132_pdf" style="margin: auto;" onchange="toggleKeyDisplay()" checked>
+				<span class="slider"></span>
+			</label><br>
+		</div>
+		<p class="note center" style="margin-top: 5px; max-width: 90%;">To format master keys on the PDF backup document.</p>
 		<p style="max-width: 500px;">
 		It is recommended that you print and save this wallet backup file with each of your devices.
 		</p>
@@ -216,6 +224,11 @@
 				addressesList.style.display = 'block';
 				btn.innerText = 'Hide past addresses';
 			}
+		}
+		function toggleKeyDisplay() {
+			let slip132Checkbox = document.getElementById('use_slip_132_pdf');
+			let xpubs = document.getElementsByClassName('slip132_xpub');
+			let zpubs = document.getElementsByClassName('normal_xpub');
 		}
 		var isNewWallet = location.search.split('newwallet=')[1]
 		if (isNewWallet) {

--- a/src/cryptoadvance/specter/templates/wallet/receive/wallet_receive.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/receive/wallet_receive.jinja
@@ -227,8 +227,10 @@
 		}
 		function toggleKeyDisplay() {
 			let slip132Checkbox = document.getElementById('use_slip_132_pdf');
+			/* If at some point this view will show the key, the below selectors will be needed to convert back and forth depending on the switch selection
 			let xpubs = document.getElementsByClassName('slip132_xpub');
 			let zpubs = document.getElementsByClassName('normal_xpub');
+			*/
 		}
 		var isNewWallet = location.search.split('newwallet=')[1]
 		if (isNewWallet) {

--- a/src/cryptoadvance/specter/templates/wallet/receive/wallet_receive.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/receive/wallet_receive.jinja
@@ -189,7 +189,7 @@
 		<div style="margin: 0 auto;" class="center">
 			<label style="font-size: 1em;"">Use SLIP-132:&nbsp;</label>
 			<label class="switch">
-				<input type="checkbox" id="use_slip_132_pdf" style="margin: auto;" onchange="toggleKeyDisplay()" checked>
+				<input type="checkbox" id="use_slip_132_pdf" style="margin: auto;" onchange="toggleKeyDisplay()">
 				<span class="slider"></span>
 			</label><br>
 		</div>

--- a/src/cryptoadvance/specter/templates/wallet/settings/wallet_settings.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/settings/wallet_settings.jinja
@@ -43,7 +43,7 @@
 		<div id="keys_list" class="center" style="margin: auto; display: none; width: 85%;">
 			<label style="font-size: 1.3em;">Use SLIP-132:&nbsp;</label>
 			<label class="switch">
-				<input type="checkbox" id="use_slip_132" onchange="toggleKeyDisplay()" checked>
+				<input type="checkbox" id="use_slip_132" onchange="toggleKeyDisplay()">
 				<span class="slider"></span>
 			</label><br>
 			<p class="note" style="margin-top: 5px; max-width: 90%;">SLIP-132 extended public keys (xpubs) are a different format for xpubs which usually starts with zpub or ypub.</p>
@@ -137,7 +137,7 @@
 			<div style="margin: 0 auto;" class="center">
 				<label style="font-size: 1em;"">Use SLIP-132:&nbsp;</label>
 				<label class="switch">
-				<input type="checkbox" id="use_slip_132_pdf" style="margin: auto;" onchange="toggleKeyDisplay()" checked>
+				<input type="checkbox" id="use_slip_132_pdf" style="margin: auto;" onchange="toggleKeyDisplay()">
 				<span class="slider"></span>
 			</label><br>
 			</div>

--- a/src/cryptoadvance/specter/templates/wallet/settings/wallet_settings.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/settings/wallet_settings.jinja
@@ -134,6 +134,14 @@
 			It is recommended that you print and save this wallet backup file with each of your devices.
 			</p>
 			<button id="pdf-wallet-download" type="button" class="btn centered padded" style="margin: 30px auto;">Save Backup PDF</button>
+			<div style="margin: 0 auto;" class="center">
+				<label style="font-size: 1em;"">Use SLIP-132:&nbsp;</label>
+				<label class="switch">
+				<input type="checkbox" id="use_slip_132_pdf" style="margin: auto;" onchange="toggleKeyDisplay()" checked>
+				<span class="slider"></span>
+			</label><br>
+			</div>
+			<p class="note center" style="margin-top: 5px; max-width: 90%;">To format master keys on the PDF backup document.</p>
 			<p style="max-width: 500px;" class="note center">
 			This backup includes all the information you'd need to restore your wallet in Specter Desktop or other compatible wallets including Bitcoin Core itself.<br>
 			<p>


### PR DESCRIPTION
Added the SLIP-132 switch on the backup PDF view so the document can properly reflect master key format.
![image](https://user-images.githubusercontent.com/5783552/103934919-936c4f00-5104-11eb-8f2d-e0cae07a6c85.png)