### PR TITLE
Add target="_blank" for help links

### DIFF
--- a/src/cryptoadvance/specter/templates/settings/bitcoin_core_settings.jinja
+++ b/src/cryptoadvance/specter/templates/settings/bitcoin_core_settings.jinja
@@ -76,7 +76,7 @@
 								Please doublecheck the Host and the Port. Make sure you can reach
 								the host and make sure that Bitcoin-Core is listening at the port
 								you have specified. 
-								For more hints, please look at this <a style="color:grey" href="https://github.com/cryptoadvance/specter-desktop/blob/master/docs/connect-your-node.md">article</a>.
+								For more hints, please look at this <a style="color:grey" href="https://github.com/cryptoadvance/specter-desktop/blob/master/docs/connect-your-node.md" target="_blank">article</a>.
 							</tool-tip>
 						{% else %}
 							<div></div>
@@ -90,7 +90,7 @@
 							<tool-tip title="Your Credentials don't work" style="float: right;">
 								Please doublecheck the user and the Password. Look at the bitcoin.conf
 								for the correct values in that field.
-								For more hints, please look at this <a style="color:grey" href="https://github.com/cryptoadvance/specter-desktop/blob/master/docs/connect-your-node.md">article</a>.
+								For more hints, please look at this <a style="color:grey" href="https://github.com/cryptoadvance/specter-desktop/blob/master/docs/connect-your-node.md" target="_blank">article</a>.
 							</tool-tip>
 						{% else %}
 							<div></div>


### PR DESCRIPTION
Otherwise, it opens in the Electron app itself.