### PR TITLE
bugfix weird ci-issue (directory exists)

### DIFF
--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -37,6 +37,9 @@ start_bitcoind-function:
 
 Travis-CI setup is very straightforward. As we're using the build-cache, the bitcoind sources, npm-setup (for cypress) and build is cached. Therefore such a build would only take 10 minutes. If the master-branch has new commits, bitcoind gets automatically rebuilt and the tests are running against the new version (tests/install_bitcoind.sh).py
 
+# Cirrus
+Still to be done
+
 # Releasing
 
 ## What gets released

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -37,9 +37,6 @@ start_bitcoind-function:
 
 Travis-CI setup is very straightforward. As we're using the build-cache, the bitcoind sources, npm-setup (for cypress) and build is cached. Therefore such a build would only take 10 minutes. If the master-branch has new commits, bitcoind gets automatically rebuilt and the tests are running against the new version (tests/install_bitcoind.sh).py
 
-# Cirrus
-Still to be done
-
 # Releasing
 
 ## What gets released

--- a/src/cryptoadvance/specter/wallet_manager.py
+++ b/src/cryptoadvance/specter/wallet_manager.py
@@ -77,6 +77,7 @@ class WalletManager:
             # creating folders if they don't exist
             if not os.path.isdir(data_folder):
                 os.mkdir(data_folder)
+        self.working_folder = None
         if self.chain is not None and self.data_folder is not None:
             self.working_folder = os.path.join(self.data_folder, self.chain)
         pathlib.Path(self.working_folder).mkdir(parents=True, exist_ok=True)

--- a/src/cryptoadvance/specter/wallet_manager.py
+++ b/src/cryptoadvance/specter/wallet_manager.py
@@ -1,13 +1,19 @@
-import os, json, logging, shutil, threading
-from io import BytesIO
-from collections import OrderedDict
-from .util.descriptor import AddChecksum
-from .helpers import alias, load_jsons
-from .rpc import get_default_datadir, RpcError
-from .specter_error import SpecterError
-from .wallet import Wallet
-from .persistence import delete_file, delete_folder
+import json
+import logging
+import os
+import pathlib
+import shutil
+import threading
 import traceback
+from collections import OrderedDict
+from io import BytesIO
+
+from .helpers import alias, load_jsons
+from .persistence import delete_file, delete_folder
+from .rpc import RpcError, get_default_datadir
+from .specter_error import SpecterError
+from .util.descriptor import AddChecksum
+from .wallet import Wallet
 
 logger = logging.getLogger()
 
@@ -71,11 +77,9 @@ class WalletManager:
             # creating folders if they don't exist
             if not os.path.isdir(data_folder):
                 os.mkdir(data_folder)
-        self.working_folder = None
         if self.chain is not None and self.data_folder is not None:
             self.working_folder = os.path.join(self.data_folder, self.chain)
-        if self.working_folder is not None and not os.path.isdir(self.working_folder):
-            os.mkdir(self.working_folder)
+        pathlib.Path(self.working_folder).mkdir(parents=True, exist_ok=True)
         if rpc is not None:
             self.rpc = rpc
         self.wallets_update_list = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,11 +83,8 @@ def bitcoin_regtest(docker, request):
 @pytest.fixture
 def empty_data_folder():
     # Make sure that this folder never ever gets a reasonable non-testing use-case
-    data_folder = "./test_specter_data_2789334"
-    shutil.rmtree(data_folder, ignore_errors=True)
-    os.mkdir(data_folder)
-    yield data_folder
-    shutil.rmtree(data_folder, ignore_errors=True)
+    with tempfile.TemporaryDirectory("_specter_home_tmp") as data_folder:
+        yield data_folder
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixing this very weird ci-issue:

```
[...]
            self.data_folder = data_folder
            if data_folder.startswith("~"):
                data_folder = os.path.expanduser(data_folder)
            # creating folders if they don't exist
            if not os.path.isdir(data_folder):
                os.mkdir(data_folder)
        self.working_folder = None
        if self.chain is not None and self.data_folder is not None:
            self.working_folder = os.path.join(self.data_folder, self.chain)
        if self.working_folder is not None and not os.path.isdir(self.working_folder):
>           os.mkdir(self.working_folder)
E           FileExistsError: [Errno 17] File exists: '/home/travis/build/cryptoadvance/specter-desktop/test_specter_data_2789334/wallets/regtest'
src/cryptoadvance/specter/wallet_manager.py:78: FileExistsError
```