### PR TITLE
Check whether tx address contains list before enumerating it

### DIFF
--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -538,8 +538,10 @@ class Wallet:
 
                 if isinstance(tx["address"], str):
                     tx["label"] = self.getlabel(tx["address"])
-                else:
+                elif isinstance(tx["address"], list):
                     tx["label"] = [self.getlabel(address) for address in tx["address"]]
+                else:
+                    tx["label"] = None
 
                 # TODO: validate for unique txids only
                 tx["validated_blockhash"] = ""  # default is assume unvalidated


### PR DESCRIPTION
If `tx["address"]` isn't string, current code assumes `tx["address"]` contains list and enumerates it. If `tx["address"]` is in reality `None`, exception `TypeError: NoneType object is not iterable` is raised and no transaction at all is displayed on the History tab (user just sees "No transactions found...").

I believe this fixes #850, because I can see abandoned tx on one of OP's screenshot of Bitcoin Core. I used to have abandoned tx in my wallet as well, and even though since that time I already rescanned my Bitcoin Core wallet, the CSV cache of my Specter wallet still contains record:

`{ABANDONED_TXID},,{ABANDONED_TX_UNIXTIME},[],{ABANDONED_RAW_TX},,,,,,,`

With this record in my CSV cache, Specter v1.0 fails to load the transaction History for the whole wallet - exactly as described in #850 (even though my Bitcoin Core wallet no longer contains the transaction). 