### PR TITLE
Bugfix: Fix getting keys in wrong network format when no node is used

### DIFF
--- a/src/cryptoadvance/specter/hwi_rpc.py
+++ b/src/cryptoadvance/specter/hwi_rpc.py
@@ -235,22 +235,17 @@ class HWIBridge(JSONRPC):
             # Client will be configured for testnet if our Specter instance is
             #   currently connected to testnet. This will prevent us from
             #   getting mainnet xpubs unless we set is_testnet here:
-            if not chain or chain == "None":
-                try:
-                    client.chain = (
-                        Chain.TEST
-                        if derivation.split("/")[2].startswith("1")
-                        else Chain.MAIN
-                    )
-                except:
-                    client.chain = Chain.MAIN
-            else:
-                client.chain = Chain.argparse(chain)
+            try:
+                client.chain = (
+                    Chain.TEST
+                    if derivation.split("/")[2].startswith("1")
+                    else Chain.MAIN
+                )
+            except:
+                client.chain = Chain.MAIN
 
             network = networks.get_network(
-                chain
-                if chain and chain != "None"
-                else ("main" if client.chain == Chain.MAIN else "test")
+                "main" if client.chain == Chain.MAIN else "test"
             )
 
             master_fpr = client.get_master_fingerprint().hex()

--- a/src/cryptoadvance/specter/hwi_rpc.py
+++ b/src/cryptoadvance/specter/hwi_rpc.py
@@ -247,7 +247,11 @@ class HWIBridge(JSONRPC):
             else:
                 client.chain = Chain.argparse(chain)
 
-            network = networks.get_network(chain)
+            network = networks.get_network(
+                chain
+                if chain and chain != "None"
+                else ("main" if client.chain == Chain.MAIN else "test")
+            )
 
             master_fpr = client.get_master_fingerprint().hex()
 


### PR DESCRIPTION
Fix xpubs being converted to wrong SLIP132 format when no node is connected in Specter.