### PR TITLE
Use the configured bitcoind data directory (regression)

### DIFF
--- a/src/cryptoadvance/specter/rpc.py
+++ b/src/cryptoadvance/specter/rpc.py
@@ -113,7 +113,7 @@ def get_configs(config=None, datadir=get_default_datadir()):
 
 
 def detect_rpc_confs(config=None, datadir=get_default_datadir()):
-    rpcconfs = get_configs(config)
+    rpcconfs = get_configs(config, datadir)
     rpc_arr = []
     for conf in rpcconfs:
         rpc_arr.append(conf)


### PR DESCRIPTION
Without this fix, the configured data directory is ignored and the default is always used instead.

This did not happen with v1.5.0, it appears that the regression was introduced [in 22cd3e93](https://github.com/cryptoadvance/specter-desktop/commit/22cd3e9372abd0f95ce679d02711fb2bde86e126#diff-04de6bab3ea93d6516d4769480f8ab06fa7e2eb339fc1c0dd302292fa820fd94L115) (#1333).