### PR TITLE
Fix a minor bug that always shows addresses as used

### DIFF
--- a/src/cryptoadvance/specter/templates/includes/address-data.html
+++ b/src/cryptoadvance/specter/templates/includes/address-data.html
@@ -35,7 +35,7 @@
             this.info = clone.querySelector(".address-data-info");
             this.isVerifyQR = this.getAttribute('data-verify-qr') == 'True';
             this.isVerifyHwi = this.getAttribute('data-verify-hwi') == 'True';
-            this.used = this.getAttribute('data-used');
+            this.used = (this.getAttribute('data-used') == 'true');
             this.utxo = this.getAttribute('data-utxo');
             this.amount = this.getAttribute('data-amount');
             this.amountPrice = this.getAttribute('data-amount-price');


### PR DESCRIPTION
In the line 39 of the file templates/includes/address-data.html , the variable _this.used_ is set as string.
So the conditional in line 85 always returns true and so, any address will be shown as used.