### PR TITLE
Keep local dev .specter data separate

### DIFF
--- a/src/cryptoadvance/specter/config.py
+++ b/src/cryptoadvance/specter/config.py
@@ -71,6 +71,9 @@ class BaseConfig(object):
 class DevelopmentConfig(BaseConfig):
     # https://stackoverflow.com/questions/22463939/demystify-flask-app-secret-key
     SECRET_KEY = "development key"
+    SPECTER_DATA_FOLDER = os.path.expanduser(
+        os.getenv("SPECTER_DATA_FOLDER", "~/.specter_dev")
+    )
 
 
 class TestConfig(BaseConfig):


### PR DESCRIPTION
_(originally tried to submit this as a simple patch PR just using the github UI. Dunno why the Black formatting pass failed. Trying again here)_

I use my laptop for local dev as well as real-world Specter/bridge mode use. Local dev is often set up to connect to a local bitcoind. Real-world use connects to my node on a different machine. Adding this to make it easier to keep my worlds separate.