### PR TITLE
fix fee estimation on liquid

### DIFF
--- a/src/cryptoadvance/specter/liquid/rpc.py
+++ b/src/cryptoadvance/specter/liquid/rpc.py
@@ -319,8 +319,15 @@ class LiquidRPC(BitcoinRPC):
         return decoded
 
     def decoderawtransaction(self, tx):
+        blinded = super().__getattr__("decoderawtransaction")(tx)
         unblinded = self.unblindrawtransaction(tx)["hex"]
         obj = super().__getattr__("decoderawtransaction")(unblinded)
+        if "vsize" in blinded:
+            obj["vsize"] = blinded["vsize"]
+        if "size" in blinded:
+            obj["size"] = blinded["size"]
+        if "weight" in blinded:
+            obj["weight"] = blinded["weight"]
         try:
             # unblind the rest of outputs
             b = LTransaction.from_string(tx)

--- a/src/cryptoadvance/specter/liquid/wallet.py
+++ b/src/cryptoadvance/specter/liquid/wallet.py
@@ -322,9 +322,6 @@ class LWallet(Wallet):
         if fee_rate > 0 and fee_rate < self.MIN_FEE_RATE:
             fee_rate = self.MIN_FEE_RATE
 
-        # FIXME: stupid scale of the fee rate for now
-        fee_rate = 2 * fee_rate
-
         options = {"includeWatching": True, "replaceable": rbf}
         extra_inputs = []
 
@@ -381,7 +378,6 @@ class LWallet(Wallet):
                 # bitcoin core needs us to convert sat/B to BTC/kB
                 options["feeRate"] = round((fee_rate * 1000) / 1e8, 8)
 
-            # don't reuse change addresses - use getrawchangeaddress instead
             r = self.rpc.walletcreatefundedpsbt(
                 extra_inputs,  # inputs
                 [
@@ -407,43 +403,37 @@ class LWallet(Wallet):
                     {"txid": inp["previous_txid"], "vout": inp["previous_vout"]}
                     for inp in psbt["inputs"]
                 ]
-            if "changeAddress" in psbt:
-                options["changeAddress"] = psbt["changeAddress"]
+            # FIXME: get back change addresses
+            # if "changeAddress" in psbt:
+            #     options["changeAddress"] = psbt["changeAddress"]
             if "base64" in psbt:
                 b64psbt = psbt["base64"]
 
-        # if fee_rate > 0.0:
-        #     if not existing_psbt:
-        #         psbt_fees_sats = int(psbt["fee"] * 1e8)
-        #         # estimate final size: add weight of inputs
-        #         tx_full_size = ceil(
-        #             psbt["tx"]["vsize"]
-        #             + len(psbt["inputs"]) * self.weight_per_input / 4
-        #         )
-        #         adjusted_fee_rate = (
-        #             fee_rate
-        #             * (fee_rate / (psbt_fees_sats / psbt["tx"]["vsize"]))
-        #             * (tx_full_size / psbt["tx"]["vsize"])
-        #         )
-        #         options["feeRate"] = "%.8f" % round((adjusted_fee_rate * 1000) / 1e8, 8)
-        #     else:
-        #         options["feeRate"] = "%.8f" % round((fee_rate * 1000) / 1e8, 8)
-        #     r = self.rpc.walletcreatefundedpsbt(
-        #         extra_inputs,  # inputs
-        #         [{addresses[i]: amounts[i]} for i in range(len(addresses))],  # output
-        #         0,  # locktime
-        #         options,  # options
-        #         True,  # bip32-der
-        #     )
+        if fee_rate > 0.0:
+            if not existing_psbt:
+                adjusted_fee_rate = self.adjust_fee(psbt, fee_rate)
+                options["feeRate"] = "%.8f" % round((adjusted_fee_rate * 1000) / 1e8, 8)
+            else:
+                options["feeRate"] = "%.8f" % round((fee_rate * 1000) / 1e8, 8)
+            r = self.rpc.walletcreatefundedpsbt(
+                extra_inputs,  # inputs
+                [
+                    {addresses[i]: amounts[i], "asset": assets[i]}
+                    for i in range(len(addresses))
+                ],  # output
+                0,  # locktime
+                options,  # options
+                True,  # bip32-der
+            )
 
-        #     b64psbt = r["psbt"]
-        #     psbt = self.rpc.decodepsbt(b64psbt)
-        #     psbt["fee_rate"] = options["feeRate"]
-        # # estimate full size
-        # tx_full_size = ceil(
-        #     psbt["tx"]["vsize"] + len(psbt["inputs"]) * self.weight_per_input / 4
-        # )
-        # psbt["tx_full_size"] = tx_full_size
+            b64psbt = r["psbt"]
+            psbt = self.rpc.decodepsbt(b64psbt)
+            psbt["fee_rate"] = options["feeRate"]
+        # estimate full size
+        tx_full_size = ceil(
+            psbt["tx"]["vsize"] + len(psbt["inputs"]) * self.weight_per_input / 4
+        )
+        psbt["tx_full_size"] = tx_full_size
 
         psbt["base64"] = b64psbt
         psbt["amount"] = amounts
@@ -456,3 +446,26 @@ class LWallet(Wallet):
             self.save_pending_psbt(psbt)
 
         return psbt
+
+    def adjust_fee(self, psbt, fee_rate):
+        psbt_fees_sats = int(psbt.get("fees", {}).get("bitcoin", 0) * 1e8)
+
+        # TODO: handle non-blind outputs differently
+        num_blinded_outs = len(psbt["outputs"]) - 1
+        # estimate final size: add weight of inputs and outputs
+        # out witness weight is 4245 (from random tx)
+        # commitments in blinded tx: 33 for nonce and 33 for value
+        commitment_size = 33 + 33
+        tx_full_size = ceil(
+            psbt["tx"]["vsize"]
+            + len(psbt["inputs"]) * self.weight_per_input / 4
+            + num_blinded_outs * 4245 / 4
+            # probably elements doesn't count commitments
+            + len(psbt["inputs"]) * commitment_size
+            + num_blinded_outs * commitment_size
+        )
+        return (
+            fee_rate
+            * (fee_rate / (psbt_fees_sats / psbt["tx"]["vsize"]))
+            * (tx_full_size / psbt["tx"]["vsize"])
+        )

--- a/src/cryptoadvance/specter/templates/wallet/send/new/components/fee_selection.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/send/new/components/fee_selection.jinja
@@ -24,9 +24,10 @@
     <br>
     <div id = "fee_manual" style="display: {% if fee_options_dynamic %}none{% else %}block{% endif %}">
         {{ _("Fee rate:") }}<br>
-        <input type="number" class="fee_rate" name="fee_rate" id="fee_rate" min="1" step="any" autocomplete="off" {% if not fee_options_dynamic %}value="{{ fee_rate }}"{% endif %}> sat/vbyte
+        {% set min_fee = 0.1 if specter.is_liquid else 1 %}
+        <input type="number" class="fee_rate" name="fee_rate" id="fee_rate" min="{{min_fee}}" step="any" autocomplete="off" {% if not fee_options_dynamic %}value="{{ fee_rate }}"{% endif %}> sat/vbyte
         <div class="note">
-            {{ _("leave blank to set automatically, 1 sat/vbyte is the minimal fee rate.") }}
+            {{ _("leave blank to set automatically, {} sat/vbyte is the minimal fee rate.".format(min_fee)) }}
         </div>
     </div>
     <div id ="fee_dynamic" style="display: {% if fee_options_dynamic %}block{% else %}none{% endif %}">

--- a/src/cryptoadvance/specter/templates/wallet/send/new/wallet_send.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/send/new/wallet_send.jinja
@@ -97,7 +97,9 @@
 				<div class="row break-row-mobile" id="coin-selection-row" style="margin-top: 30px;">
 					<button id="add-recipient" style="width: 200px; height: 38px;" type="button" class="btn" onclick="addRecipient('', 0, 'btc', '')"><svg width="20" height="20" viewBox="0 0 24 24"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/></svg> {{ _("Add recipient") }} </button>
 				{% if wallet.utxo | length > 0 %}
+					{% if not specter.is_liquid %}
 					<button style="width: 200px; height: 38px; margin-left: 10px;" id="coinselect" type="button" class="btn" onclick="toggleExpand()">{{ _("Select coins") }}<span class="optional">&nbsp;{{ _("manually") }}</span></button>
+					{% endif %}
 				{% endif %}
 				</div><br>
 				{% with selected_coins=selected_coins %}
@@ -112,6 +114,13 @@
 
 {% block scripts %}
 	<script>
+		{% if specter.is_liquid %}
+		const MIN_FEE_RATE = 0.1;
+		const FEE_RATE_STEP = 0.01;
+		{% else %}
+		const MIN_FEE_RATE = 1;
+		const FEE_RATE_STEP = 0.5;
+		{% endif %}
 		// Amounts and units
 		var units = [];
 		var amounts = [];
@@ -545,9 +554,9 @@
 				if (!feeOptionManual.checked) {
 					feeOptionManual.checked = true;
 					showFeeOption(feeOptionManual);
-					let manualRate = Math.round(document.getElementById('fee_rate_dynamic').value * 2) / 2;
-					if (manualRate < 1) {
-						manualRate = 1;
+					let manualRate = Math.round(document.getElementById('fee_rate_dynamic').value / FEE_RATE_STEP) * FEE_RATE_STEP;
+					if (manualRate < MIN_FEE_RATE) {
+						manualRate = MIN_FEE_RATE;
 					}
 					document.getElementById('fee_rate').value = manualRate;
 				}
@@ -581,7 +590,8 @@
 				} else {
 					document.getElementById('calculated_tx_fee').innerText = `: ${result.error}`;
 				}
-			} catch {
+			} catch (e) {
+				console.log(e);
 				document.getElementById('calculated_tx_fee').innerText = `: {{ _("failed to calculate transaction fees") }}`;
 			}
 			return -1;

--- a/src/cryptoadvance/specter/templates/wallet/send/sign/wallet_send_sign_psbt.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/send/sign/wallet_send_sign_psbt.jinja
@@ -115,7 +115,7 @@
 				<br>
 				<h2 class="tx_details_header">{{ _("Transaction Info") }}</h2>
 				<p style="text-align: left; background-color: #131a24; padding: 10px; line-height: 2; border-radius: 15px;">
-					<b>{{ _("Total fee:") }}/b> {{ psbt['fee'] | btc2sat }} sats {% if specter.price_check %}<span class="note">&nbsp;({{ psbt['fee'] | altunit }})</span>{% endif %}<br>
+					<b>{{ _("Total fee:") }}</b> {{ psbt['fee'] | btc2sat }} sats {% if specter.price_check %}<span class="note">&nbsp;({{ psbt['fee'] | altunit }})</span>{% endif %}<br>
 					<b>{{ _("Fee rate:") }}</b>
 					{% if 'tx_full_size' in psbt %}
 						{{ (psbt['fee'] / psbt['tx_full_size']) | feerate }} sat/vbyte<br>

--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -1439,15 +1439,13 @@ class Wallet:
                 "replaceable": rbf,
             }
 
-            # 209900 is pre-v21 for Elements Core
-            if self.manager.bitcoin_core_version_raw >= 209900:
+            if self.manager.bitcoin_core_version_raw >= 210000:
                 options["add_inputs"] = selected_coins == []
 
             if fee_rate > 0:
                 # bitcoin core needs us to convert sat/B to BTC/kB
                 options["feeRate"] = round((fee_rate * 1000) / 1e8, 8)
 
-            # don't reuse change addresses - use getrawchangeaddress instead
             r = self.rpc.walletcreatefundedpsbt(
                 extra_inputs,  # inputs
                 [{addresses[i]: amounts[i]} for i in range(len(addresses))],  # output


### PR DESCRIPTION
Fixes fee estimation on Liquid as `walletcreatepsbt` doesn't take into account witnesses of outputs.
Currently assumes all outputs and inputs are confidential.

The resulting fee is slightly larger than the min fee (0.11 sat/vbyte against 0.1 sat/vbyte), but I think better to be on the safe side and spend a few more satoshis instead of not being able to broadcast transaction.

What exactly Elements Core takes into account when calculating the fee is not very clear to me, I think we can get back to it when we fix other major issues and unconfidential addresses.

Also fixes a `<b>` tag in tx details.