### PR TITLE
Minor liquid fixes

### DIFF
--- a/src/cryptoadvance/specter/liquid/wallet.py
+++ b/src/cryptoadvance/specter/liquid/wallet.py
@@ -229,21 +229,6 @@ class LWallet(Wallet):
         self.balance = balance
         return self.balance
 
-    def txlist(
-        self,
-        fetch_transactions=True,
-        validate_merkle_proofs=False,
-        current_blockheight=None,
-    ):
-        """Returns a list of all transactions in the wallet's CSV cache - processed with information to display in the UI in the transactions list
-        #Parameters:
-        #    fetch_transactions (bool): Update the TxList CSV caching by fetching transactions from the Bitcoin RPC
-        #    validate_merkle_proofs (bool): Return transactions with validated_blockhash
-        #    current_blockheight (int): Current blockheight for calculating confirmations number (None will fetch the block count from the RPC)
-        """
-        # TODO: only from RPC for now
-        return self.rpc.listtransactions("*", 10000, 0, True)
-
     def fill_psbt(self, b64psbt, non_witness: bool = True, xpubs: bool = True):
         psbt = PSET.from_string(b64psbt)
 

--- a/src/cryptoadvance/specter/liquid/wallet.py
+++ b/src/cryptoadvance/specter/liquid/wallet.py
@@ -294,7 +294,7 @@ class LWallet(Wallet):
                     for o1, o2 in zip(psbt["outputs"], decoded["vout"]):
                         if o1["script"]["hex"] != o2["scriptPubKey"]["hex"]:
                             mismatch = True
-                            continue
+                            break
                     if mismatch:
                         continue
                     else:

--- a/src/cryptoadvance/specter/server_endpoints/wallets.py
+++ b/src/cryptoadvance/specter/server_endpoints/wallets.py
@@ -907,7 +907,7 @@ def broadcast(wallet_alias):
     res = wallet.rpc.testmempoolaccept([tx])[0]
     if res["allowed"]:
         app.specter.broadcast(tx)
-        wallet.delete_pending_psbt(get_txid(tx))
+        wallet.delete_pending_psbt(get_txid(tx), tx=tx)
         return jsonify(success=True)
     else:
         return jsonify(
@@ -959,7 +959,7 @@ def broadcast_blockexplorer(wallet_alias):
                 f"{app.config['EXPLORERS_LIST'][explorer]['url']}{url_network}api/tx",
                 data=tx,
             )
-            wallet.delete_pending_psbt(get_txid(tx))
+            wallet.delete_pending_psbt(get_txid(tx), tx=tx)
             return jsonify(success=True)
         except Exception as e:
             return jsonify(

--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -708,7 +708,7 @@ class Wallet:
             )
         return amount
 
-    def delete_pending_psbt(self, txid):
+    def delete_pending_psbt(self, txid, tx=None):
         try:
             self.rpc.lockunspent(True, self.pending_psbts[txid]["tx"]["vin"])
         except:


### PR DESCRIPTION
- removes redundant `txlist` function - so now correct addresses and amounts are displayed in the transaction history page
- deletes pending psbt from the wallet when tx is signed and broadcasted - the issue was due to different txid for blinded transactions comparing to one in psbt (unblinded). Now we can accept additional tx argument and search for psbt that has the same inputs and outputs as the broadcasted transaction.