### PR TITLE
UIUX Fix #829 - Aligned notification font size, fixed notification horizontal alignment

### DIFF
--- a/src/cryptoadvance/specter/static/styles.css
+++ b/src/cryptoadvance/specter/static/styles.css
@@ -576,8 +576,10 @@ textarea{
 #messages{
     position: absolute;
     top: 0;
-    left: 50%;
-    transform:translateX(-50%);
+    width: inherit;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
     z-index: 99999;
 }
 .btn.danger{

--- a/src/cryptoadvance/specter/templates/includes/message-box.html
+++ b/src/cryptoadvance/specter/templates/includes/message-box.html
@@ -8,7 +8,7 @@
     .main{
         min-width: 200px;
         max-width: 800px;
-        font-size: 0.7em;
+        font-size: 0.85em;
         color: #fff;
         overflow-x: scroll;
         background: var(--cmap-bg-lightest);
@@ -48,9 +48,12 @@
     .main::-webkit-scrollbar{
       display: none;
     }
+    .close {
+      margin: 0px -22px;
+    }
   </style>
   <div class="main">
-    <a class="close">⨉</a>
+    <a class="close">&#x2715;</a>
     <slot>
      Error: Something bad happened!
     </slot>


### PR DESCRIPTION
### Notification horizontal alignment
Fixed the horizontal alignment of notifications. They are now centered horizontally within the main content. On top of that ... :

- Notification font size now aligned with button font size as per #829 
- Using the unicode equivalent character for the close button

#### Before
![Bildschirmfoto 2021-01-22 um 15 27 14](https://user-images.githubusercontent.com/77632998/105508950-458f4380-5ccd-11eb-9427-280772c92b95.png)

#### After
![Bildschirmfoto 2021-01-22 um 15 54 24](https://user-images.githubusercontent.com/77632998/105508971-4d4ee800-5ccd-11eb-9abb-e12ba21dca59.png)
![Bildschirmfoto 2021-01-22 um 15 57 39](https://user-images.githubusercontent.com/77632998/105509002-550e8c80-5ccd-11eb-989c-2a4b255cfeea.png)
![Bildschirmfoto 2021-01-22 um 15 58 19](https://user-images.githubusercontent.com/77632998/105509026-5cce3100-5ccd-11eb-82a5-0dd166d32c00.png)

Tested on Chromium, Firefox, Safari.