### PR TITLE
disable elements hot wallet for bitcoin wallets

### DIFF
--- a/src/cryptoadvance/specter/devices/elements_core.py
+++ b/src/cryptoadvance/specter/devices/elements_core.py
@@ -1,6 +1,8 @@
 import os
 from embit import bip39
 from embit.liquid.slip77 import master_blinding_from_seed
+
+from ..helpers import is_liquid
 from . import DeviceTypes
 from .bitcoin_core import BitcoinCore
 
@@ -42,3 +44,14 @@ class ElementsCore(BitcoinCore):
         master_blinding_key = master_blinding_from_seed(seed)
         rpc.importmasterblindingkey(master_blinding_key.secret.hex())
         self.set_blinding_key(master_blinding_key.wif())
+
+    def has_key_types(self, wallet_type, network="main"):
+        if not is_liquid(network):
+            return False
+        return super().has_key_types(wallet_type, network)
+
+    def no_key_found_reason(self, wallet_type, network="main"):
+        if self.has_key_types(wallet_type, network=network):
+            return ""
+        if not is_liquid(network):
+            return "This wallet can only sign on Liquid"


### PR DESCRIPTION
One shouldn't be able to use liquid hot devices for bitcoin wallets
![disable_elements](https://user-images.githubusercontent.com/1706012/125194341-240d1e80-e251-11eb-8c24-559697768d31.png)
