### PR TITLE
Bugfix: Cypress-tests

### DIFF
--- a/cypress/integration/spec_empty_specter_home.js
+++ b/cypress/integration/spec_empty_specter_home.js
@@ -50,6 +50,7 @@ describe('Completely empty specter-home', () => {
     cy.get('[value="test"]').click()
     cy.get(':nth-child(2) > button > div').should('have.css', 'color', 'rgb(0, 128, 0)') // connectable: green
     cy.get(':nth-child(5) > button > div').should('have.css', 'color', 'rgb(255, 0, 0)') // Credentials: red
+    cy.get('message-box').shadow().find('div.error > a').click()
     cy.get('#password').clear()
     cy.get('#password').type("secret")
     cy.get('[value="test"]').click()
@@ -57,6 +58,7 @@ describe('Completely empty specter-home', () => {
     cy.get(':nth-child(5) > button > div').should('have.css', 'color', 'rgb(0, 128, 0)') // Credentials: green
     cy.get(':nth-child(8) > button > div').should('have.css', 'color', 'rgb(0, 128, 0)') // Version green
     cy.get(':nth-child(11) > button > div').should('have.css', 'color', 'rgb(0, 128, 0)') // Walletsenabled green
+    cy.get('message-box').shadow().find('div.main > a').click()
     cy.get('[value="save"]').click()
 
   })


### PR DESCRIPTION
The error-messages while the node is not detected properly needs to be clicked away before one can press the save-button. Weird, but ok.