### PR TITLE
Bugfix: RPC-password as pin for multiple nodes

### DIFF
--- a/src/cryptoadvance/specter/managers/node_manager.py
+++ b/src/cryptoadvance/specter/managers/node_manager.py
@@ -16,6 +16,8 @@ logger = logging.getLogger(__name__)
 
 class NodeManager:
     # chain is required to manage wallets when bitcoind is not running
+    DEFAULT_ALIAS = "default"
+
     def __init__(
         self,
         proxy_url="socks5h://localhost:9050",
@@ -70,7 +72,7 @@ class NodeManager:
                 host="localhost",
                 protocol="http",
                 external_node=True,
-                default_alias="default",
+                default_alias=self.DEFAULT_ALIAS,
             )
         else:
             self.nodes = nodes
@@ -86,6 +88,9 @@ class NodeManager:
     def switch_node(self, node_alias):
         # this will throw an error if the node doesn't exist
         self._active_node = self.get_by_alias(node_alias).alias
+
+    def default_node(self):
+        return self.get_by_alias(self.DEFAULT_ALIAS)
 
     def get_by_alias(self, alias):
         for node_name in self.nodes:

--- a/src/cryptoadvance/specter/server_endpoints/auth.py
+++ b/src/cryptoadvance/specter/server_endpoints/auth.py
@@ -35,8 +35,11 @@ def login():
             return redirect_login(request)
         if auth["method"] == "rpcpasswordaspin":
             # TODO: check the password via RPC-call
-            if app.specter.rpc is None:
-                if app.specter.node.password == request.form["password"]:
+            if (
+                app.specter.default_node.rpc is None
+                or not app.specter.default_node.rpc.test_connection()
+            ):
+                if app.specter.default_node.password == request.form["password"]:
                     app.login("admin")
                     app.logger.info(
                         "AUDIT: Successfull Login via RPC-credentials (node disconnected)"
@@ -55,7 +58,7 @@ def login():
                     ),
                     401,
                 )
-            rpc = app.specter.rpc.clone()
+            rpc = app.specter.default_node.rpc.clone()
             rpc.password = request.form["password"]
             if rpc.test_connection():
                 app.login("admin")

--- a/src/cryptoadvance/specter/specter.py
+++ b/src/cryptoadvance/specter/specter.py
@@ -179,6 +179,10 @@ class Specter:
             return self.node_manager.active_node
 
     @property
+    def default_node(self):
+        return self.node_manager.default_node()
+
+    @property
     def rpc(self):
         return self.node.rpc
 


### PR DESCRIPTION
Currently there are more than one node possible and if you selected a different node than the default, you would need to auth with the rpc-password of that other node.
This will fix that so that the password is always validated against the default-node.