### PR TITLE
Improved Liquid support for Specter-DIY

### DIFF
--- a/src/cryptoadvance/specter/devices/specter.py
+++ b/src/cryptoadvance/specter/devices/specter.py
@@ -31,7 +31,7 @@ class Specter(SDCardDevice):
             if psbt.unknown.get(b"\xfc\x07specter\x00"):
                 for out in psbt.outputs:
                     out.range_proof = None
-                    out.surjection_proof = None
+                    # out.surjection_proof = None
                     # we know assets - we can blind it
                     if out.asset:
                         out.asset_commitment = None

--- a/src/cryptoadvance/specter/devices/specter.py
+++ b/src/cryptoadvance/specter/devices/specter.py
@@ -63,10 +63,17 @@ class Specter(SDCardDevice):
                 break
         # remove unnecessary derivations from inputs and outputs
         for inp in qr_psbt.inputs + qr_psbt.outputs:
-            # keep only my derivation
-            for k in list(inp.bip32_derivations.keys()):
-                if fgp and inp.bip32_derivations[k].fingerprint != fgp:
-                    inp.bip32_derivations.pop(k, None)
+            # keep only one derivation path (idealy ours)
+            found = False
+            pubkeys = list(inp.bip32_derivations.keys())
+            for i, pub in enumerate(pubkeys):
+                if fgp and inp.bip32_derivations[pub].fingerprint != fgp:
+                    # only pop if we already saw our derivation
+                    # or if it's not the last one
+                    if found or i < len(pubkeys)-1:
+                        inp.bip32_derivations.pop(k, None)
+                else:
+                    found = True
         # remove scripts from outputs (DIY should know about the wallet)
         for out in qr_psbt.outputs:
             out.witness_script = None

--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -1237,6 +1237,10 @@ class Wallet:
         if index is None:
             index = self.change_index if change else self.address_index
         desc = self.change_descriptor if change else self.recv_descriptor
+        # remove blinding stuff from descriptor so HWI Descriptor can work
+        ldesc = LDescriptor.from_string(desc)
+        ldesc.blinding_key = None
+        desc = str(ldesc)
         derived_desc = Descriptor.parse(desc).derive(index).serialize()
         derived_desc_xpubs = (
             Descriptor.parse(desc).derive(index, keep_xpubs=True).serialize()


### PR DESCRIPTION
Makes some PSET optimizations for Specter-DIY so number of QR codes is reasonable on Liquid as well.
Specter-DIY uses the same deterministic blinding scheme as Specter-Desktop, so it can regenerate most of the blinding factors from the tx seed (provided as proprietary field in PSET)

DIY requires firmware with this PR:
https://github.com/cryptoadvance/specter-diy/pull/173

Other changes:
- fixes verify on device functionality on Liquid
- if Elements Core can't finalize the transaction we try to finalize it ourselves (see https://github.com/ElementsProject/elements/issues/1026 )
- keeps at least one derivation path in PSBT even if DIY is not the signer in the input / output