### PR TITLE
adding regular logs to core-settings-page

### DIFF
--- a/src/cryptoadvance/specter/server_endpoints/controller.py
+++ b/src/cryptoadvance/specter/server_endpoints/controller.py
@@ -3,13 +3,7 @@ from datetime import datetime
 from binascii import unhexlify
 from flask import make_response
 
-from flask import (
-    render_template,
-    request,
-    redirect,
-    url_for,
-    flash,
-)
+from flask import render_template, request, redirect, url_for, flash, Markup
 from flask_login import login_required, current_user
 from ..helpers import (
     generate_mnemonic,
@@ -99,8 +93,11 @@ def server_error_timeout(e):
         # make sure specter knows that rpc is not there
         app.specter.check()
     app.logger.error("ExternalProcessTimeoutException: %s" % e)
-    flash("Bitcoin Core node is starting up, please refresh in a few seconds")
-    return redirect(url_for("settings_endpoint.bitcoin_core"))
+    flash(
+        "Bitcoin Core is not coming up in time. Maybe it's just slow but please check the logs below",
+        "warn",
+    )
+    return redirect(url_for("settings_endpoint.bitcoin_core_internal_logs"))
 
 
 ########## on every request ###############

--- a/src/cryptoadvance/specter/server_endpoints/controller.py
+++ b/src/cryptoadvance/specter/server_endpoints/controller.py
@@ -106,6 +106,8 @@ def selfcheck():
     """check status before every request"""
     if app.specter.rpc is not None:
         type(app.specter.rpc).counter = 0
+        if not app.specter.chain:
+            app.specter.check()
     if app.config.get("LOGIN_DISABLED"):
         app.login("admin")
 

--- a/src/cryptoadvance/specter/server_endpoints/settings.py
+++ b/src/cryptoadvance/specter/server_endpoints/settings.py
@@ -25,6 +25,7 @@ from ..persistence import write_devices, write_wallet
 from ..user import hash_password
 from ..util.tor import start_hidden_service, stop_hidden_services
 from ..util.sha256sum import sha256sum
+from ..util.shell import get_last_lines_from_file
 from ..specter_error import handle_exception, ExtProcTimeoutException
 
 rand = random.randint(0, 1e32)  # to force style refresh
@@ -40,6 +41,19 @@ def settings():
         return redirect(url_for("settings_endpoint.bitcoin_core"))
     else:
         return redirect(url_for("settings_endpoint.general"))
+
+
+@settings_endpoint.route("/bitcoin_core/internal_logs", methods=["GET"])
+@login_required
+def bitcoin_core_internal_logs():
+    logfile_location = os.path.join(
+        app.specter.config["internal_node"]["datadir"], "debug.log"
+    )
+    return render_template(
+        "settings/bitcoin_core_internal_logs.jinja",
+        specter=app.specter,
+        loglines="".join(get_last_lines_from_file(logfile_location)),
+    )
 
 
 @settings_endpoint.route("/bitcoin_core", methods=["GET", "POST"])

--- a/src/cryptoadvance/specter/templates/node_setup_wizard.jinja
+++ b/src/cryptoadvance/specter/templates/node_setup_wizard.jinja
@@ -357,7 +357,6 @@
                     let stage = result.stage;
                     let progress = parseFloat(result.stage_progress);
                     if (progress == -1) {
-                        showNotification('Finished successfully');
                         showStep(++currentStep);
                         document.getElementById('stage-progress-details').classList.add('hidden');
                         document.getElementById('show-progress-details').classList.add('hidden');

--- a/src/cryptoadvance/specter/templates/settings/bitcoin_core_internal_logs.jinja
+++ b/src/cryptoadvance/specter/templates/settings/bitcoin_core_internal_logs.jinja
@@ -1,0 +1,25 @@
+{% extends "base.jinja" %}
+{% block main %}
+
+	<form action="?" method="POST">
+		<input type="hidden" class="csrf-token" name="csrf_token" value="{{ csrf_token() }}"/>
+		<h1 id="title" class="settings-title">Settings</h1>
+		{% from 'settings/components/settings_menu.jinja' import settings_menu %}
+		{% from 'settings/components/settings_menu_item.jinja' import settings_menu_item %}
+		{{ settings_menu('bitcoin_core', current_user) }}
+		<nav class="row">
+			{{ settings_menu_item('bitcoin_core', 'Built In Node', False, isLeft=True) }}
+			{{ settings_menu_item('bitcoin_core', 'Built In Node', False) }}
+			{{ settings_menu_item('bitcoin_core_internal_logs', 'Bitcoind Logs', 'bitcoin_core_internal_logs', isRight=True) }}
+		</nav>
+	</form>
+
+		<br><br><br>
+        <div class="card" style="width:90%; max-width: 1000px;">
+            Bitcoin Logs:
+            <pre><code>{{ loglines }}</code></pre>
+            <br>
+            <div>If this is an issue, please let us know! Create an <a href="https://github.com/cryptoadvance/specter-desktop/issues" target="_blank">issue</a> or ping us on <a href="https://t.me/spectersupport" target="_blank">Telegram</a> to fix it.</div>
+		</div>
+		
+{% endblock %}

--- a/src/cryptoadvance/specter/templates/settings/bitcoin_core_internal_logs.jinja
+++ b/src/cryptoadvance/specter/templates/settings/bitcoin_core_internal_logs.jinja
@@ -7,19 +7,15 @@
 		{% from 'settings/components/settings_menu.jinja' import settings_menu %}
 		{% from 'settings/components/settings_menu_item.jinja' import settings_menu_item %}
 		{{ settings_menu('bitcoin_core', current_user) }}
-		<nav class="row">
-			{{ settings_menu_item('bitcoin_core', 'Built In Node', False, isLeft=True) }}
-			{{ settings_menu_item('bitcoin_core', 'Built In Node', False) }}
-			{{ settings_menu_item('bitcoin_core_internal_logs', 'Bitcoind Logs', 'bitcoin_core_internal_logs', isRight=True) }}
-		</nav>
 	</form>
-
-		<br><br><br>
-        <div class="card" style="width:90%; max-width: 1000px;">
-            Bitcoin Logs:
-            <pre><code>{{ loglines }}</code></pre>
-            <br>
-            <div>If this is an issue, please let us know! Create an <a href="https://github.com/cryptoadvance/specter-desktop/issues" target="_blank">issue</a> or ping us on <a href="https://t.me/spectersupport" target="_blank">Telegram</a> to fix it.</div>
-		</div>
+	<br><br><br>
+	<a href="{{ url_for('settings_endpoint.bitcoin_core')}}" class="btn centered">Return</a>
+	<br><br>
+	<div class="card" style="width:90%; max-width: 1000px;">
+		Bitcoin Logs:
+		<pre><code>{{ loglines }}</code></pre>
+		<br>
+		<div>If this is an issue, please let us know! Create an <a href="https://github.com/cryptoadvance/specter-desktop/issues" target="_blank" style="color: #fff;">issue</a> or ping us on <a href="https://t.me/spectersupport" target="_blank" style="color: #fff;">Telegram</a> to fix it.</div>
+	</div>
 		
 {% endblock %}

--- a/src/cryptoadvance/specter/templates/settings/bitcoin_core_settings.jinja
+++ b/src/cryptoadvance/specter/templates/settings/bitcoin_core_settings.jinja
@@ -6,10 +6,12 @@
 		<input type="hidden" class="csrf-token" name="csrf_token" value="{{ csrf_token() }}"/>
 		<h1 id="title" class="settings-title">Settings</h1>
 		{% from 'settings/components/settings_menu.jinja' import settings_menu %}
+		{% from 'settings/components/settings_menu_item.jinja' import settings_menu_item %}
 		{{ settings_menu('bitcoin_core', current_user) }}
 		<nav class="row">
 			<button type="button" id="external_node_view_btn" class="btn radio left checked" onclick="setNodeTypeView('external')"> Existing Node </button>
-			<button type="button" id="internal_node_view_btn" class="btn radio right" onclick="setNodeTypeView('internal')"> Built In Node </button>
+			<button type="button" id="internal_node_view_btn" class="btn radio" onclick="setNodeTypeView('internal')"> Built In Node </button>
+			{{ settings_menu_item('bitcoin_core_internal_logs', 'Bitcoind Logs', False, isRight=True) }}
 		</nav>
 
 		<div id="internal_node_setup_view" class="card" style="margin: 20px auto 120px; text-align: center;">

--- a/src/cryptoadvance/specter/templates/settings/bitcoin_core_settings.jinja
+++ b/src/cryptoadvance/specter/templates/settings/bitcoin_core_settings.jinja
@@ -10,8 +10,7 @@
 		{{ settings_menu('bitcoin_core', current_user) }}
 		<nav class="row">
 			<button type="button" id="external_node_view_btn" class="btn radio left checked" onclick="setNodeTypeView('external')"> Existing Node </button>
-			<button type="button" id="internal_node_view_btn" class="btn radio" onclick="setNodeTypeView('internal')"> Built In Node </button>
-			{{ settings_menu_item('bitcoin_core_internal_logs', 'Bitcoind Logs', False, isRight=True) }}
+			<button type="button" id="internal_node_view_btn" class="btn radio right" onclick="setNodeTypeView('internal')"> Built In Node </button>
 		</nav>
 
 		<div id="internal_node_setup_view" class="card" style="margin: 20px auto 120px; text-align: center;">
@@ -34,11 +33,15 @@
 						<b>(Warning: QuickSync will override any existing data of your Bitcoin Node!)</b>
 						</p>
 					{% endif %}
+					<br><br>
 				{% else %}
 					<p>Please switch node type to start the built in node.</p>
 				{% endif %}
 				<br><br>
 				<div class="card">
+					<h1>Debug</h1>
+					<a class="btn centered" href="{{url_for('settings_endpoint.bitcoin_core_internal_logs')}}">See Bitcoind Logs</a>
+					<br><br>
 					<h1>Danger Zone</h1>
 					<button type="submit" name="action" value="uninstall_bitcoind" class="btn danger centered">Unistall Bitcoin Core</button>
 					<br>


### PR DESCRIPTION
In the case that bitcoind is slow or broken, redirect to a newly created log-page. This PR has two issues:
* The logs-tab is also existing if you run an external-node. Maybe that makes sense but only if that external node is running on the same machine. In that case the tab should show the external logs?! Or not at all?
* The navigation from the "log-tab" to the "external Node" Tab is broken because of mixture of javascript/request-response. Maybe it's fixable?