### PR TITLE
Improved export and restore hot wallet process

### DIFF
--- a/src/cryptoadvance/specter/devices/__init__.py
+++ b/src/cryptoadvance/specter/devices/__init__.py
@@ -12,7 +12,7 @@ from .passport import Passport
 from .jade import Jade
 from .generic import GenericDevice
 from .electrum import Electrum
-from .bitcoin_core import BitcoinCore
+from .bitcoin_core import BitcoinCore, BitcoinCoreWatchOnly
 from .elements_core import ElementsCore
 from .seedsigner import SeedSignerDevice
 
@@ -31,6 +31,7 @@ __all__ = [
     SeedSignerDevice,
     Electrum,
     BitcoinCore,
+    BitcoinCoreWatchOnly,
     ElementsCore,
     GenericDevice,
 ]

--- a/src/cryptoadvance/specter/devices/bitcoin_core.py
+++ b/src/cryptoadvance/specter/devices/bitcoin_core.py
@@ -256,3 +256,46 @@ class BitcoinCore(Device):
                         break
         except:
             pass  # We tried...
+
+
+class BitcoinCoreWatchOnly(BitcoinCore):
+    device_type = DeviceTypes.BITCOINCORE_WATCHONLY
+    name = "Bitcoin Core (watch only)"
+    icon = "bitcoincore_icon.svg"
+
+    hot_wallet = True
+
+    def sign_psbt(self, base64_psbt, wallet, file_password=None):
+        raise Exception("Cannot sign with a watch-only wallet. Convert")
+
+    def sign_raw_tx(self, raw_tx, wallet, file_password=None):
+        raise Exception("Cannot sign with a watch-only wallet")
+
+    def add_hot_wallet_keys(
+        self,
+        mnemonic,
+        passphrase,
+        paths,
+        file_password,
+        wallet_manager,
+        testnet,
+        keys_range=[0, 1000],
+        keys_purposes=[],
+    ):
+        # Convert the watch-only wallet to a hot wallet then fix up its internal attrs to
+        # match.
+        super().add_hot_wallet_keys(
+            mnemonic,
+            passphrase,
+            paths,
+            file_password,
+            wallet_manager,
+            testnet,
+            keys_range,
+            keys_purposes,
+        )
+
+        # Change type (also triggers write to file)
+        self.set_type(DeviceTypes.BITCOINCORE)
+        # After update this device will be available as a BitcoinCore (hot) instance
+        self.manager.update()

--- a/src/cryptoadvance/specter/devices/bitcoin_core.py
+++ b/src/cryptoadvance/specter/devices/bitcoin_core.py
@@ -261,9 +261,6 @@ class BitcoinCore(Device):
 class BitcoinCoreWatchOnly(BitcoinCore):
     device_type = DeviceTypes.BITCOINCORE_WATCHONLY
     name = "Bitcoin Core (watch only)"
-    icon = "bitcoincore_icon.svg"
-
-    hot_wallet = True
 
     def sign_psbt(self, base64_psbt, wallet, file_password=None):
         raise Exception("Cannot sign with a watch-only wallet. Convert")

--- a/src/cryptoadvance/specter/devices/device_types.py
+++ b/src/cryptoadvance/specter/devices/device_types.py
@@ -1,6 +1,7 @@
 class DeviceTypes:
     BITBOX02 = "bitbox02"
     BITCOINCORE = "bitcoincore"
+    BITCOINCORE_WATCHONLY = "bitcoincore_watchonly"
     COBO = "cobo"
     COLDCARD = "coldcard"
     ELECTRUM = "electrum"

--- a/src/cryptoadvance/specter/managers/wallet_manager.py
+++ b/src/cryptoadvance/specter/managers/wallet_manager.py
@@ -62,7 +62,7 @@ class WalletManager:
         self.WalletClass = LWallet if is_liquid(chain) else Wallet
         self.update(data_folder, rpc, chain)
 
-    def update(self, data_folder=None, rpc=None, chain=None):
+    def update(self, data_folder=None, rpc=None, chain=None, use_threading=True):
         if self.is_loading:
             return
         self.is_loading = True
@@ -102,7 +102,7 @@ class WalletManager:
             for k in list(self.wallets.keys()):
                 if k not in self.wallets_update_list:
                     self.wallets.pop(k)
-            if self.allow_threading:
+            if self.allow_threading and use_threading:
                 t = threading.Thread(
                     target=self._update,
                     args=(

--- a/src/cryptoadvance/specter/server_endpoints/devices.py
+++ b/src/cryptoadvance/specter/server_endpoints/devices.py
@@ -14,6 +14,8 @@ from flask import current_app as app
 from flask_babel import lazy_gettext as _
 from flask_login import login_required, current_user
 from mnemonic import Mnemonic
+
+from cryptoadvance.specter.devices.device_types import DeviceTypes
 from ..devices.bitcoin_core import BitcoinCore
 from ..helpers import is_testnet, generate_mnemonic, validate_mnemonic
 from ..key import Key
@@ -84,11 +86,19 @@ def new_device_keys(device_type):
                     err = _("Failed to parse these xpubs") + ":\n" + "\n".join(xpub)
                     break
         if not keys and not err:
-            if device_type in ["bitcoincore", "elementscore"]:
+            if device_type in [
+                DeviceTypes.BITCOINCORE,
+                DeviceTypes.ELEMENTSCORE,
+                DeviceTypes.BITCOINCORE_WATCHONLY,
+            ]:
                 if not paths:
                     err = _("No paths were specified, please provide at least one.")
                 if err is None:
                     if existing_device:
+                        if device_type == DeviceTypes.BITCOINCORE_WATCHONLY:
+                            device.setup_device(
+                                file_password, app.specter.wallet_manager
+                            )
                         device.add_hot_wallet_keys(
                             mnemonic,
                             passphrase,

--- a/src/cryptoadvance/specter/server_endpoints/settings.py
+++ b/src/cryptoadvance/specter/server_endpoints/settings.py
@@ -117,6 +117,7 @@ def general():
                         continue
                 write_wallet(wallet)
                 app.specter.wallet_manager.update()
+                time.sleep(1)
                 try:
                     wallet_obj = app.specter.wallet_manager.get_by_alias(
                         wallet["alias"]

--- a/src/cryptoadvance/specter/server_endpoints/settings.py
+++ b/src/cryptoadvance/specter/server_endpoints/settings.py
@@ -116,8 +116,8 @@ def general():
                         )
                         continue
                 write_wallet(wallet)
-                app.specter.wallet_manager.update()
-                time.sleep(1)
+                app.specter.wallet_manager.update(use_threading=False)
+
                 try:
                     wallet_obj = app.specter.wallet_manager.get_by_alias(
                         wallet["alias"]

--- a/src/cryptoadvance/specter/specter.py
+++ b/src/cryptoadvance/specter/specter.py
@@ -19,6 +19,8 @@ from requests.exceptions import ConnectionError
 from stem.control import Controller
 from urllib3.exceptions import NewConnectionError
 
+from cryptoadvance.specter.devices.device_types import DeviceTypes
+
 from .helpers import clean_psbt, deep_update, is_liquid, is_testnet, get_asset_label
 from .internal_node import InternalNode
 from .liquid.rpc import LiquidRPC
@@ -649,8 +651,12 @@ class Specter:
                     data = zipfile.ZipInfo("{}.json".format(device.alias))
                     data.date_time = time.localtime(time.time())[:6]
                     data.compress_type = zipfile.ZIP_DEFLATED
+                    device = device.json
+                    # Exporting the bitcoincore hot wallet as watchonly
+                    if device["type"] == DeviceTypes.BITCOINCORE:
+                        device["type"] = DeviceTypes.BITCOINCORE_WATCHONLY
                     zf.writestr(
-                        "devices/{}.json".format(device.alias), json.dumps(device.json)
+                        "devices/{}.json".format(device["alias"]), json.dumps(device)
                     )
         memory_file.seek(0)
         return memory_file

--- a/src/cryptoadvance/specter/templates/device/components/device_type.jinja
+++ b/src/cryptoadvance/specter/templates/device/components/device_type.jinja
@@ -5,7 +5,9 @@
         <select name="device_type" id="device_type">
             <option value="" selected>{{ _("Select type") }}</option>
             {% for cls in specter.device_manager.supported_devices %}
-            <option value="{{cls.device_type}}">{{cls.name}}</option>
+                {% if device.device_type != "bitcoincore_watchonly" or cls.device_type != "bitcoincore"%}
+                    <option value="{{cls.device_type}}">{{cls.name}}</option>
+                {% endif %}
             {% endfor %}
         </select>
     </fieldset>

--- a/src/cryptoadvance/specter/templates/device/device.jinja
+++ b/src/cryptoadvance/specter/templates/device/device.jinja
@@ -66,7 +66,11 @@
 	<div style="line-height: 1; margin-top: 30px;">
 		<form action="./" method="POST">
 			<input type="hidden" class="csrf-token" name="csrf_token" value="{{ csrf_token() }}"/>
-			<button id="add_keys" type="submit" name="action" value="add_keys" class="btn centered">{{ _("Add more keys") }}</button>
+			{% if device.device_type != "bitcoincore_watchonly"%}
+				<button id="add_keys" type="submit" name="action" value="add_keys" class="btn centered">{{ _("Add more keys") }}</button>
+			{% else %}
+				<button id="add_keys" type="submit" name="action" value="add_keys" class="btn centered">{{ _("Convert to hot wallet") }}</button>
+			{% endif %}
 		</form>
 		<br>
 		{% if device.hwi_support %}

--- a/src/cryptoadvance/specter/templates/device/new_device/new_device_keys.jinja
+++ b/src/cryptoadvance/specter/templates/device/new_device/new_device_keys.jinja
@@ -89,7 +89,7 @@
                     {{ _("To pair your Passport with Specter, navigate to Pair Wallet –> Specter and follow the instructions on your Passport.<br>If your webcam is having difficulty scanning QR codes on Passport’s screen, we recommend using a microSD.") }}
                     </span>
                 </div>
-                <div id="hwi-only-instructions" {%if device_class.device_type in ['bitcoincore', 'cobo', 'coldcard', 'electrum', 'other', 'specter']%}class="hidden"{% endif %}>
+                <div id="hwi-only-instructions" {%if device_class.device_type in ['bitcoincore', 'bitcoincore_watchonly', 'cobo', 'coldcard', 'electrum', 'other', 'specter']%}class="hidden"{% endif %}>
                     <p>{{ _("Connect your hardware device to the computer via USB.") }}</p>
                 </div>
                 <br>

--- a/src/cryptoadvance/specter/templates/device/new_device/new_device_type.jinja
+++ b/src/cryptoadvance/specter/templates/device/new_device/new_device_type.jinja
@@ -8,12 +8,14 @@
             <div id="devices_list" class="row overflow">
                 {% for cls in specter.device_manager.supported_devices_for_chain(specter) %}
                     {% if not cls.hot_wallet or specter.rpc %}
-                        <a id="label_device_type_{{ cls.name | replace(' ', '') }}" href="{{ url_for('devices_endpoint.new_device_keys', device_type=cls.device_type) if not cls.hot_wallet else url_for('devices_endpoint.new_device_mnemonic', device_type=cls.device_type) }}" style="text-decoration: none;">
-                            <div class="small-card radio" id="{{ cls.device_type }}_device_card" style="transform: scale(0.85); margin: 3px;">
-                                <img src="{{ url_for('static', filename='img/devices/' ~ cls.icon) }}" width="18px">
-                                {{ cls.name }}
-                            </div>
-                        </a>
+                        {% if cls.device_type != "bitcoincore_watchonly" %}
+                            <a id="label_device_type_{{ cls.name | replace(' ', '') }}" href="{{ url_for('devices_endpoint.new_device_keys', device_type=cls.device_type) if not cls.hot_wallet else url_for('devices_endpoint.new_device_mnemonic', device_type=cls.device_type) }}" style="text-decoration: none;">
+                                <div class="small-card radio" id="{{ cls.device_type }}_device_card" style="transform: scale(0.85); margin: 3px;">
+                                    <img src="{{ url_for('static', filename='img/devices/' ~ cls.icon) }}" width="18px">
+                                    {{ cls.name }}
+                                </div>
+                            </a>
+                        {% endif %}
                     {% endif %}
                 {% endfor %}
             </div>

--- a/src/cryptoadvance/specter/templates/device/new_device_manual.jinja
+++ b/src/cryptoadvance/specter/templates/device/new_device_manual.jinja
@@ -228,7 +228,7 @@ m/48h/{{ 0 if specter.info.chain == "main" else 1 }}h/0h/2h</textarea>
 		function setPubkeysView() {
 			var coldDevice = document.getElementById("cold_device");
 			var hotDevice = document.getElementById("hot_device");
-			if (deviceType.value == 'bitcoincore') {
+			if (deviceType.value == 'bitcoincore' or deviceType.value == 'bitcoincore_watchonly') {
 				coldDevice.style.display = 'none';
 				hotDevice.style.display = 'block';
 			} else {

--- a/src/cryptoadvance/specter/templates/includes/overlay/sign_tx_method.jinja
+++ b/src/cryptoadvance/specter/templates/includes/overlay/sign_tx_method.jinja
@@ -62,7 +62,7 @@
         {% endif %}
         {% if device.hot_wallet %}
             <button id="{{ device.alias }}_hot_sign_btn" class="btn flex-item" style="width: 190px; margin: 15px auto;">
-                {% if device.device_type == "bitcoincore" %}
+                {% if device.device_type == "bitcoincore" or device.device_type == "bitcoincore_watchonly" %}
                     {% from "components/bitcoin_svg.jinja" import bitcoin_svg %}
                     {{ bitcoin_svg(chain, 16) }} {{ _("Sign with Bitcoin Core") }}
                 {% else %}

--- a/src/cryptoadvance/specter/templates/includes/overlay/sign_tx_method.jinja
+++ b/src/cryptoadvance/specter/templates/includes/overlay/sign_tx_method.jinja
@@ -62,7 +62,7 @@
         {% endif %}
         {% if device.hot_wallet %}
             <button id="{{ device.alias }}_hot_sign_btn" class="btn flex-item" style="width: 190px; margin: 15px auto;">
-                {% if device.device_type == "bitcoincore" or device.device_type == "bitcoincore_watchonly" %}
+                {% if device.device_type == "bitcoincore" %}
                     {% from "components/bitcoin_svg.jinja" import bitcoin_svg %}
                     {{ bitcoin_svg(chain, 16) }} {{ _("Sign with Bitcoin Core") }}
                 {% else %}

--- a/src/cryptoadvance/specter/templates/wallet/send/sign/wallet_send_sign_psbt.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/send/sign/wallet_send_sign_psbt.jinja
@@ -208,9 +208,14 @@
 		<div id="signing_container" class="signing_container flex-column {% if psbt['raw'] %}hidden{% endif %}" style="text-align: center;">
 			<p style="margin-bottom: 15px; margin-top: 0px;">{{ _("Sign transaction with your:") }}</p>
 			{% for device in wallet.devices %}
-				<button type="button" class="btn signing-column-btn" id="{{ device.alias }}_tx_sign_btn" {{ 'disabled style=background-color:#303c49;' if device.alias in psbt.get("devices_signed",[]) else '' }}>
-					{{ device.name }} {% if device.alias in psbt.get('devices_signed',[]) %} (&#10004;) {% endif %}
-				</button>
+				{% if device.type != bitcoincore_watchonly %}
+					<button type="button" class="btn signing-column-btn" id="{{ device.alias }}_tx_sign_btn" {{ 'disabled style=background-color:#303c49;' if device.alias in psbt.get("devices_signed",[]) else '' }}>
+						{{ device.name }} {% if device.alias in psbt.get('devices_signed',[]) %} (&#10004;) {% endif %}
+					</button>
+				{% endif %}
+				{% if device.type == bitcoincore_watchonly %}
+					<p>{{ _("Cannot sign with a watchonly wallet") }}</p>
+				{% endif %}
 			{% endfor %}
 		</div>
 


### PR DESCRIPTION
Fixes #948 

Added bitcoincore_watchonly device type and now while exporting
bitcoincore hot wallets, they will exported as watchonly wallets.