### PR TITLE
add LiquidRPC class that is compatible with BitcoinRPC

### DIFF
--- a/src/cryptoadvance/specter/liquid/rpc.py
+++ b/src/cryptoadvance/specter/liquid/rpc.py
@@ -1,0 +1,98 @@
+from ..rpc import RpcError, BitcoinRPC
+
+
+class LiquidRPC(BitcoinRPC):
+    """
+    This class introduces fixes to Elements RPC that are broken in current Elements Core.
+    It also adds custom fields that are normaly not present in the final blind pset, but
+    that we find useful.
+
+    In particular this class:
+    - combines walletcreatefundedpsbt and blindpsbt calls into one call by default (walletcreatefundedpsbt)
+    - TODO: adds support for assets in walletcreatefundedpsbt
+    - TODO: adds custom fields to pset:
+      - blinding pubkeys for HW recv addr verification
+      - ecdh nonce for deterministic range proof
+      - extra data that should be encoded in the change rangeproof
+    """
+
+    def getbalance(
+        self,
+        dummy="*",
+        minconf=0,
+        include_watchonly=True,
+        avoid_reuse=False,
+        assetlabel="bitcoin",  # pass None to get all
+        **kwargs
+    ):
+        """
+        Bitcoin-like getbalance rpc call without assets,
+        set assetlabel=None to get balances for all assets
+        """
+        args = [dummy, minconf, include_watchonly, avoid_reuse]
+        # if assetlabel is explicitly set to None - return all assets
+        if assetlabel is not None:
+            args.append(assetlabel)
+        return super().__getattr__("getbalance")(*args, **kwargs)
+
+    def getbalances(self, assetlabel="bitcoin", **kwargs):
+        """
+        Bitcoin-like getbalance rpc call without assets,
+        set assetlabel=None to get balances for all assets
+        """
+        res = super().__getattr__("getbalances")(**kwargs)
+        # if assetlabel is explicitly set to None - return as is
+        if assetlabel is None:
+            return res
+        # otherwise get balances for a particular assetlabel
+        for k in res:
+            for kk in res[k]:
+                v = res[k][kk].get(assetlabel, 0)
+                res[k][kk] = v
+        return res
+
+    def getreceivedbyaddress(self, address, minconf=1, assetlabel="bitcoin", **kwargs):
+        args = [address, minconf]
+        if assetlabel is not None:
+            args.append(assetlabel)
+        return super().__getattr__("getreceivedbyaddress")(*args, **kwargs)
+
+    def walletcreatefundedpsbt(self, inputs, outputs, *args, blind=True, **kwargs):
+        """
+        Creates and blinds an Elements PSBT transaction.
+        Arguments:
+        1. inputs: [{txid, vout[, sequence, pegin stuff]}]
+        2. outputs: [{address: amount, "asset": asset}, ...] # TODO: add assets support
+        3. locktime = 0
+        4. options {includeWatching, changeAddress, subtractFeeFromOutputs,
+                    replaceable, add_inputs, feeRate, fee_rate}
+        5. bip32 derivations
+        6. solving data
+        7. blind = True - Specter-LiquidRPC specific thing - blind transaction after creation
+        """
+        res = super().__getattr__("walletcreatefundedpsbt")(
+            inputs, outputs, *args, **kwargs
+        )
+        psbt = res.get("psbt", None)
+        # check if we should blind the transaction
+        if psbt and blind:
+            blinded = self.blindpsbt(psbt)
+            # res["unblinded"] = psbt
+            res["psbt"] = blinded
+        return res
+
+    @classmethod
+    def from_bitcoin_rpc(cls, rpc):
+        """Convert BitcoinRPC to LiquidRPC"""
+        return cls(
+            user=rpc.user,
+            password=rpc.password,
+            host=rpc.host,
+            port=rpc.port,
+            protocol=rpc.protocol,
+            path=rpc.path,
+            timeout=rpc.timeout,
+            session=rpc.session,
+            proxy_url=rpc.proxy_url,
+            only_tor=rpc.only_tor,
+        )

--- a/src/cryptoadvance/specter/rpc.py
+++ b/src/cryptoadvance/specter/rpc.py
@@ -250,7 +250,7 @@ class BitcoinRPC:
         self.session = session
 
     def wallet(self, name=""):
-        return BitcoinRPC(
+        return type(self)(
             user=self.user,
             password=self.password,
             port=self.port,

--- a/src/cryptoadvance/specter/specter.py
+++ b/src/cryptoadvance/specter/specter.py
@@ -19,6 +19,7 @@ from .tor_daemon import TorDaemonController
 from urllib3.exceptions import NewConnectionError
 from requests.exceptions import ConnectionError
 from .rpc import BitcoinRPC
+from .liquid.rpc import LiquidRPC
 from .device_manager import DeviceManager
 from .wallet_manager import WalletManager
 from .user_manager import UserManager
@@ -71,6 +72,16 @@ def get_rpc(
         if not conf.get("port", None):
             conf["port"] = 8332
         rpc = BitcoinRPC(**conf)
+
+    # check if it's liquid
+    try:
+        res = rpc.getblockchaininfo()
+        if is_liquid(res.get("chain")):
+            # convert to LiquidRPC class
+            rpc = LiquidRPC.from_bitcoin_rpc(rpc)
+    except Exception as e:
+        logger.error(e)
+
     if return_broken_instead_none:
         return rpc
     # check if we have something to compare with

--- a/src/cryptoadvance/specter/util/descriptor.py
+++ b/src/cryptoadvance/specter/util/descriptor.py
@@ -1,5 +1,6 @@
 import re
 from embit import bip32, ec, networks, script
+from embit.liquid.networks import get_network
 from cryptoadvance.specter.specter_error import SpecterError
 
 # Based on hwilib by achow101: https://github.com/bitcoin-core/HWI/blob/1.2.1/hwilib/descriptor.py which is from
@@ -358,9 +359,9 @@ class Descriptor:
 
     def address(self, idx=None, network=None):
         if network is None:
-            net = networks.NETWORKS["test" if self.testnet else "main"]
+            net = get_network("test" if self.testnet else "main")
         else:
-            net = networks.NETWORKS[network]
+            net = get_network(network)
         return self.scriptpubkey(idx).address(net)
 
     def serialize(self):


### PR DESCRIPTION
In Elements methods like `getbalance`, `getbalances` and `getreceivedbyaddress` return dicts with multiple assets by default.
This PR makes a LiquidRPC class that is more similar to BitcoinRPC - by default it returns balances only in LBTC and ignoring all other assets.
To get balances in all assets pass `assetlabel=None` to the corresponding method.
This class is also combining `walletcreatefundedpsbt` with `blindpsbt` rpc call so we don't need to change anything in Specter logic.
