### PR TITLE
fix elementsd process in tests

### DIFF
--- a/src/cryptoadvance/specter/process_controller/elementsd_controller.py
+++ b/src/cryptoadvance/specter/process_controller/elementsd_controller.py
@@ -10,7 +10,7 @@ class ElementsPlainController(NodePlainController):
 
     def __init__(
         self,
-        elementsd_path="elements",
+        elementsd_path="elementsd",
         rpcport=18555,
         network="regtest",
         rpcuser="liquid",


### PR DESCRIPTION
Tests were failing on my machine as it was not able to run `elements` process.
Looks like there is a typo in `elementsd_controller`.
This PR fixes the typo.