### PR TITLE
Cancel transaction with RBF

### DIFF
--- a/src/cryptoadvance/specter/server_endpoints/wallets.py
+++ b/src/cryptoadvance/specter/server_endpoints/wallets.py
@@ -670,10 +670,9 @@ def send_new(wallet_alias):
                     # calculate new amount if we need to subtract
                     if subtract:
                         for v in psbt["tx"]["vout"]:
-                            if (
-                                addresses[0] in v["scriptPubKey"]["addresses"]
-                                or addresses[0] == v["scriptPubKey"]["address"]
-                            ):
+                            if addresses[0] in v["scriptPubKey"].get(
+                                "addresses", [""]
+                            ) or addresses[0] == v["scriptPubKey"].get("address", ""):
                                 amounts[0] = v["value"]
             except Exception as e:
                 err = e
@@ -709,6 +708,22 @@ def send_new(wallet_alias):
                 )
             except Exception as e:
                 flash("Failed to perform RBF. Error: %s" % e, "error")
+        elif action == "rbf_cancel":
+            try:
+                rbf_tx_id = request.form["rbf_tx_id"]
+                rbf_fee_rate = float(request.form["rbf_fee_rate"])
+                psbt = wallet.canceltx(rbf_tx_id, rbf_fee_rate)
+                return render_template(
+                    "wallet/send/sign/wallet_send_sign_psbt.jinja",
+                    psbt=psbt,
+                    labels=[],
+                    wallet_alias=wallet_alias,
+                    wallet=wallet,
+                    specter=app.specter,
+                    rand=rand,
+                )
+            except Exception as e:
+                flash("Failed to cancel transaction with RBF. Error: %s" % e, "error")
         elif action == "rbf_edit":
             try:
                 decoded_tx = wallet.decode_tx(rbf_tx_id)

--- a/src/cryptoadvance/specter/static/img/cross.svg
+++ b/src/cryptoadvance/specter/static/img/cross.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6 6L18 18" stroke="black" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M18 6L6.00001 18" stroke="black" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/src/cryptoadvance/specter/templates/includes/tx-data.html
+++ b/src/cryptoadvance/specter/templates/includes/tx-data.html
@@ -109,7 +109,7 @@
                     <tr><td>Fee rate:</td><td>${parseFloat((-1e8 * tx.fee / rawtx.vsize).toFixed(2)).toString()} sat/vbyte</td></tr>
                 `;
             }
-            if (tx.confirmations) {
+            if (tx.confirmations && tx.confirmations > 0) {
                 rawtxHTML += `
                     <tr><td>Mined at block:</td><td>${tx.blockheight}</td></tr>
                     <tr><td>Block hash:</td><td style="word-break: break-all;">${tx.blockhash}</td></tr>

--- a/src/cryptoadvance/specter/templates/includes/tx-row.html
+++ b/src/cryptoadvance/specter/templates/includes/tx-row.html
@@ -27,7 +27,8 @@
         <td class="time"></td>
         <td>
             <span class="confirmations"></span>
-            <button class="rbf btn optional hidden" style="width: 120px; float: right;" type="button">Speed up</button>
+            <button class="rbf btn optional hidden" style="width: 130px; float: right;" type="button">Speed up</button>
+            <button class="rbf-cancel danger btn optional hidden" style="width: 130px; float: right; margin-right: 10px;" type="button">Cancel transaction</button>
         </td>
         <td class="hidden optional blockhash"></td>
         <td><input class="select-tx-value" type="hidden" value=""><img style="vertical-align: middle;" class="select-tx-img" src="{{ url_for('static', filename='img/checkbox-untick.svg') }}" width="25px"></tool-tip></td>
@@ -52,6 +53,7 @@
             this.confirmations = clone.querySelector(".confirmations");
             this.blockhash = clone.querySelector(".blockhash");        
             this.rbf = clone.querySelector(".rbf");
+            this.rbfCancel = clone.querySelector(".rbf-cancel");
             this.selectTxValue = clone.querySelector(".select-tx-value");
             this.selectTxImg = clone.querySelector(".select-tx-img");
             this.frozenImg = clone.querySelector(".frozen-img");
@@ -150,48 +152,20 @@
 
             if ((this.tx.category == "send" || this.tx.category == "selftransfer") && this.tx["bip125-replaceable"] == "yes") {
                 this.rbf.classList.remove('hidden');
+                if (this.tx.category == "selftransfer") {
+                    this.rbfCancel.classList.add('hidden');
+                } else {
+                    this.rbfCancel.classList.remove('hidden');
+                    this.rbfCancel.onclick = () => {
+                        rbfPopup(this, 'cancel');
+                    }
+                }
                 this.rbf.onclick = () => {
-                    let txDataPopup = document.getElementById('tx-popup');
-                    let url = `{{ url_for('wallets_endpoint.send_new', wallet_alias='WALLET_ALIAS') }}`.replace("WALLET_ALIAS", this.wallet);
-                    let newFee = parseFloat((((this.tx.fee * -1) / this.tx.vsize) * 1e8).toFixed(2));
-                    if (newFee <= 1.02) {
-                        newFee = 1;
-                    }
-                    newFee += 2;
-                    txDataPopup.innerHTML = `
-                    <form action="${url}" method="POST">
-                    <h1>Speed up the Transaction</h1>
-                    <p>You can speedup the transaction by increasing its fee rate:</p>
-                    <input type="hidden" name="rbf_tx_id" value='${this.tx.txid}' />
-                    <input type="number" min="${newFee}" value="${newFee}" class="fee_rate" name="rbf_fee_rate" id="rbf_fee_rate" min="1" step="any" autocomplete="off"> sat/vbyte
-                    <input type="hidden" class="csrf-token" name="csrf_token" value="{{ csrf_token() }}"/>
-                    <br>
-                    <br>
-                    <button type="submit" name="action" value="rbf" class="btn centered">Speed up!</button>
-                    <br>
-			        <span class="toggle_advanced_rbf" style="cursor: pointer;">Advanced {% if show_advanced_settings %}&#9660;{% else %}&#9654;{% endif %}</span>
-                    <div class="advanced_rbf hidden warning">
-                        <p style="max-width: 400px;">If you would like further customization, you can click here to fully edit the transaction.<br>(advanced, not recommended for new users)</p>
-                        <button type="submit" name="action" value="rbf_edit" class="btn centered">Edit the transaction (advanced)</button>
-                    </div>
-                    </form>
-                    `;
-                    txDataPopup.querySelector('.toggle_advanced_rbf').onclick = () => {
-                        let advancedButton = txDataPopup.querySelector('.toggle_advanced_rbf')
-                        let advancedSettings = txDataPopup.querySelector('.advanced_rbf')
-                        if (advancedSettings.classList.contains('hidden')) {
-                            advancedSettings.classList.remove('hidden')
-                            advancedButton.innerHTML = 'Advanced &#9660;';
-                        } else {
-                            advancedSettings.classList.add('hidden')
-                            advancedButton.innerHTML = 'Advanced &#9654;';
-                        }
-                    }
-
-                    showPageOverlay('tx-popup');
+                    rbfPopup(this, 'speedup');
                 }
             } else {
                 this.rbf.classList.add('hidden');
+                this.rbfCancel.classList.add('hidden');
             }
             
             // Set time
@@ -231,6 +205,51 @@
                 this.selectTxImg.classList.add('hidden');
             }
         }
+    }
+
+    function rbfPopup(self, rbfType) {
+        let txDataPopup = document.getElementById('tx-popup');
+        let url = `{{ url_for('wallets_endpoint.send_new', wallet_alias='WALLET_ALIAS') }}`.replace("WALLET_ALIAS", self.wallet);
+        let newFee = parseFloat((((self.tx.fee * -1) / self.tx.vsize) * 1e8).toFixed(2));
+        if (newFee <= 1.02) {
+            newFee = 1;
+        }
+        if (rbfType == 'cancel') {
+            newFee += 2;
+        } else {
+            newFee *= 1.5; // Tx likely to have lower size so will need higher fee
+        }
+        txDataPopup.innerHTML = `
+        <form action="${url}" method="POST">
+        <h1>${rbfType == 'cancel' ? 'Cancel' : 'Speed up'} the Transaction</h1>
+        <p>You can ${rbfType == 'cancel' ? 'cancel' : 'speed up'} the transaction by increasing its fee rate${rbfType == 'cancel' ? ' and sending the funds back to yourself' : ''}:</p>
+        <input type="hidden" name="rbf_tx_id" value='${self.tx.txid}' />
+        <input type="number" min="${newFee}" value="${newFee}" class="fee_rate" name="rbf_fee_rate" id="rbf_fee_rate" min="1" step="any" autocomplete="off"> sat/vbyte
+        <input type="hidden" class="csrf-token" name="csrf_token" value="{{ csrf_token() }}"/>
+        <br>
+        <br>
+        <button type="submit" name="action" value="${rbfType == 'cancel' ? 'rbf_cancel' : 'rbf'}" class="btn centered ${rbfType == 'cancel' ? 'danger' : ''}">${rbfType == 'cancel' ? 'Cancel transaction' : 'Speed up!'}</button>
+        <br>
+        <span class="toggle_advanced_rbf" style="cursor: pointer;">Advanced {% if show_advanced_settings %}&#9660;{% else %}&#9654;{% endif %}</span>
+        <div class="advanced_rbf hidden warning">
+            <p style="max-width: 400px;">If you would like further customization, you can click here to fully edit the transaction.<br>(advanced, not recommended for new users)</p>
+            <button type="submit" name="action" value="rbf_edit" class="btn centered">Edit the transaction (advanced)</button>
+        </div>
+        </form>
+        `;
+        txDataPopup.querySelector('.toggle_advanced_rbf').onclick = () => {
+            let advancedButton = txDataPopup.querySelector('.toggle_advanced_rbf')
+            let advancedSettings = txDataPopup.querySelector('.advanced_rbf')
+            if (advancedSettings.classList.contains('hidden')) {
+                advancedSettings.classList.remove('hidden')
+                advancedButton.innerHTML = 'Advanced &#9660;';
+            } else {
+                advancedSettings.classList.add('hidden')
+                advancedButton.innerHTML = 'Advanced &#9654;';
+            }
+        }
+
+        showPageOverlay('tx-popup');
     }
 
     function getCategoryImg(category, isConfirmed) {

--- a/src/cryptoadvance/specter/templates/includes/tx-row.html
+++ b/src/cryptoadvance/specter/templates/includes/tx-row.html
@@ -12,6 +12,9 @@
         .svg-selftransfer {
             filter: invert(77%) sepia(68%) saturate(3384%) hue-rotate(44deg) brightness(112%) contrast(74%);
         }
+        .svg-cancelled {
+            filter: invert(20%) sepia(32%) saturate(4838%) hue-rotate(332deg) brightness(81%) contrast(97%);
+        }
     </style>
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='styles.css') }}">
     <tr class="tx-row">
@@ -145,9 +148,14 @@
             // Set confirmations
             if (this.tx.confirmations > 0) {
                 this.confirmations.innerHTML = this.hideSensitiveInfo ? '########' : `${this.tx.confirmations}<span class="optional"> Confirmations</span>`;
-            } else {
+            } else if (this.tx.confirmations == 0) {
                 this.el.classList.add('unconfirmed');
                 this.confirmations.innerHTML = this.hideSensitiveInfo ? '########' : `Unconfirmed`;
+            } else {
+                this.confirmations.innerHTML = this.hideSensitiveInfo ? '########' : `Cancelled (replaced by sender)`;
+                this.category.src = `{{ url_for('static', filename='img') }}/cross.svg`;
+                this.category.classList.remove('svg-' + this.tx.category);
+                this.category.classList.add('svg-cancelled');
             }
 
             if ((this.tx.category == "send" || this.tx.category == "selftransfer") && this.tx["bip125-replaceable"] == "yes") {

--- a/src/cryptoadvance/specter/templates/includes/tx-row.html
+++ b/src/cryptoadvance/specter/templates/includes/tx-row.html
@@ -215,9 +215,9 @@
             newFee = 1;
         }
         if (rbfType == 'cancel') {
-            newFee += 2;
-        } else {
             newFee *= 1.5; // Tx likely to have lower size so will need higher fee
+        } else {
+            newFee += 2;
         }
         txDataPopup.innerHTML = `
         <form action="${url}" method="POST">

--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -702,7 +702,9 @@ class Wallet:
                     tx.get("confirmations") == 0
                     and tx.get("bip125-replaceable", "no") == "yes"
                 ):
-                    tx["fee"] = self.rpc.gettransaction(tx["txid"]).get("fee", 1)
+                    rpc_tx = self.rpc.gettransaction(tx["txid"])
+                    tx["fee"] = rpc_tx.get("fee", 1)
+                    tx["confirmations"] = rpc_tx.get("confirmations", 0)
 
                 if isinstance(tx["address"], str):
                     tx["label"] = self.getlabel(tx["address"])


### PR DESCRIPTION
Add cancel transaction button to let user cancel a transaction with RBF.
Also show transaction status as Cancelled instead of unconfirmed when it was replaced by the sender.

<img width="1507" alt="Screen Shot 2021-05-28 at 12 11 13" src="https://user-images.githubusercontent.com/10667901/119960818-0be98480-bfae-11eb-8dbb-38f4545e222d.png">

![2021-05-28 12 13 58](https://user-images.githubusercontent.com/10667901/119960971-32a7bb00-bfae-11eb-9553-8eee3b2c0333.jpg)
