### PR TITLE
Fixes add key functionality for hot wallets

### DIFF
--- a/src/cryptoadvance/specter/server_endpoints/devices.py
+++ b/src/cryptoadvance/specter/server_endpoints/devices.py
@@ -451,6 +451,7 @@ def device(device_alias):
                     existing_device=device,
                     device_alias=device_alias,
                     device_class=get_device_class(device.device_type),
+                    device_type=device.device_type,
                     specter=app.specter,
                     rand=rand,
                 )


### PR DESCRIPTION
Earlier specter used to give an error 404 not found when trying to add
new keys to a hot wallet. This commit fixes this behaviour.