### PR TITLE
Display slashes and parentheses correctly in tx labels

### DIFF
--- a/src/cryptoadvance/specter/templates/includes/tx-table.html
+++ b/src/cryptoadvance/specter/templates/includes/tx-table.html
@@ -516,7 +516,7 @@
                             data-btc-unit="${self.btcUnit ? self.btcUnit : 'btc'}"
                             data-price="${self.price ? self.price : 0}"
                             data-symbol="${self.symbol ? self.symbol : ''}"
-                            data-tx='${JSON.stringify(tx).replace(/[\/\(\)\']/g, "&apos;")}'
+                            data-tx='${JSON.stringify(tx).replace(/[\(]/g, "&lpar;").replace(/[\)]/g, "&rpar;").replace(/[\/]/g, "&sol;").replace(/[\']/g, "&apos;")}'
                             data-wallet="${(self.wallet ? self.wallet : tx.wallet_alias)}"
                             data-show-blockhash="${showBlockhash}">
                             </tx-row>


### PR DESCRIPTION
Replace slashes and parentheses in tx data by corresponding HTML5 entities (and not all by `&apos;`).

Without this PR, Specter (e.g. v1.0) displays all slashes and parentheses in tx labels as apostrophes (in both History and UTXO views).