### PR TITLE
Fix release-process

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,10 +25,21 @@ before_script:
   - python -V  # Print out python version for debugging
   - apt update
   - apt install -y libusb-1.0-0-dev libudev-dev # usb-support in hidapi
-  - ./tests/install_bitcoind.sh --debug --elements compile
+# This doesn't get cached in gitlab but we don't need it anyway for now:
+#  - ./tests/install_bitcoind.sh --debug --elements compile
   - pip3 install --upgrade virtualenv
   - virtualenv --python=python3 .env
   - source .env/bin/activate
+
+check:
+  stage: testing
+  # We simply check here whether all the tests on github are completed and green
+  script:
+    - ./utils/release wait_on_master || exit 1 # that command will have a non-0 exit-value if not everything is green
+
+# jobs with a preceding . like .test are hidden jobs and are not executed. I leave them in here as
+# we might want to reactivate them in the case that github explodes or something.
+# So effectively, gitlab is currently only used for releasing.
 
 .test:
  stage: testing

--- a/utils/release.sh
+++ b/utils/release.sh
@@ -14,7 +14,12 @@ ask_yn() {
 while [[ $# -gt 0 ]]
 do
 key="$1"
+command="main"
 case $key in
+    wait_on_master)
+    command=wait_on_master
+    shift
+    ;;
     --release-notes)
     RELEASE_NOTES="yes"
     shift # past value
@@ -39,121 +44,165 @@ esac
 done
 
 
-if ! [ "$(git remote -v | grep upstream | grep 'git@github.com:cryptoadvance/specter-desktop.git' | wc -l)" = "2" ]; then
-    echo "    --> You don't have the correct upstream-remote. You need this to release. Please do this:"
-    echo "git remote add upstream git@gitlab.com:cryptoadvance/specter-cloud.git "
-    exit 2
-fi
+function main() {
 
-if ! [ "$(git remote -v | grep origin | grep 'git@github.com:' | wc -l)" = "2" ]; then
-    echo "    --> You don't have a reasonable origin-remote. You need this to release (especially with --dev). Please add one!"
-    exit 2
-fi
-
-echo "    --> Fetching all tags ..."
-git fetch upstream --tags
-
-current_branch=$(git rev-parse --abbrev-ref HEAD)
-
-if [ "$current_branch" != "master" ]; then
-    echo "You're currently not on the master-branch, so we assume this will get a PR"
-    git fetch upstream master
-    PR_MODE=yes
-    if ! git diff master..${current_branch} --exit-code > /dev/null; then
-        echo "You current branch is also not similiar to master."
-        echo "should i merge master?"
-        if ! ask_yn ; then
-            echo "break"
-            exit 2
-        fi
-        git merge master
-    fi
-fi
-
-echo "What should be the new version? Type in please (e.g. v0.9.3 ):"
-read new_version
-if ! [[ $new_version =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)(-([0-9A-Za-z-]+))?$ ]]; then 
-    echo "Does not match the pattern!"
-    exit 1; 
-fi
-
-if [[ -n "$RELEASE_NOTES" ]]; then
-
-
-    if [ -z $GH_TOKEN ]; then
-        echo "Your github-token is missing. Please export them like:"
-        echo "export GH_TOKEN="
+    if ! [ "$(git remote -v | grep upstream | grep 'git@github.com:cryptoadvance/specter-desktop.git' | wc -l)" = "2" ]; then
+        echo "    --> You don't have the correct upstream-remote. You need this to release. Please do this:"
+        echo "git remote add upstream git@gitlab.com:cryptoadvance/specter-cloud.git "
         exit 2
     fi
 
-    latest_version=$(git tag -l "v*" | grep -v 'pre' | grep -v 'dev' | sort -V | tail -1)
-
-    echo "latest_version is $latest_version. "
-
-    echo "    --> The latest version is $latest_version. "
-    echo "    --> We'll create the release-notes based on that."
-    if ! ask_yn ; then
-        echo "Ok, then you type in the latest_version:"
-        read latest_version
-        if ! [[ $new_version =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)(-([0-9A-Za-z-]+))?$ ]]; then 
-            echo "Does not match the pattern!"
-            exit 1; 
-        fi
-    fi
-
-    echo "Here are the release-notes:"
-    echo "--------------------------------------------------"
-    echo "## ${new_version} $(date +'%B %d, %Y')" > docs/new_release_notes.md
-    docker run registry.gitlab.com/cryptoadvance/specter-desktop/github-changelog:latest --github-token $GH_TOKEN --branch master cryptoadvance specter-desktop $latest_version | sort >> docs/new_release_notes.md
-    echo "" >> docs/new_release_notes.md
-    cat docs/new_release_notes.md
-    echo "--------------------------------------------------"
-
-    cp docs/release-notes.md docs/release-notes.md.orig
-    cat docs/new_release_notes.md docs/release-notes.md.orig >  docs/release-notes.md
-    rm docs/release-notes.md.orig docs/new_release_notes.md
-
-    echo "Please check your new File and modify as you find approriate!"
-    echo "We're waiting here ..."
-
-    echo "    --> Should we commit and push that (to origin) now? "
-
-    if ! ask_yn ; then
-        echo "break"
-        echo "Rolling back release_notes.md ..."
-        git checkout docs/release-notes.md
+    if ! [ "$(git remote -v | grep origin | grep 'git@github.com:' | wc -l)" = "2" ]; then
+        echo "    --> You don't have a reasonable origin-remote. You need this to release (especially with --dev). Please add one!"
         exit 2
     fi
 
-    git add docs/release-notes.md
-    git commit -m "adding release_notes to $new_version"
-    git push origin
+    echo "    --> Fetching all tags ..."
+    git fetch upstream --tags
 
-    echo "Now go ahead and make your PR:"
-    echo "https://github.com/cryptoadvance/specter-desktop/compare"
-    exit 0
-fi
+    current_branch=$(git rev-parse --abbrev-ref HEAD)
 
-
-
-if [[ -n "$TAG" ]]; then
-
-    echo "    --> Should i now create the tag and push the version $new_version ?"
-    if [ -z $DEV ]; then
-        echo "    --> This will push to your origin-remote!"
-    else
-        echo "    --> THIS WILL PUSH TO THE UPSTREAM-REMOTE!"
-        if ! ask_yn ; then
-            echo "break"
-            exit 2
+    if [ "$current_branch" != "master" ]; then
+        echo "You're currently not on the master-branch, so we assume this will get a PR"
+        git fetch upstream master
+        PR_MODE=yes
+        if ! git diff master..${current_branch} --exit-code > /dev/null; then
+            echo "You current branch is also not similiar to master."
+            echo "should i merge master?"
+            if ! ask_yn ; then
+                echo "break"
+                exit 2
+            fi
+            git merge master
         fi
     fi
+
+    echo "What should be the new version? Type in please (e.g. v0.9.3 ):"
+    read new_version
+    if ! [[ $new_version =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)(-([0-9A-Za-z-]+))?$ ]]; then 
+        echo "Does not match the pattern!"
+        exit 1; 
+    fi
+
+    if [[ -n "$RELEASE_NOTES" ]]; then
+
+
+        if [ -z $GH_TOKEN ]; then
+            echo "Your github-token is missing. Please export them like:"
+            echo "export GH_TOKEN="
+            exit 2
+        fi
+
+        latest_version=$(git tag -l "v*" | grep -v 'pre' | grep -v 'dev' | sort -V | tail -1)
+
+        echo "latest_version is $latest_version. "
+
+        echo "    --> The latest version is $latest_version. "
+        echo "    --> We'll create the release-notes based on that."
+        if ! ask_yn ; then
+            echo "Ok, then you type in the latest_version:"
+            read latest_version
+            if ! [[ $new_version =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)(-([0-9A-Za-z-]+))?$ ]]; then 
+                echo "Does not match the pattern!"
+                exit 1; 
+            fi
+        fi
+
+        echo "Here are the release-notes:"
+        echo "--------------------------------------------------"
+        echo "## ${new_version} $(date +'%B %d, %Y')" > docs/new_release_notes.md
+        docker run registry.gitlab.com/cryptoadvance/specter-desktop/github-changelog:latest --github-token $GH_TOKEN --branch master cryptoadvance specter-desktop $latest_version | sort >> docs/new_release_notes.md
+        echo "" >> docs/new_release_notes.md
+        cat docs/new_release_notes.md
+        echo "--------------------------------------------------"
+
+        cp docs/release-notes.md docs/release-notes.md.orig
+        cat docs/new_release_notes.md docs/release-notes.md.orig >  docs/release-notes.md
+        rm docs/release-notes.md.orig docs/new_release_notes.md
+
+        echo "Please check your new File and modify as you find approriate!"
+        echo "We're waiting here ..."
+
+        echo "    --> Should we commit and push that (to origin) now? "
+
+        if ! ask_yn ; then
+            echo "break"
+            echo "Rolling back release_notes.md ..."
+            git checkout docs/release-notes.md
+            exit 2
+        fi
+
+        git add docs/release-notes.md
+        git commit -m "adding release_notes to $new_version"
+        git push origin
+
+        echo "Now go ahead and make your PR:"
+        echo "https://github.com/cryptoadvance/specter-desktop/compare"
+        exit 0
+    fi
+
+
+
+    if [[ -n "$TAG" ]]; then
+
+        echo "    --> Should i now create the tag and push the version $new_version ?"
+        if [ -z $DEV ]; then
+            echo "    --> This will push to your origin-remote!"
+        else
+            echo "    --> THIS WILL PUSH TO THE UPSTREAM-REMOTE!"
+            if ! ask_yn ; then
+                echo "break"
+                exit 2
+            fi
+        fi
+        
+        git tag $new_version 
+        if [ -z $DEV ]; then
+            git push origin $new_version
+        else
+            git push upstream $new_version
+        fi
+    fi
+
+}
+
+function wait_on_master() {
+    echo "# check status of masterbranch ..."
+    i=0
+    # First, wait on the check-runs to be completed:
+    for i in {1..5} ; do
+        current_state=$(curl -s https://api.github.com/repos/cryptoadvance/specter-desktop/commits/master/check-runs)
+        different_states=$(echo $current_state | jq -r '.check_runs[] | select(.status == "completed") | .status' | uniq | wc -l)
+        status=$(echo $current_state | jq -r '.check_runs[] | select(.status == "completed") | .status' | uniq)
     
-    git tag $new_version 
-    if [ -z $DEV ]; then
-        git push origin $new_version
-    else
-        git push upstream $new_version
-    fi
-fi
+        if [[ "$different_states" == 1 ]] && [[ "$status" == "completed" ]] ; then
+            break
+        fi
+        echo "# Builds still running. Will check again in 5 seconds."
+        sleep 5
+    done
 
+    # Now check all the runs and make sure there are all green:
+    current_state=$(curl -s https://api.github.com/repos/cryptoadvance/specter-desktop/commits/master/check-runs)
+    different_conclusions=$(echo $current_state | jq -r '.check_runs[] | select(.conclusion == "success") | .conclusion' | uniq | wc -l)
+    conclusion=$(echo $current_state | jq -r '.check_runs[] | select(.conclusion == "success") | .conclusion' | uniq)
+    
+    # We only have one conclusion over all runs:
+    if [ $different_conclusions -gt 1 ] ; then
+        echo "# different_conclusions: $different_conclusions"
+        echo "# Seems that master is not green. Exiting 1"
+        exit 1
+    fi
+    # ... and that conclusion is "success"
+    if [[ "$conclusion" == "success" ]]; then
+        echo "# Great, conclusion is success! Exiting 0"
+        exit 0
+    fi
+
+    echo "# ERROR: I'm confused. This should not happened, exiting 99"
+    echo "# conclusion = $conclusion"
+    #echo $current_state
+    exit 99
+}
+
+$command


### PR DESCRIPTION
The elements-compilation (and effectively also the bitcoind-compilation) is a quite time consuming process which is cached in the [cirrus-ci process](https://github.com/cryptoadvance/specter-desktop/blob/master/.cirrus.yml#L16) However that caching looks dificult to do in gitlab and effectivley doing all the tests both in travis (and latter cirrus) and gitlab was a luxury in the first place. We did it because we wanted to have some resilience and wanted to release via gitlab as private runners were not available in travis.

The situation changed. Private runners are available in cirrus but you can even run the cirrus-process via the [cirrus-cli](https://github.com/cirruslabs/cirrus-cli) in any other ci-system.

So because of that, let's drop gitlab test-support. Instead, we'll simply check the build-status of master via the gitlab-api assuming that we'll always release from master.