### PR TITLE
Add assets registry for Liquid wallets

### DIFF
--- a/src/cryptoadvance/specter/templates/includes/overlay/liquid_assets_registry.html
+++ b/src/cryptoadvance/specter/templates/includes/overlay/liquid_assets_registry.html
@@ -1,0 +1,67 @@
+<div id="liquid-assets-registry" class="hidden">
+    <h2>{{ _("Liquid Assets List:") }}</h2><br>
+    <table>
+        <thead>
+            <tr>
+                <th style="text-align: center;">{{ _("Asset label") }}</th>
+                <th style="text-align: center;">{{ _("Asset ID") }}</th>
+            </tr>
+        </thead>
+        <tbody id="liquid-assets-list">
+            {% for asset in specter.asset_labels.keys() | sort %}
+                <tr>
+                    <td><asset-label data-asset="{{asset}}" data-label="{{asset | assetlabel}}" edit-mode="enabled"></asset-label></td>
+                    <td>{{asset}}</td>
+                </tr>
+            {% endfor %}
+            <tr>
+                <td><input type="text" id="new_asset_label" placeholder="{{ _('New asset label') }}"/></td>
+                <td>
+                    <input style="width: 80%" type="text" id="new_asset_id" placeholder="{{ _('New asset ID') }}"/>
+                    <button style="display: inline-block;" type="button" class="btn" onclick="addAssetLabel()">{{ _("Add asset") }}</button>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+<script type="text/javascript">
+    async function addAssetLabel() {
+            let url = `{{ url_for('settings_endpoint.set_asset_label') }}`;
+            var formData = new FormData();
+            let assetIDField = document.getElementById('new_asset_id');
+            let assetLabelField = document.getElementById('new_asset_label');
+            let assetsList = document.getElementById('liquid-assets-list');
+            formData.append('asset', assetIDField.value);
+            formData.append('label', assetLabelField.value);
+            formData.append('csrf_token', '{{ csrf_token() }}');
+            try {
+                const response = await fetch(
+                    url,
+                    {
+                        method: 'POST',
+                        body: formData
+                    }
+                );
+                if(response.status != 200){
+                    showError(await response.text());
+                    return;
+                }
+                const jsonResponse = await response.json();
+
+                let newAssetRow = document.createElement('tr');
+                newAssetRow.innerHTML = `
+                <td><asset-label data-asset="${assetIDField.value}" data-label="${assetLabelField.value}" edit-mode="enabled"></asset-label></td>
+                <td>${assetIDField.value}</td>
+                `;
+                assetsList.insertBefore(newAssetRow, assetsList.childNodes[assetsList.childNodes.length - 3]);
+                assetIDField.value = '';
+                assetLabelField.value = '';
+                return jsonResponse.success;
+            } catch(e) {
+                console.log("Caught error: ", e);
+                showError(e);
+                return false;
+            }
+        }
+</script>

--- a/src/cryptoadvance/specter/templates/wallet/history/components/total_wallet_balances.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/history/components/total_wallet_balances.jinja
@@ -27,18 +27,25 @@
                      {% endif %}
             )</small>
         {% endif %}
-        {% if specter.is_liquid and wallet.balance.get("assets", {}) %}
-        <div>
-            <small style="line-height:30px">Assets:<br>
-            {% for asset in wallet.balance.get("assets",{}).keys() | sort %}
-                {% set balance = wallet.balance.get("assets",{}).get(asset, {}) %}
-                <div style="margin: 0 10px; display: inline-block;">
-                    {{ (balance.get("trusted", 0) + balance.get("untrusted_pending", 0) + balance.get("immature", 0)) | btcamount }}
-                    <asset-label data-asset="{{asset}}" data-label="{{asset | assetlabel}}" edit-mode="enabled"></asset-label>
-                </div>
-            {% endfor %}
-            </small>
-        </div>
+        {% if specter.is_liquid %}
+        {% if wallet.balance.get("assets", {}) %}
+            <div style="margin-bottom: 15px;">
+                <small style="line-height:30px">Assets:<br>
+                {% for asset in wallet.balance.get("assets",{}).keys() | sort %}
+                    {% set balance = wallet.balance.get("assets",{}).get(asset, {}) %}
+                    <div style="margin: 0 10px; display: inline-block;">
+                        {{ (balance.get("trusted", 0) + balance.get("untrusted_pending", 0) + balance.get("immature", 0)) | btcamount }}
+                        <asset-label data-asset="{{asset}}" data-label="{{asset | assetlabel}}" edit-mode="enabled"></asset-label>
+                    </div>
+                {% endfor %}
+                </small>
+            </div>
+        {% endif %}
+        {% include 'includes/overlay/liquid_assets_registry.html' %}
+        <small style="line-height: 30px;">
+            <button type="button" class="btn" onclick="showPageOverlay('liquid-assets-registry')">{{ _("Show assets list") }}</button>
+        </small>
+        <br>
         {% endif %}
     </h1>
     {% if wallet.rescan_progress or specter.utxorescanwallet == wallet.alias %}

--- a/src/cryptoadvance/specter/templates/wallet/wallets_overview.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/wallets_overview.jinja
@@ -40,18 +40,23 @@
                      {% endif %}
             )</small>
         {% endif %}
-        {% if specter.is_liquid and balance.get("assets", {}) %}
-        <div>
-            <small style="line-height:30px">{{ _("Assets:") }}<br>
-            {% for asset in balance.get("assets",{}).keys() | sort %}
-                {% set asset_balance = balance.get("assets",{}).get(asset, {}) %}
-                <div style="margin: 0 10px; display: inline-block;">
-                    {{ (asset_balance.get("trusted", 0) + asset_balance.get("untrusted_pending", 0) + asset_balance.get("immature", 0)) | btcamount }}
-                    <asset-label data-asset="{{asset}}" data-label="{{asset | assetlabel}}" edit-mode="enabled"></asset-label>
-                </div>
-            {% endfor %}
-            </small>
-        </div>
+        {% if specter.is_liquid %}
+        {% if balance.get("assets", {}) %}
+            <div style="margin-bottom: 15px;">
+                <small style="line-height:30px">{{ _("Assets:") }}<br>
+                {% for asset in balance.get("assets",{}).keys() | sort %}
+                    {% set asset_balance = balance.get("assets",{}).get(asset, {}) %}
+                    <div style="margin: 0 10px; display: inline-block;">
+                        {{ (asset_balance.get("trusted", 0) + asset_balance.get("untrusted_pending", 0) + asset_balance.get("immature", 0)) | btcamount }}
+                        <asset-label data-asset="{{asset}}" data-label="{{asset | assetlabel}}" edit-mode="enabled"></asset-label>
+                    </div>
+                {% endfor %}
+                </small>
+            </div>
+        {% endif %}
+        {% include 'includes/overlay/liquid_assets_registry.html' %}
+        <small><button type="button" class="btn" onclick="showPageOverlay('liquid-assets-registry')">{{ _("Show assets list") }}</button></small>
+        <br>
         {% endif %}
     </h1>
     <div class="table-holder">


### PR DESCRIPTION
Add a registry with the full known asset list to the main screen of the wallet. User can add or edit assets in the registry.