### PR TITLE
Bugfix to restore rpc cookie after bitcoind restart

### DIFF
--- a/src/cryptoadvance/specter/specter.py
+++ b/src/cryptoadvance/specter/specter.py
@@ -67,9 +67,9 @@ def get_rpc(
     if rpc is None:
         # check if old rpc is still valid
         return old_rpc if old_rpc.test_connection() else None
-    # check if something have changed
-    # and return new rpc if so
-    if rpc.url == old_rpc.url:
+    # check if something has changed and return new rpc if so.
+    # RPC cookie will have a new password if bitcoind is restarted.
+    if rpc.url == old_rpc.url and rpc.password == old_rpc.password:
         return old_rpc
     else:
         logger.info("rpc config have changed.")


### PR DESCRIPTION
When bitcoind is restarted its auth cookie is regenerated. If Specter Desktop is connecting via RPC cookie, it does reread and instantiate a new rpc but the check in `get_rpc` fails to notice the change and instead returns the `old_rpc` which is no longer valid.