### PR TITLE
Fully unblind liquid transactions sent by Specter

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -13,7 +13,7 @@ requests==2.25.0
 pysocks==1.7.1
 six==1.12.0
 stem==1.8.0
-embit==0.4.0
+embit==0.4.1
 psutil==5.7.3
 pyopenssl==20.0.1
 flask_wtf==0.14.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -97,8 +97,8 @@ ecdsa==0.16.1 \
     # via
     #   bitbox02
     #   hwi
-embit==0.4.0 \
-    --hash=sha256:c78331439b7fd8a2b155735523fae1e554020f82e77eb6a6a7139311b8c9f9c7
+embit==0.4.1 \
+    --hash=sha256:0d4df81f8bddb2b5e6529bb8a26db872e54ce89d59593acbb4f71a7c0d03e476
     # via -r requirements.in
 flask-cors==3.0.9 \
     --hash=sha256:6bcfc100288c5d1bcb1dbb854babd59beee622ffd321e444b05f24d6d58466b8 \

--- a/src/cryptoadvance/specter/liquid/rpc.py
+++ b/src/cryptoadvance/specter/liquid/rpc.py
@@ -1,8 +1,18 @@
 from ..rpc import RpcError, BitcoinRPC
+from embit.ec import PrivateKey, PublicKey
+from embit.hashes import tagged_hash
+from embit.descriptor.checksum import add_checksum
 from embit.liquid.descriptor import LDescriptor
 from embit.liquid.pset import PSET
-from embit.descriptor.checksum import add_checksum
 from embit.liquid.addresses import addr_decode
+from embit.liquid.addresses import address as liquid_address
+from embit.liquid.networks import get_network
+from embit.liquid.transaction import LTransaction, unblind
+from embit.liquid import slip77
+from embit.psbt import read_string
+
+from io import BytesIO
+
 import logging
 
 logger = logging.getLogger(__name__)
@@ -123,8 +133,8 @@ class LiquidRPC(BitcoinRPC):
             # check that change is also blinded - fixes a bug in pset branch
             tx = PSET.from_string(psbt)
             der = None
-            changepos = res["changepos"]
-            if len(args) >= 2:
+            changepos = res.get("changepos", None)
+            if changepos is not None and len(args) >= 2:
                 addr = args[1].get("changeAddress", None)
                 if addr:
                     _, bpub = addr_decode(addr)
@@ -133,17 +143,65 @@ class LiquidRPC(BitcoinRPC):
                         tx.outputs[changepos].blinding_pubkey = bpub.sec()
                     res["psbt"] = str(tx)
                     psbt = str(tx)
-            # blindpsbt is used on master branch
-            try:
-                blinded = self.blindpsbt(psbt)
-                logger.info("transaction blinded")
-            except Exception as e:
-                # in pset branch (achow/pset) walletprocesspsbt is used instead
-                logger.warn(e)
-                # blind without signing
-                blinded = self.walletprocesspsbt(psbt, False)["psbt"]
-            res["psbt"] = blinded
+
+            # generate all blinding stuff ourselves in deterministic way
+            bpk = bytes.fromhex(self.dumpmasterblindingkey())
+            tx.unblind(PrivateKey(bpk)) # get values and blinding factors for inputs
+            seed = tagged_hash("liquid/blinding_seed", bpk)
+            tx.blind(seed) # generate all blinding factors etc
+            # proprietary fields for Specter - 00 is global blinding seed
+            tx.unknown[b"\xfc\x07specter\x00"] = seed
+
+            # reblind and encode nonces in change output
+            if changepos is not None:
+                txseed = tx.txseed(seed)
+                # blinding seed to calculate per-output nonces
+                message = b"\x01\x00\x20"+txseed
+                for i, out in enumerate(tx.outputs):
+                    # skip unblinded and change address itself
+                    if out.blinding_pubkey is None or i == changepos:
+                        continue
+                    # key 01<i> is blinding pubkey for output i
+                    message += b"\x05\x01" + i.to_bytes(4, 'little')
+                    # message is blinding pubkey
+                    message += bytes([len(out.blinding_pubkey)]) + out.blinding_pubkey
+                # extra message for rangeproof - proprietary field
+                tx.outputs[changepos].unknown[b"\xfc\x07specter\x01"] = message
+                # re-generate rangeproof with extra message
+                nonce = tagged_hash("liquid/range_proof", txseed+changepos.to_bytes(4,'little'))
+                tx.outputs[changepos].reblind(nonce, extra_message=message)
+
+            res["psbt"] = str(tx)
         return res
+
+    def _cleanpsbt(self, psbt):
+        """ Removes stuff that Core doesn't like """
+        tx = PSET.from_string(psbt)
+        for inp in tx.inputs:
+            inp.value = None
+            inp.asset = None
+            inp.value_blinding_factor = None
+            inp.asset_blinding_factor = None
+
+        for out in tx.outputs:
+            if out.is_blinded:
+                out.asset = None
+                out.asset_blinding_factor = None
+                out.value = None
+                out.value_blinding_factor = None
+        return str(tx)
+
+    def walletprocesspsbt(self, psbt, *args, **kwargs):
+        try:
+            if self.getwalletinfo().get("private_keys_enabled", False):
+                psbt = self._cleanpsbt(psbt)
+        except Exception as e:
+            logger.warn(f"Failed to clean psbt: {e}")
+        return super().__getattr__("walletprocesspsbt")(psbt, *args, **kwargs)
+
+    def finalizepsbt(self, psbt, *args, **kwargs):
+        psbt = self._cleanpsbt(psbt)
+        return super().__getattr__("finalizepsbt")(psbt, *args, **kwargs)
 
     def combinepsbt(self, psbts, *args, **kwargs):
         if len(psbts) == 0:
@@ -182,6 +240,7 @@ class LiquidRPC(BitcoinRPC):
                 inp1.partial_sigs.update(inp2.partial_sigs)
                 inp1.bip32_derivations.update(inp2.bip32_derivations)
                 inp1.unknown.update(inp2.unknown)
+                inp1.range_proof = inp1.range_proof or inp2.range_proof
 
             for i in range(len(tx.outputs)):
                 out1 = tx.outputs[i]
@@ -228,7 +287,106 @@ class LiquidRPC(BitcoinRPC):
 
     def decoderawtransaction(self, tx):
         unblinded = self.unblindrawtransaction(tx)["hex"]
-        return super().__getattr__("decoderawtransaction")(unblinded)
+        obj = super().__getattr__("decoderawtransaction")(unblinded)
+        try:
+            # unblind the rest of outputs
+            b = LTransaction.from_string(tx)
+
+            mbpk = PrivateKey(bytes.fromhex(self.dumpmasterblindingkey()))
+            net = get_network(self.getblockchaininfo().get("chain"))
+
+            outputs = obj["vout"]
+            datas = []
+            fee = 0
+            # search for datas encoded in rangeproofs
+            for i, out in enumerate(b.vout):
+                o = outputs[i]
+                if isinstance(out.value, int):
+                    if "value" in o:
+                        assert o["value"] == round(out.value*1e-8,8)
+                    else:
+                        o["value"] = round(out.value*1e-8,8)
+                    if "asset" in o:
+                        assert o["asset"] == bytes(reversed(out.asset[-32:])).hex()
+                    else:
+                        o["asset"] = bytes(reversed(out.asset[-32:])).hex()
+                    try:
+                        o["scriptPubKey"]["addresses"] = [liquid_address(out.script_pubkey, network=net)]
+                    except:
+                        pass
+                    if out.script_pubkey.data == b"":
+                        # fee negative?
+                        fee -= out.value
+
+                pk = slip77.blinding_key(mbpk, out.script_pubkey)
+                try:
+                    res = out.unblind(pk.secret, message_length=1000)
+                    value, asset, vbf, abf, extra, min_value, max_value = res
+                    if "value" in o:
+                        assert o["value"] == round(value*1e-8,8)
+                    else:
+                        o["value"] = round(value*1e-8,8)
+                    if "asset" in o:
+                        assert o["asset"] == bytes(reversed(asset[-32:])).hex()
+                    else:
+                        o["asset"] = bytes(reversed(asset[-32:])).hex()
+                    try:
+                        o["scriptPubKey"]["addresses"] = [liquid_address(out.script_pubkey, pk, network=net)]
+                    except:
+                        pass
+                    if len(extra.rstrip(b"\x00")) > 0:
+                        datas.append(extra)
+                except Exception as e:
+                    pass
+
+            # should be changed with seed from tx
+            tx = PSET(b)
+            seed = tagged_hash("liquid/blinding_seed", mbpk.secret)
+            txseed = tx.txseed(seed)
+            pubkeys = {}
+
+            for extra in datas:
+                s = BytesIO(extra)
+                while True:
+                    k = read_string(s)
+                    if len(k) == 0:
+                        break
+                    v = read_string(s)
+                    if k[0] == 1 and len(k)==5:
+                        idx = int.from_bytes(k[1:], 'little')
+                        pubkeys[idx] = v
+                    elif k == b"\x01\x00":
+                        txseed = v
+
+            for i, out in enumerate(outputs):
+                o = out
+                if i in pubkeys and len(pubkeys[i]) in [33, 65]:
+                    nonce = tagged_hash("liquid/range_proof", txseed+i.to_bytes(4,'little'))
+                    if b.vout[i].ecdh_pubkey == PrivateKey(nonce).sec():
+                        try:
+                            res = unblind(pubkeys[i], nonce, b.vout[i].witness.range_proof.data, b.vout[i].value, b.vout[i].asset, b.vout[i].script_pubkey)
+                            value, asset, vbf, abf, extra, min_value, max_value = res
+                            if "value" in o:
+                                assert o["value"] == round(value*1e-8,8)
+                            else:
+                                o["value"] = round(value*1e-8,8)
+                            if "asset" in o:
+                                assert o["asset"] == bytes(reversed(asset[-32:])).hex()
+                            else:
+                                o["asset"] = bytes(reversed(asset[-32:])).hex()
+                            try:
+                                o["scriptPubKey"]["addresses"] = [liquid_address(b.vout[i].script_pubkey, PublicKey.parse(pubkeys[i]), network=net)]
+                            except:
+                                pass
+                        except Exception as e:
+                            logger.warn(f"Failed at unblinding output {i}: {e}")
+                    else:
+                        logger.warn(f"Failed at unblinding: {e}")
+            if fee != 0:
+                obj["fee"] = round(-fee*1e-8, 8)
+        except Exception as e:
+            logger.warn(f"Failed at unblinding transaction: {e}")
+        return obj
 
     @classmethod
     def from_bitcoin_rpc(cls, rpc):

--- a/src/cryptoadvance/specter/templates/includes/tx-data.html
+++ b/src/cryptoadvance/specter/templates/includes/tx-data.html
@@ -104,9 +104,15 @@
             <tr><td>Size:</td><td>${rawtx.vsize} vbytes <span class="note">(${rawtx.size} bytes)</span></td></tr>
             `;
             if (tx.fee) {
+                fee = tx.fee;
+                if(typeof tx.fee == "object"){
+                    if("bitcoin" in tx.fee){
+                        fee = tx.fee.bitcoin;
+                    }
+                }
                 rawtxHTML += `
-                    <tr><td>Fee:</td><td>${parseInt(-1e8 * tx.fee)} sats</td></tr>
-                    <tr><td>Fee rate:</td><td>${parseFloat((-1e8 * tx.fee / rawtx.vsize).toFixed(2)).toString()} sat/vbyte</td></tr>
+                    <tr><td>Fee:</td><td>${parseInt(-1e8 * fee)} sats</td></tr>
+                    <tr><td>Fee rate:</td><td>${parseFloat((-1e8 * fee / rawtx.vsize).toFixed(2)).toString()} sat/vbyte</td></tr>
                 `;
             }
             if (tx.confirmations && tx.confirmations > 0) {

--- a/src/cryptoadvance/specter/templates/includes/tx-data.html
+++ b/src/cryptoadvance/specter/templates/includes/tx-data.html
@@ -104,7 +104,7 @@
             <tr><td>Size:</td><td>${rawtx.vsize} vbytes <span class="note">(${rawtx.size} bytes)</span></td></tr>
             `;
             if (tx.fee) {
-                fee = tx.fee;
+                let fee = tx.fee;
                 if(typeof tx.fee == "object"){
                     if("bitcoin" in tx.fee){
                         fee = tx.fee.bitcoin;


### PR DESCRIPTION
This PR adds deterministic blinding to liquid transactions and encodes some extra information in the change output rangeproof, so Specter will be able to use this data for unblinding the transaction. So when you click on the transaction in the history you will see all addresses in confidential form and all amounts as normal numbers there.

This change doesn't affect `txlist` table yet as we currently get this info directly from Elements Core.

It will however change as soon as we fix `TxList` class that caches all wallet transactions and therefore contains all necessary information to unblind amounts and assets on Specter side. But this will be in another PR.