### PR TITLE
UIUX: Only tor quicksync warning

### DIFF
--- a/src/cryptoadvance/specter/templates/node_setup_wizard.jinja
+++ b/src/cryptoadvance/specter/templates/node_setup_wizard.jinja
@@ -134,7 +134,7 @@
 
         </div>
         <br>
-        {% if not specter.only_tor  %}
+        {% if specter.only_tor  %}
         You have activated to only connect via Tor. This will significantly slow down the download-process and is not recommended.
         <br>
         {% endif %}

--- a/src/cryptoadvance/specter/templates/node_setup_wizard.jinja
+++ b/src/cryptoadvance/specter/templates/node_setup_wizard.jinja
@@ -131,8 +131,14 @@
         <div class="row center">
             <p class="explorer-link" id="step4-helper" onclick="toggleHelper('step4')">Unsure? Click here for more info!</p>
             <a class="explorer-link hidden" id="step4-support" href="https://t.me/spectersupport" target="_blank">Still need help?</a>
+
         </div>
-        <br><br>
+        <br>
+        {% if not specter.only_tor  %}
+        You have activated to only connect via Tor. This will significantly slow down the download-process and is not recommended.
+        <br>
+        {% endif %}
+        <br>
         <div class="row">
             <button type="button" class="btn wizard-btn action" id="setup-bitcoind-dir-button" onclick="setupBitcoindDirectory()">Start Syncing!</button>
         </div>


### PR DESCRIPTION
Show a warning like this if you try to download the quicksync-chain via tor:

![image](https://user-images.githubusercontent.com/117085/112351952-a1c11480-8cca-11eb-8da8-44e3f801eecb.png)
