### PR TITLE
Resolve "Network Error" issue when clicking on Download Specter Backup link

### DIFF
--- a/src/cryptoadvance/specter/templates/settings/general_settings.jinja
+++ b/src/cryptoadvance/specter/templates/settings/general_settings.jinja
@@ -20,7 +20,7 @@
 			Specter Data Backup:
 			<br><br>
 			<div class="row">
-				<a href="{{ url_for('settings_endpoint.backup_file') }}" download class="btn" style="width: 100%; margin-top: -5px;">Download Specter backup files</a>
+				<a href="{{ url_for('settings_endpoint.backup_file') }}" class="btn" style="width: 100%; margin-top: -5px;">Download Specter backup files</a>
 			</div>
 			<br>
 			<div class="tool-tip" style="float: right; margin-bottom: 5px;">


### PR DESCRIPTION
Resolve download issue in Chrome and Edge. They don't like the download attribute on the anchor tag.

Maybe due to origin checks with self-signed certs?

https://www.w3schools.com/tags/att_a_download.asp