### PR TITLE
Fix no block height with Bitcoin Core v0.19

### DIFF
--- a/src/cryptoadvance/specter/server_endpoints/wallets.py
+++ b/src/cryptoadvance/specter/server_endpoints/wallets.py
@@ -949,6 +949,14 @@ def decoderawtx(wallet_alias):
         txid = request.form.get("txid", "")
         if txid:
             tx = wallet.rpc.gettransaction(txid)
+            # This is a fix for Bitcoin Core versions < v0.20
+            # These do not return the blockheight as part of the `gettransaction` command
+            # So here we check if this property is lacking and if so
+            # query the blockheader based on the transaction blockhash
+            ##################### Remove from here after dropping Core v0.19 support #####################
+            if "blockhash" in tx and "blockheight" not in tx:
+                tx["blockheight"] = wallet.rpc.getblockheader(tx["blockhash"])["height"]
+            ##################### Remove until here after dropping Core v0.19 support #####################
             return {
                 "success": True,
                 "tx": tx,

--- a/src/cryptoadvance/specter/templates/includes/tx-data.html
+++ b/src/cryptoadvance/specter/templates/includes/tx-data.html
@@ -82,7 +82,7 @@
                 }
                 if (tx.confirmations) {
                     rawtxHTML += `
-                        <tr><td>Mine at block:</td><td>${tx.blockheight}</td></tr>
+                        <tr><td>Mined at block:</td><td>${tx.blockheight}</td></tr>
                         <tr><td>Block hash:</td><td style="word-break: break-all;">${tx.blockhash}</td></tr>
                         <tr><td>Block time:</td><td>${new Date(tx.blocktime * 1000)} <span style="font-size: 0.9em;color: #ccc;">(${tx.blocktime})</span></td></tr>
                     `;

--- a/src/cryptoadvance/specter/util/price_providers.py
+++ b/src/cryptoadvance/specter/util/price_providers.py
@@ -70,7 +70,6 @@ def get_price_at(specter, current_user, timestamp="now"):
                     currency = "gbp"
                     currency_symbol = "£"
                 exchange = specter.price_provider.split("spotbit_")[1]
-                print(timestamp)
                 if timestamp == "now":
                     price = requests_session.get(
                         "http://h6zwwkcivy2hjys6xpinlnz2f74dsmvltzsd4xb42vinhlcaoe7fdeqd.onion/now/{}/{}".format(
@@ -78,7 +77,6 @@ def get_price_at(specter, current_user, timestamp="now"):
                         )
                     ).json()["close"]
                 else:
-                    print(timestamp)
                     price = requests_session.get(
                         "http://h6zwwkcivy2hjys6xpinlnz2f74dsmvltzsd4xb42vinhlcaoe7fdeqd.onion/hist/{}/{}/{}/{}".format(
                             currency,

--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -145,6 +145,10 @@ class Wallet:
                 or not self._transactions[tx["txid"]].get("address", None)
                 or self._transactions[tx["txid"]].get("blockhash", None)
                 != tx.get("blockhash", None)
+                or (
+                    self._transactions[tx["txid"]].get("blockhash", None)
+                    and not self._transactions[tx["txid"]].get("blockheight", None)
+                )  # Fix for Core v19 with Specter v1
                 or self._transactions[tx["txid"]].get("conflicts", [])
                 != tx.get("walletconflicts", [])
             ]


### PR DESCRIPTION
Bitcoin Core v0.19 doesn't return the `blockheight` as part of the `gettransaction` command, which currently breaks Specter blockheight caching and tx details display.

Adding here a fix to calculate the blockheight if the property doesn't exist, but this should be removed once we drop support for Bitcoin Core v0.19.

Fix #851 