### PR TITLE
Fix #605 - Display UI notification after btc core connection test

### DIFF
--- a/src/cryptoadvance/specter/key.py
+++ b/src/cryptoadvance/specter/key.py
@@ -42,8 +42,8 @@ class Key:
             derivation = ""
         if key_type not in purposes:
             key_type = ""
-        if not purpose or purpose not in list(purposes.values()):
-            purpose = purposes[key_type]
+        if not purpose:
+            purpose = purposes.get(key_type, "General")
         self.original = original
         self.fingerprint = fingerprint
         self.derivation = derivation

--- a/src/cryptoadvance/specter/server_endpoints/settings.py
+++ b/src/cryptoadvance/specter/server_endpoints/settings.py
@@ -93,6 +93,12 @@ def bitcoin_core():
                 autodetect=autodetect,
                 datadir=datadir,
             )
+
+            if "tests" in test:
+                if not test["tests"]["connectable"]:
+                    flash(f"Test failed: {test['err']}", "error")
+                else:
+                    flash("Test passed", "info")
         elif action == "save":
             if current_user.is_admin:
                 success = app.specter.update_rpc(

--- a/src/cryptoadvance/specter/server_endpoints/settings.py
+++ b/src/cryptoadvance/specter/server_endpoints/settings.py
@@ -95,7 +95,8 @@ def bitcoin_core():
             )
 
             if "tests" in test:
-                if not test["tests"]["connectable"]:
+                # If any test has failed, we notify the user that the test has not passed
+                if False in list(test["tests"].values()):
                     flash(f"Test failed: {test['err']}", "error")
                 else:
                     flash("Test passed", "info")

--- a/src/cryptoadvance/specter/templates/settings/bitcoin_core_settings.jinja
+++ b/src/cryptoadvance/specter/templates/settings/bitcoin_core_settings.jinja
@@ -31,7 +31,7 @@
 				Bitcoin Core data directory path:<br><input type="text" id="datadir" name="datadir" type="text" value="{{ datadir }}">
 			</span>
 			<br><br>
-			<div id="rpc_settings" style="padding: 10px; border-radius: 10px;">
+			<div id="rpc_settings">
 				<div id="lock" class="center">
 					<p style="text-align: center; margin: auto; ">&#128274;</p>
 					<span class="note centered"> (disable auto-detect to configure manually)</span>

--- a/src/cryptoadvance/specter/templates/settings/bitcoin_core_settings.jinja
+++ b/src/cryptoadvance/specter/templates/settings/bitcoin_core_settings.jinja
@@ -151,6 +151,9 @@
 					datadirContainer.style.removeProperty('display');
 					rpcSettings.style['pointer-events'] = 'none';
 					rpcSettings.style['background-color'] = '#8881';
+					rpcSettings.style['padding'] = '10px';
+					rpcSettings.style['border-radius'] = '10px';
+
 					scanRpc.style.display = 'none';
 					document.getElementById("username").value = '{{ username }}';
 					document.getElementById("password").value = '{{ password }}';
@@ -159,6 +162,8 @@
 					datadirContainer.style['display'] = 'none';
 					rpcSettings.style.removeProperty('background-color');
 					rpcSettings.style.removeProperty('pointer-events');
+					rpcSettings.style.removeProperty('padding');
+					rpcSettings.style.removeProperty('border-radius');
 					scanRpc.style.removeProperty('display');
 				}
 			}


### PR DESCRIPTION
The result of a BTC core connection test was not 100% obvious before. You had to scroll down to check the results.

This PR introduces a simple UI notification that gives initial feedback about the test, while keeping the full fledged test results at the bottom of the page.

![Bildschirmfoto 2021-01-27 um 11 17 03](https://user-images.githubusercontent.com/77632998/105987077-10ed0480-609e-11eb-9dba-28d8ec4ae8f7.png)
![Bildschirmfoto 2021-01-27 um 11 16 19](https://user-images.githubusercontent.com/77632998/105987095-164a4f00-609e-11eb-8efc-4b517df5f159.png)
