### PR TITLE
Add failed wallets popup

### DIFF
--- a/src/cryptoadvance/specter/server_endpoints/wallets.py
+++ b/src/cryptoadvance/specter/server_endpoints/wallets.py
@@ -59,6 +59,30 @@ def wallets_overview():
     )
 
 
+################## Failed wallets fix #######################
+
+
+@wallets_endpoint.route("/failed_wallets/", methods=["POST"])
+@login_required
+def failed_wallets():
+    if request.method == "POST":
+        action = request.form["action"]
+        if action == "retry_loading_wallets":
+            app.specter.wallet_manager.update()
+        elif action == "delete_failed_wallet":
+            try:
+                wallet = json.loads(request.form["wallet_data"])
+                fullpath = wallet["fullpath"]
+                delete_file(fullpath)
+                delete_file(fullpath + ".bkp")
+                delete_file(fullpath.replace(".json", "_addr.csv"))
+                delete_file(fullpath.replace(".json", "_txs.csv"))
+                app.specter.wallet_manager.update()
+            except Exception as e:
+                flash(f"Failed to delete failed wallet: {str(e)}", "error")
+    return redirect("/")
+
+
 ################## New wallet #######################
 
 

--- a/src/cryptoadvance/specter/templates/includes/sidebar/sidebar.jinja
+++ b/src/cryptoadvance/specter/templates/includes/sidebar/sidebar.jinja
@@ -115,6 +115,36 @@
         {% endif %}
         {% if specter.chain %}
             {{ sidebar_btn(url_for('wallets_endpoint.new_wallet_type'), 'Add new wallet', 'btn_new_wallet') }}
+            {% if specter.wallet_manager.failed_load_wallets %}
+                <form action="{{ url_for('wallets_endpoint.failed_wallets') }}" method="POST">
+                    <p class="warning center">
+                        &#9432;<br>Failed to load some wallets<br>
+                        <button class="btn" name="action" value="retry_loading_wallets" style="margin: auto;">Retry loading wallets</button>
+                        <button type="button" class="btn" onclick="showPageOverlay('failed_wallets_popup')" style="margin: auto; margin-top: 5px;">Show Details</button>
+                    </p>
+                </form>
+                <div class="hidden" id="failed_wallets_popup">
+                    {% for wallet in specter.wallet_manager.failed_load_wallets %}
+                        <div class="card">
+                            <h1>Wallet Name: {{wallet.name}}</h1>
+                            <h2>Error Details:</h2>
+                            <p style="color: red">{{wallet.loading_error}}</p>
+                            <br><br>
+                            <form action="{{ url_for('wallets_endpoint.failed_wallets') }}" method="POST" class="row center">
+                                <input type="hidden" name="wallet_data" value='{{ wallet|tojson|safe }}' />
+                                <a class="btn" id="download_failed_wallet_{{wallet.alias}}" download="{{ wallet.name }}.json" style="width: 180px; height: 35px; margin-top: 1.5px;">Download wallet file</a>&nbsp;&nbsp;
+                                <button class="btn" type="submit" name="action" value="importwallet" formaction="{{ url_for('wallets_endpoint.new_wallet', wallet_type='import_wallet') }}">Recreate the wallet</button>&nbsp;&nbsp;
+                                <button class="btn" name="action" value="delete_failed_wallet">Delete wallet</button>
+                            </form>
+                        </div>
+                        <script>
+                            document.addEventListener("DOMContentLoaded", function(){
+                                document.getElementById('download_failed_wallet_{{wallet.alias}}').href = 'data:text/json,' + encodeURIComponent(`{{ wallet|tojson }}`);
+                            });
+                        </script>
+                    {% endfor %}
+                </div>
+            {% endif %}
         {% else %}
             <p class="warning">
             &#9432;<br>Wallets are unavailable if Specter is not connected to Bitcoin Core!<br>


### PR DESCRIPTION
Adds a warning of wallets which Specter failed to load in case an error was encountered.

Clicking on the Show details will show a popup with a list of the wallets Specter failed to load, the error, and options on how to proceed. Not really sure about the design of the list, wasn't sure what details to include there...

<img width="257" alt="Screen Shot 2021-02-16 at 18 24 04" src="https://user-images.githubusercontent.com/10667901/108091292-3dd07e00-7084-11eb-8841-15df604e094d.png">
<img width="636" alt="Screen Shot 2021-02-16 at 18 24 27" src="https://user-images.githubusercontent.com/10667901/108091268-3610d980-7084-11eb-9eeb-561445277610.png">


