### PR TITLE
return 0 if derivation is not like assumed

### DIFF
--- a/src/cryptoadvance/specter/server_endpoints/devices.py
+++ b/src/cryptoadvance/specter/server_endpoints/devices.py
@@ -443,6 +443,8 @@ def device(device_alias):
         if not k.derivation:
             return 0
         match = re.search(pattern, k.derivation)
+        if not match:
+            return 0
         return (
             int(match.group(1))
             + (int(match.group(2)) + 1) * 1000000


### PR DESCRIPTION
Sorting fails if derivation path exists but doesn't match pattern.

For example, if Coldcard keys are imported including legacy `m/45h` the match will return `None` and break sorting.