### PR TITLE
Doc update to specify correct docker tag

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -65,7 +65,7 @@ pytest
 
 # needs a working docker-setup (but not bitcoind)
 # prerequsisite: 
-# docker pull registry.gitlab.com/cryptoadvance/specter-desktop/python-bitcoind:latest
+# docker pull registry.gitlab.com/cryptoadvance/specter-desktop/python-bitcoind:v0.20.1
 pytest --docker 
 
 # Run all the tests in a specific test-file


### PR DESCRIPTION
The "latest" docker image is older than the "v0.20.1" image and the test suite hard-codes a v0.20.1 assumption in a number of places (e.g. `pytest.ini`, `conftest.py`). As a result the test suite fails against "latest".