### PR TITLE
Fix test connection crash when node can't be reached

### DIFF
--- a/src/cryptoadvance/specter/node.py
+++ b/src/cryptoadvance/specter/node.py
@@ -311,7 +311,12 @@ class Node:
         """
         rpc = self.get_rpc()
         if rpc is None:
-            return {"out": "", "err": _("Connection to node failed"), "code": -1}
+            return {
+                "out": "",
+                "err": _("Connection to node failed"),
+                "code": -1,
+                "tests": {},
+            }
         r = {}
         r["tests"] = {"connectable": False}
         r["err"] = ""

--- a/src/cryptoadvance/specter/server_endpoints/nodes.py
+++ b/src/cryptoadvance/specter/server_endpoints/nodes.py
@@ -146,7 +146,7 @@ def node_settings(node_alias):
 
             if "tests" in test:
                 # If any test has failed, we notify the user that the test has not passed
-                if False in list(test["tests"].values()):
+                if not test["tests"] or False in list(test["tests"].values()):
                     flash(_("Test failed: {}").format(test["err"]), "error")
                 else:
                     flash(_("Test passed"), "info")


### PR DESCRIPTION
Fix a current issue where clicking the Test button to test node connection throws an error if the node can't be reached.