### PR TITLE
[FIX] #784 URL encode to prevent breaking characters on RPC connection

### DIFF
--- a/src/cryptoadvance/specter/rpc.py
+++ b/src/cryptoadvance/specter/rpc.py
@@ -2,6 +2,7 @@ import logging
 import requests, json, os
 import os, sys, errno
 from .helpers import is_ip_private
+import urllib.parse
 
 logger = logging.getLogger(__name__)
 
@@ -259,9 +260,10 @@ class BitcoinRPC:
 
     @property
     def url(self):
-        return "{s.protocol}://{s.user}:{s.password}@{s.host}:{s.port}{s.path}".format(
-            s=self
-        )
+        user = urllib.parse.quote_plus("{s.user}".format(s=self));
+        password = urllib.parse.quote_plus("{s.password}".format(s=self));
+        encoded = "{s.protocol}://".format(s=self)+user+":"+password+"@{s.host}:{s.port}{s.path}".format(s=self)
+        return encoded;
 
     def test_connection(self):
         """ returns a boolean depending on whether getblockchaininfo() succeeds """

--- a/src/cryptoadvance/specter/rpc.py
+++ b/src/cryptoadvance/specter/rpc.py
@@ -262,8 +262,15 @@ class BitcoinRPC:
     def url(self):
         user = urllib.parse.quote_plus("{s.user}".format(s=self));
         password = urllib.parse.quote_plus("{s.password}".format(s=self));
-        encoded = "{s.protocol}://".format(s=self)+user+":"+password+"@{s.host}:{s.port}{s.path}".format(s=self)
-        return encoded;
+        encoded = (
+            "{s.protocol}://".format(s=self)
+            +user
+            +":"
+            +password
+            +"@{s.host}:{s.port}{s.path}".format(s=self)
+        )
+        return encoded
+
 
     def test_connection(self):
         """ returns a boolean depending on whether getblockchaininfo() succeeds """

--- a/src/cryptoadvance/specter/rpc.py
+++ b/src/cryptoadvance/specter/rpc.py
@@ -260,17 +260,16 @@ class BitcoinRPC:
 
     @property
     def url(self):
-        user = urllib.parse.quote_plus("{s.user}".format(s=self));
-        password = urllib.parse.quote_plus("{s.password}".format(s=self));
+        user = urllib.parse.quote_plus("{s.user}".format(s=self))
+        password = urllib.parse.quote_plus("{s.password}".format(s=self))
         encoded = (
             "{s.protocol}://".format(s=self)
-            +user
-            +":"
-            +password
-            +"@{s.host}:{s.port}{s.path}".format(s=self)
+            + user
+            + ":"
+            + password
+            + "@{s.host}:{s.port}{s.path}".format(s=self)
         )
         return encoded
-
 
     def test_connection(self):
         """ returns a boolean depending on whether getblockchaininfo() succeeds """


### PR DESCRIPTION
This fixes #784 by doing url encode on both user and password and thus, parsing characters that might break the URL format.