### PR TITLE
Use RPCAuth instead of username + password

### DIFF
--- a/src/cryptoadvance/specter/specter.py
+++ b/src/cryptoadvance/specter/specter.py
@@ -127,7 +127,7 @@ class Specter:
                 "external_node": True,
             },
             "internal_node": {
-                "autodetect": True,
+                "autodetect": False,
                 "datadir": os.path.join(self.data_folder, ".bitcoin"),
                 "user": "bitcoin",
                 "password": secrets.token_urlsafe(16),

--- a/src/cryptoadvance/specter/util/bitcoind_setup_tasks.py
+++ b/src/cryptoadvance/specter/util/bitcoind_setup_tasks.py
@@ -6,6 +6,7 @@ from .sha256sum import sha256sum
 import logging
 from .file_download import download_file
 from ..specter_error import handle_exception, ExtProcTimeoutException
+from .rpcauth import generate_salt, password_to_hmac
 
 logger = logging.getLogger(__name__)
 
@@ -55,8 +56,13 @@ def setup_bitcoind_thread(specter=None, internal_bitcoind_version=""):
             os.path.join(specter.config["internal_node"]["datadir"], "bitcoin.conf"),
             "w",
         ) as file:
-            file.write(f'\nrpcuser={specter.config["internal_node"]["user"]}')
-            file.write(f'\nrpcpassword={specter.config["internal_node"]["password"]}')
+            salt = generate_salt(16)
+            password_hmac = password_to_hmac(
+                salt, specter.config["internal_node"]["password"]
+            )
+            file.write(
+                f'\nrpcauth={specter.config["internal_node"]["user"]}:{salt}${password_hmac}'
+            )
             file.write(f"\nserver=1")
             file.write(f"\nlisten=1")
             file.write(f"\nproxy=127.0.0.1:9050")
@@ -135,9 +141,12 @@ def setup_bitcoind_directory_thread(specter=None, quicksync=True, pruned=True):
                     ),
                     "a",
                 ) as file:
-                    file.write(f'\nrpcuser={specter.config["internal_node"]["user"]}')
+                    salt = generate_salt(16)
+                    password_hmac = password_to_hmac(
+                        salt, specter.config["internal_node"]["password"]
+                    )
                     file.write(
-                        f'\nrpcpassword={specter.config["internal_node"]["password"]}'
+                        f'\nrpcauth={specter.config["internal_node"]["user"]}:{salt}${password_hmac}'
                     )
         else:
             with open(
@@ -168,7 +177,7 @@ def setup_bitcoind_directory_thread(specter=None, quicksync=True, pruned=True):
         time.sleep(15)
         success = specter.update_rpc(
             port=8332,
-            autodetect=True,
+            autodetect=False,
             user=specter.config["internal_node"]["user"],
             password=specter.config["internal_node"]["password"],
             need_update="true",


### PR DESCRIPTION
Use `rpcauth` instead of deprecated `rpcuser` + `rpcpassword` for the internal node setup.

I'm thinking whatever it would make sense to force change `config["internal_node"]["autodetect"]` to be `False` in existing internal_node setups? If it won't make problems, and I see no reason it would, I guess it would make sense. Is there a reason not to?