### PR TITLE
Fix typo (puropse -> purpose)

### DIFF
--- a/src/cryptoadvance/specter/templates/device/new_device.jinja
+++ b/src/cryptoadvance/specter/templates/device/new_device.jinja
@@ -282,7 +282,7 @@
 
             let xpubAddCustomRowHTML =  `
                 <td></td>
-                <td><input id="new_xpub_purpose" type="text" placeholder="XPUB puropse"></td>
+                <td><input id="new_xpub_purpose" type="text" placeholder="XPUB purpose"></td>
                 <td><input id="new_xpub_derivation" type="text" placeholder="m/..."></td>
                 <td></td>
                 <td><button type="button" class="btn" style="width: 60px;" onclick="addCustomDerivation()">Add</button></td>


### PR DESCRIPTION
Fix typo on the word "purpose" in the 'Add Device' screen.

Screenshot of typo as it is right now:

<img width="957" alt="Screen Shot 2021-01-21 at 2 15 22 PM" src="https://user-images.githubusercontent.com/1823216/105400605-27edab80-5bf3-11eb-8ff8-45fdade3c6e6.png">
