### PR TITLE
Fixed bug.  Now it saves the addresslist

### DIFF
--- a/src/cryptoadvance/specter/addresslist.py
+++ b/src/cryptoadvance/specter/addresslist.py
@@ -125,6 +125,7 @@ class AddressList(dict):
         for addr in arr:
             if addr["address"] in self:
                 self[addr["address"]].set_label(addr["label"])
+        self.save()
 
     def add(self, arr, check_rpc=False):
         """


### PR DESCRIPTION
Fixed bug in https://github.com/cryptoadvance/specter-desktop/pull/1314 , which caused that the address list was not saved.
