### PR TITLE
Bugfix on missing csrf in js fetch calls, pending send bug

### DIFF
--- a/src/cryptoadvance/specter/templates/includes/overlay/sign_tx_method.jinja
+++ b/src/cryptoadvance/specter/templates/includes/overlay/sign_tx_method.jinja
@@ -79,7 +79,7 @@
                 {% else %}
                 <h2>Proceed with signing</h2>
                 {% endif %}
-                <form action="?" method="POST" id="hot_enter_passphrase__content" class="flex-center flex-column">
+                <form action="{{ url_for('wallets_endpoint.send_new', wallet_alias=wallet.alias) }}" method="POST" id="hot_enter_passphrase__content" class="flex-center flex-column">
                     <input type="hidden" class="csrf-token" name="csrf_token" value="{{ csrf_token() }}"/>
                     <br/>
                     <div>

--- a/src/cryptoadvance/specter/templates/wallet/send/sign/wallet_send_sign_psbt.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/send/sign/wallet_send_sign_psbt.jinja
@@ -350,7 +350,7 @@
 
 				if (jsonResponse.success) {
 					hidePageOverlay();
-					window.location.replace("../history/");
+					window.location.replace("{{ url_for('wallets_endpoint.history', wallet_alias=wallet.alias) }}");
 				} else {
 					showError("Server failed to broadcast transactions!\n" + jsonResponse.error);
 				}

--- a/src/cryptoadvance/specter/templates/wallet/send/sign/wallet_send_sign_psbt.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/send/sign/wallet_send_sign_psbt.jinja
@@ -266,6 +266,7 @@
 			let url = "{{ url_for('wallets_endpoint.combine', wallet_alias=wallet.alias) }}";
 
 			var formData = new FormData();
+			formData.append("csrf_token", "{{ csrf_token() }}");
 			formData.append("psbt0", psbt0);
 			formData.append("psbt1", psbt1);
 			formData.append("txid", "{{ psbt['tx']['txid'] }}");
@@ -333,6 +334,7 @@
 			let url="{{ url_for('wallets_endpoint.broadcast', wallet_alias=wallet.alias) }}";
 
 			var formData = new FormData();
+			formData.append("csrf_token", "{{ csrf_token() }}");
 			formData.append("tx", tx);
 
 			try {


### PR DESCRIPTION
* JS `fetch` POSTs are failing the `flask_wtf` csrf checks on `combine` and `broadcast`. Adds missing `csrf_token` to the payload.
* Pending psbt signing going nowhere on submit because of the form `action="?"` (but works fine for new psbts). Fixed to explicitly point to the `send/new` endpoint.
* Oddity where HWI signing a pending psbt (KeepKey) was getting misrouted with "/history" improperly appended to url. Did not occur when signing new psbts. Did not occur when signing with bitcoin core hot wallet. Fixed to explicitly point to the `history` endpoint.