### PR TITLE
Liquid class separation

### DIFF
--- a/src/cryptoadvance/specter/liquid/wallet.py
+++ b/src/cryptoadvance/specter/liquid/wallet.py
@@ -1,8 +1,8 @@
 from ..wallet import *
 from embit.liquid.pset import PSET
 
-class LWallet(Wallet):
 
+class LWallet(Wallet):
     def fetch_transactions(self):
         return
 

--- a/src/cryptoadvance/specter/liquid/wallet.py
+++ b/src/cryptoadvance/specter/liquid/wallet.py
@@ -1,0 +1,44 @@
+from ..wallet import *
+from embit.liquid.pset import PSET
+
+class LWallet(Wallet):
+
+    def fetch_transactions(self):
+        return
+
+    def txlist(
+        self,
+        fetch_transactions=True,
+        validate_merkle_proofs=False,
+        current_blockheight=None,
+    ):
+        """Returns a list of all transactions in the wallet's CSV cache - processed with information to display in the UI in the transactions list
+        #Parameters:
+        #    fetch_transactions (bool): Update the TxList CSV caching by fetching transactions from the Bitcoin RPC
+        #    validate_merkle_proofs (bool): Return transactions with validated_blockhash
+        #    current_blockheight (int): Current blockheight for calculating confirmations number (None will fetch the block count from the RPC)
+        """
+        # TODO: only from RPC for now
+        return self.rpc.listtransactions("*", 10000, 0, True)
+
+    def gettransaction(self, txid, blockheight=None, decode=False):
+        # TODO: only from RPC for now
+        try:
+            # From RPC
+            tx_data = self.rpc.gettransaction(txid)
+            if decode:
+                return self.rpc.decoderawtransaction(tx_data["hex"])
+            return tx_data
+        except Exception as e:
+            logger.warning("Could not get transaction {}, error: {}".format(txid, e))
+
+    def fill_psbt(self, b64psbt, non_witness: bool = True, xpubs: bool = True):
+        # TODO: very minimal
+        psbt = PSET.from_string(b64psbt)
+        if not non_witness:
+            # remove non_witness_utxo if we don't want them
+            for inp in psbt.inputs:
+                if inp.witness_utxo is not None:
+                    inp.non_witness_utxo = None
+
+        return psbt.to_string()

--- a/src/cryptoadvance/specter/liquid/wallet.py
+++ b/src/cryptoadvance/specter/liquid/wallet.py
@@ -1,4 +1,5 @@
 from ..wallet import *
+from ..addresslist import Address
 from embit.liquid.pset import PSET
 
 
@@ -42,3 +43,22 @@ class LWallet(Wallet):
                     inp.non_witness_utxo = None
 
         return psbt.to_string()
+
+    def get_address_info(self, address):
+        try:
+            res = self.rpc.getaddressinfo(address)
+            used = None
+            if "desc" in res:
+                used = self.rpc.getreceivedbyaddress(address, 0) > 0
+            return Address(
+                self.rpc,
+                address=address,
+                index=None
+                if "desc" not in res
+                else res["desc"].split("]")[0].split("/")[-1],
+                change=None if "desc" not in res else res["ischange"],
+                label=next(iter(res["labels"]), ""),
+                used=used,
+            )
+        except:
+            return None

--- a/src/cryptoadvance/specter/server_endpoints/wallets.py
+++ b/src/cryptoadvance/specter/server_endpoints/wallets.py
@@ -1002,7 +1002,7 @@ def combine(wallet_alias):
         # if electrum then it's base43
         try:
             decoded = b43_decode(psbt)
-            if decoded.startswith(b"psbt\xff"):
+            if decoded[:5] in [b"psbt\xff", b"pset\xff"]:
                 psbt = b2a_base64(decoded).decode()
             else:
                 psbt = decoded.hex()

--- a/src/cryptoadvance/specter/server_endpoints/wallets.py
+++ b/src/cryptoadvance/specter/server_endpoints/wallets.py
@@ -1080,7 +1080,10 @@ def decoderawtx(wallet_alias):
             if tx["confirmations"] == 0:
                 tx["is_purged"] = wallet.is_tx_purged(txid)
                 try:
-                    if wallet._transactions[txid].get("category", "") == "receive":
+                    if (
+                        wallet.gettransaction(txid, decode=True).get("category", "")
+                        == "receive"
+                    ):
                         tx["fee"] = (
                             wallet.rpc.getmempoolentry(txid)["fees"]["modified"] * -1
                         )
@@ -1090,12 +1093,10 @@ def decoderawtx(wallet_alias):
                         f"Failed to get fees from mempool entry for transaction: {txid}. Error: {e}"
                     )
 
-            if wallet.data_source == "rpc":
-                # From RPC
-                rawtx = wallet.rpc.decoderawtransaction(tx["hex"])
-            else:
-                # From CSV
+            try:
                 rawtx = decoderawtransaction(tx["hex"], app.specter.chain)
+            except:
+                rawtx = wallet.rpc.decoderawtransaction(tx["hex"])
 
             return {
                 "success": True,

--- a/src/cryptoadvance/specter/templates/includes/tx-data.html
+++ b/src/cryptoadvance/specter/templates/includes/tx-data.html
@@ -143,17 +143,20 @@
                     }
 
 
-                    let value = parseFloat(spentOutput.value.toFixed(8));
-                    let price = ''
-                    if (self.price && self.symbol) {
-                        price = `<span class="note">(${self.symbol}${numberWithCommas((parseFloat(self.price) * value).toFixed(2))})</span>`;
-                    }
+                    let value = "Confidential";
+                    let price = '';
+                    if (spentOutput.value) {
+                        value = parseFloat(spentOutput.value.toFixed(8));
+                        if (self.price && self.symbol) {
+                            price = `<span class="note">(${self.symbol}${numberWithCommas((parseFloat(self.price) * value).toFixed(2))})</span>`;
+                        }
 
-                    if (self.btcUnit == 'sat') {
-                        value = parseInt(value * 1e8)
-                    }
+                        if (self.btcUnit == 'sat') {
+                            value = parseInt(value * 1e8)
+                        }
 
-                    value = `${numberWithCommas(value.toString())}`;
+                        value = `${numberWithCommas(value.toString())}`;
+                    }
 
                     addressAndValue = `<br>
                         Address: <address-label data-copy-hidden="true" data-address="${address}" data-wallet="${self.wallet}"></address-label><br>

--- a/src/cryptoadvance/specter/templates/includes/tx-row.html
+++ b/src/cryptoadvance/specter/templates/includes/tx-row.html
@@ -119,7 +119,7 @@
                 this.amount = parseFloat(this.tx.amount.toFixed(8));
             }
 
-            if (!this.price || !this.symbol) {
+            if (!this.price || !this.symbol || this.amount == 1e-8) {
                 this.amountPrice.innerText = '';
                 this.amountPrice.classList.add('hidden');
             } else {
@@ -131,11 +131,15 @@
                 this.amountPrice.classList.remove('hidden');
             }
 
-            if (this.btcUnit == 'sat') {
+            if (this.btcUnit == 'sat' && this.amount != 1e-8) {
                 this.amount = parseInt(this.amount * 1e8);
             }
 
-            this.amountText.innerText = `${numberWithCommas(this.amount.toString())}`;
+            if (this.amount == 1e-8) {
+                this.amountText.innerText = 'Confidential';
+            } else {
+                this.amountText.innerText = `${numberWithCommas(this.amount.toString())}`;
+            }
 
             // Set confirmations
             if (this.tx.confirmations > 0) {

--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -3,7 +3,7 @@ import time
 from .device import Device
 from .key import Key
 from .util.merkleblock import is_valid_merkle_proof
-from .helpers import der_to_bytes, is_liquid
+from .helpers import der_to_bytes
 from embit import base58, bip32
 from .util.descriptor import Descriptor, sort_descriptor, AddChecksum
 from embit.liquid.descriptor import LDescriptor
@@ -92,7 +92,6 @@ class Wallet:
             os.path.join(self.manager.rpc_path, self.alias)
         )
         self.last_block = last_block
-        self.data_source = "rpc" if is_liquid(self.manager.chain) else "csv"
 
         addr_path = self.fullpath.replace(".json", "_addr.csv")
         self._addresses = AddressList(addr_path, self.rpc)
@@ -136,11 +135,6 @@ class Wallet:
 
     def fetch_transactions(self):
         """Load transactions from Bitcoin Core"""
-        # From RPC
-        if self.data_source == "rpc":
-            return
-
-        # From CSV
         arr = []
         idx = 0
         # unconfirmed_selftransfers needed since Bitcoin Core does not properly list `selftransfer` txs in `listtransactions` command
@@ -644,11 +638,6 @@ class Wallet:
         #    validate_merkle_proofs (bool): Return transactions with validated_blockhash
         #    current_blockheight (int): Current blockheight for calculating confirmations number (None will fetch the block count from the RPC)
         """
-        # From RPC
-        if self.data_source == "rpc":
-            return self.rpc.listtransactions("*", 10000, 0, True)
-
-        # From CSV
         if fetch_transactions or (
             self.use_descriptors
             and len(
@@ -745,13 +734,6 @@ class Wallet:
 
     def gettransaction(self, txid, blockheight=None, decode=False):
         try:
-            # From RPC
-            if self.data_source == "rpc":
-                tx_data = self.rpc.gettransaction(txid)
-                if decode:
-                    return self.rpc.decoderawtransaction(tx_data["hex"])
-                return tx_data
-            # From CSV
             tx_data = self._transactions.gettransaction(txid, blockheight)
             if decode:
                 return decoderawtransaction(tx_data["hex"], self.manager.chain)


### PR DESCRIPTION
This is a very small PR with my idea of separation of the chain-specific wallet logic into different classes:
- `Wallet` class in `src/wallet.py` should only care about Bitcoin
- `LWallet` class in `src/liquid/wallet.py` should be derived from `Wallet` and be aware of liquid stuff - and code changes for liquid are there
- `WalletManager` can use different wallet classes depending on the `chain` argument in the constructor.

Also fixes a few things in `helpers.py` that are broken in liquid.

If you think this approach is reasonable I will continue with extra liquid-specific classes like `LAddressList` and `LTxList` classes for csv caching.