### PR TITLE
doc, Add FLASK_ENV.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -93,9 +93,11 @@ virtualenv --python=python .env
 Run the server:
 
 ```sh
+export FLASK_ENV=development
 cd specter-desktop
 python3 -m cryptoadvance.specter server --config DevelopmentConfig
 ```
+For any changes to the code to take effect it is necessary to run `python3 setup.py install` again.
 
 #### If `pip install` fails on `cryptography==3.4.x`
 Certain platform/python3 version combos require a Rust compiler. Install via:


### PR DESCRIPTION
Add "export FLASK_ENV = development", so Specter Desktop can start with "Environment: development" and "Debug mode: on".
It also makes it explicit that it is necessary to run `setup.py` again for the code changes to take effect.