### PR TITLE
Default bitcoind timeout to 60s for all platforms

### DIFF
--- a/src/cryptoadvance/specter/bitcoind.py
+++ b/src/cryptoadvance/specter/bitcoind.py
@@ -97,7 +97,7 @@ class BitcoindController:
         cleanup_hard=False,
         datadir=None,
         extra_args=[],
-        timeout=30,
+        timeout=60,
     ):
         """starts bitcoind with a specific rpcport=18543 by default.
         That's not the standard in order to make pytest running while
@@ -184,7 +184,7 @@ class BitcoindController:
             return False
 
     @staticmethod
-    def wait_for_bitcoind(rpcconn, timeout=30):
+    def wait_for_bitcoind(rpcconn, timeout=60):
         """ tries to reach the bitcoind via rpc. Timeout after n seconds """
         i = 0
         while True:

--- a/src/cryptoadvance/specter/util/bitcoind_setup_tasks.py
+++ b/src/cryptoadvance/specter/util/bitcoind_setup_tasks.py
@@ -170,13 +170,8 @@ def setup_bitcoind_directory_thread(specter=None, quicksync=True, pruned=True):
         specter._save()
 
         # Specter's 'bitcoind' attribute will instantiate a BitcoindController as needed
-        timeout = 30
-        if platform.system() == "Linux" and "armv" in platform.machine():
-            # Raspberry Pi will need more time to spin up bitcoind
-            timeout = 60
         specter.bitcoind.start_bitcoind(
-            datadir=os.path.expanduser(specter.config["rpc"]["datadir"]),
-            timeout=timeout,
+            datadir=os.path.expanduser(specter.config["rpc"]["datadir"])
         )
         specter.set_bitcoind_pid(specter.bitcoind.bitcoind_proc.pid)
         specter.update_use_external_node(False)


### PR DESCRIPTION
Timeout was expanded specifically for under-powered Raspberry Pis but just ran a test with a 2010 Macbook Air that also needs more than 30s to spin up bitcoind and respond. With my local code updated to 60s the Macbook Air was able to get bitcoind to respond in time.

I don't see any reason not to just default to 60s for everyone.

_Note/future TODO: If you successfully install bitcoin core through the UI but the `wait_for_bitcoind` times out, the wizard does not know to resume from the `start_bitcoind` call and instead starts doing the QuickSync download again. Current workaround is to go to settings and turn on the built-in node. But if the device failed the `wait_for_bitcoind` timeout once, I'd guess it'll keep failing until the timeout is expanded. Might need a "try again" option that extends the timeout even further._