### PR TITLE
More information while backing up specter data

### DIFF
--- a/src/cryptoadvance/specter/templates/settings/general_settings.jinja
+++ b/src/cryptoadvance/specter/templates/settings/general_settings.jinja
@@ -24,7 +24,7 @@
 			</div>
 			{{ _("Specter Data Backup") }}:
 			<div class="note">
-			    {{ _("Warning: This backup does not include private keys of the hot wallets") }}
+			    {{ _("Warning: This backup does not include private seed of the hot wallets or, obviously, the private seed of your Hardwarewallets.") }}
 			</div>
 			<div class="row">
 				<a href="{{ url_for('settings_endpoint.backup_file') }}" class="btn" style="width: 100%; margin-top: -5px;">{{ _("Download Specter backup files") }}</a>

--- a/src/cryptoadvance/specter/templates/settings/general_settings.jinja
+++ b/src/cryptoadvance/specter/templates/settings/general_settings.jinja
@@ -23,7 +23,9 @@
 				</p>
 			</div>
 			{{ _("Specter Data Backup") }}:
-			<br><br>
+			<div class="note">
+			    {{ _("Warning: This backup does not include private keys of the hot wallets") }}
+			</div>
 			<div class="row">
 				<a href="{{ url_for('settings_endpoint.backup_file') }}" class="btn" style="width: 100%; margin-top: -5px;">{{ _("Download Specter backup files") }}</a>
 			</div>


### PR DESCRIPTION
While backing up the specter data, private keys of the hot wallets are
not backed up. This commit shows a warning to the user informing the
same.