### PR TITLE
Add single-key taproot support

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -16,7 +16,7 @@ requests==2.25.0
 pysocks==1.7.1
 six==1.12.0
 stem==1.8.0
-embit==0.4.5
+embit==0.4.6
 psutil==5.7.3
 pyopenssl==20.0.1
 flask_wtf==0.14.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -108,8 +108,8 @@ ecdsa==0.17.0 \
     --hash=sha256:5cf31d5b33743abe0dfc28999036c849a69d548f994b535e527ee3cb7f3ef676 \
     --hash=sha256:b9f500bb439e4153d0330610f5d26baaf18d17b8ced1bc54410d189385ea68aa \
     # via bitbox02, hwi
-embit==0.4.5 \
-    --hash=sha256:fcc9f27c12c64d026dfe3a6d10f1fa8303433f9d96544caf3feb536244448577 \
+embit==0.4.6 \
+    --hash=sha256:19f69929caf0d2fcfd4b708dd873384dfc36267944d02d5e6dfebc835f294e1b \
     # via -r requirements.in
 flask-babel==2.0.0 \
     --hash=sha256:e6820a052a8d344e178cdd36dd4bb8aea09b4bda3d5f9fa9f008df2c7f2f5468 \

--- a/src/cryptoadvance/specter/device.py
+++ b/src/cryptoadvance/specter/device.py
@@ -29,6 +29,7 @@ class Device:
     hot_wallet = False
     bitcoin_core_support = True
     liquid_support = False
+    taproot_support = False
 
     def __init__(self, name, alias, keys, blinding_key, fullpath, manager):
         """

--- a/src/cryptoadvance/specter/devices/bitcoin_core.py
+++ b/src/cryptoadvance/specter/devices/bitcoin_core.py
@@ -22,6 +22,7 @@ class BitcoinCore(Device):
     icon = "bitcoincore_icon.svg"
 
     hot_wallet = True
+    taproot_support = True
 
     def setup_device(self, file_password, wallet_manager):
         wallet_name = os.path.join(wallet_manager.rpc_path + "_hotstorage", self.alias)

--- a/src/cryptoadvance/specter/devices/specter.py
+++ b/src/cryptoadvance/specter/devices/specter.py
@@ -22,6 +22,7 @@ class Specter(SDCardDevice):
     wallet_export_type = "qr"
     supports_hwi_multisig_display_address = True
     liquid_support = True
+    taproot_support = True
 
     def create_psbts(self, base64_psbt, wallet):
         try:
@@ -38,7 +39,7 @@ class Specter(SDCardDevice):
             pass
         psbts = super().create_psbts(base64_psbt, wallet)
         # remove non-witness utxo if they are there to reduce QR code size
-        updated_psbt = wallet.fill_psbt(base64_psbt, non_witness=False, xpubs=False)
+        updated_psbt = wallet.fill_psbt(base64_psbt, non_witness=False, xpubs=False, taproot_derivations=True)
         try:
             qr_psbt = PSBT.from_string(updated_psbt)
         except:
@@ -67,7 +68,8 @@ class Specter(SDCardDevice):
         psbts["qrcode"] = qr_psbt.to_string()
 
         # we can add xpubs to SD card, but non_witness can be too large for MCU
-        psbts["sdcard"] = wallet.fill_psbt(base64_psbt, non_witness=False, xpubs=True)
+        psbts["sdcard"] = wallet.fill_psbt(base64_psbt, non_witness=False, xpubs=True, taproot_derivations=True)
+        psbts["hwi"] = wallet.fill_psbt(base64_psbt, non_witness=False, xpubs=True, taproot_derivations=True)
         return psbts
 
     def export_wallet(self, wallet):

--- a/src/cryptoadvance/specter/devices/specter.py
+++ b/src/cryptoadvance/specter/devices/specter.py
@@ -39,7 +39,9 @@ class Specter(SDCardDevice):
             pass
         psbts = super().create_psbts(base64_psbt, wallet)
         # remove non-witness utxo if they are there to reduce QR code size
-        updated_psbt = wallet.fill_psbt(base64_psbt, non_witness=False, xpubs=False, taproot_derivations=True)
+        updated_psbt = wallet.fill_psbt(
+            base64_psbt, non_witness=False, xpubs=False, taproot_derivations=True
+        )
         try:
             qr_psbt = PSBT.from_string(updated_psbt)
         except:
@@ -68,8 +70,12 @@ class Specter(SDCardDevice):
         psbts["qrcode"] = qr_psbt.to_string()
 
         # we can add xpubs to SD card, but non_witness can be too large for MCU
-        psbts["sdcard"] = wallet.fill_psbt(base64_psbt, non_witness=False, xpubs=True, taproot_derivations=True)
-        psbts["hwi"] = wallet.fill_psbt(base64_psbt, non_witness=False, xpubs=True, taproot_derivations=True)
+        psbts["sdcard"] = wallet.fill_psbt(
+            base64_psbt, non_witness=False, xpubs=True, taproot_derivations=True
+        )
+        psbts["hwi"] = wallet.fill_psbt(
+            base64_psbt, non_witness=False, xpubs=True, taproot_derivations=True
+        )
         return psbts
 
     def export_wallet(self, wallet):

--- a/src/cryptoadvance/specter/helpers.py
+++ b/src/cryptoadvance/specter/helpers.py
@@ -208,7 +208,7 @@ def get_devices_with_keys_by_type(app, cosigners, wallet_type):
         device = copy.deepcopy(cosigner)
         allowed_types = ["", wallet_type]
         if wallet_type == "simple":
-            allowed_types += ["sh-wpkh", "wpkh"]
+            allowed_types += ["sh-wpkh", "wpkh", "tr"]
         elif wallet_type == "multisig":
             allowed_types += ["sh-wsh", "wsh"]
         device.keys = sorted(

--- a/src/cryptoadvance/specter/key.py
+++ b/src/cryptoadvance/specter/key.py
@@ -11,19 +11,20 @@ purposes = OrderedDict(
         "sh-wpkh": "Single (Nested)",
         "wsh": "Multisig (Segwit)",
         "sh-wsh": "Multisig (Nested)",
+        "tr": "Taproot",
     }
 )
 
 VALID_PREFIXES = {
     b"\x04\x35\x87\xcf": {  # testnet
-        b"\x04\x35\x87\xcf": "",  # unknown, maybe pkh
+        b"\x04\x35\x87\xcf": "",  # unknown, maybe pkh or taproot
         b"\x04\x4a\x52\x62": "sh-wpkh",
         b"\x04\x5f\x1c\xf6": "wpkh",
         b"\x02\x42\x89\xef": "sh-wsh",
         b"\x02\x57\x54\x83": "wsh",
     },
     b"\x04\x88\xb2\x1e": {  # mainnet
-        b"\x04\x88\xb2\x1e": "",  # unknown, maybe pkh
+        b"\x04\x88\xb2\x1e": "",  # unknown, maybe pkh or taproot
         b"\x04\x9d\x7c\xb2": "sh-wpkh",
         b"\x04\xb2\x47\x46": "wpkh",
         b"\x02\x95\xb4\x3f": "sh-wsh",
@@ -125,6 +126,8 @@ class Key:
                 key_type = "sh-wpkh"
             elif derivation_type == "84h":
                 key_type = "wpkh"
+            elif derivation_type == "86h":
+                key_type = "tr"
             elif derivation_type == "48h":
                 if len(derivation_path) >= 5:
                     if derivation_path[4] == "1h":

--- a/src/cryptoadvance/specter/node.py
+++ b/src/cryptoadvance/specter/node.py
@@ -419,6 +419,17 @@ class Node:
         return self.network_info["version"]
 
     @property
+    def taproot_support(self):
+        try:
+            # currently only master branch supports tr() descriptors
+            # TODO: replace to 220000
+            return (self.bitcoin_core_version_raw >= 219900) and (
+                self.info.get("softforks", {}).get("taproot", {}).get("active", False)
+            )
+        except Exception as e:
+            return False
+
+    @property
     def chain(self):
         return self.info["chain"]
 

--- a/src/cryptoadvance/specter/specter.py
+++ b/src/cryptoadvance/specter/specter.py
@@ -470,6 +470,10 @@ class Specter:
         return self.node.bitcoin_core_version_raw
 
     @property
+    def taproot_support(self):
+        return self.node.taproot_support
+
+    @property
     def chain(self):
         return self.node.chain
 

--- a/src/cryptoadvance/specter/templates/device/new_device/new_device_keys.jinja
+++ b/src/cryptoadvance/specter/templates/device/new_device/new_device_keys.jinja
@@ -256,6 +256,9 @@
             let accountNumber = accountNumberField.value;
             addXpub('#' + accountNumber + ' Single Sig (Nested)', 'm/49h/{{ specter.network_parameters.bip32 }}h/' + accountNumber + 'h');
             addXpub('#' + accountNumber + ' Single Sig (Segwit)', 'm/84h/{{ specter.network_parameters.bip32 }}h/' + accountNumber + 'h');
+            {% if specter.taproot_support and device_class.taproot_support %}
+            addXpub('#' + accountNumber + ' Single Sig (Taproot)', 'm/86h/{{ specter.network_parameters.bip32 }}h/' + accountNumber + 'h');
+            {% endif %}
             addXpub('#' + accountNumber + ' Multisig Sig (Nested)', 'm/48h/{{ specter.network_parameters.bip32 }}h/' + accountNumber + 'h/1h');
             addXpub('#' + accountNumber + ' Multisig Sig (Segwit)', 'm/48h/{{ specter.network_parameters.bip32 }}h/' + accountNumber + 'h/2h');
             document.getElementById('edit_add_account').style.display = 'none';

--- a/src/cryptoadvance/specter/templates/wallet/new_wallet/new_wallet_keys.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/new_wallet/new_wallet_keys.jinja
@@ -8,6 +8,7 @@
 		</div>
 		<br>
 		<h1>{{ _("Type of the wallet") }}</h1>
+		{% set enable_taproot = (wallet_type == 'simple' and specter.taproot_support) %}
 		<nav class="row">
 			<label>
 				<input type="radio" name="type" value="{{'sh-wsh' if wallet_type == 'multisig' else 'sh-wpkh'}}"
@@ -17,8 +18,15 @@
 			<label>
 				<input type="radio" name="type" value="{{'wsh' if wallet_type == 'multisig' else 'wpkh'}}" checked 
 				class="hidden type_nested_segwit" onchange="updateType(this.value);">
-				<div class="btn radio right" id="type_nested_segwit_btn">{{ _("Segwit") }}</div>
+				<div class="btn radio {% if not enable_taproot %} right {% endif %}" id="type_native_segwit_btn">{{ _("Segwit") }}</div>
 			</label>
+			{% if enable_taproot %}
+			<label>
+				<input type="radio" name="type" value="tr"
+				class="hidden" onchange="updateType(this.value);">
+				<div class="btn radio right" id="type_taproot_btn">{{ _("Taproot") }}</div>
+			</label>
+			{% endif %}
 		</nav>
 
 		<div class="note optional">

--- a/src/cryptoadvance/specter/templates/wallet/new_wallet/new_wallet_keys.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/new_wallet/new_wallet_keys.jinja
@@ -8,7 +8,7 @@
 		</div>
 		<br>
 		<h1>{{ _("Type of the wallet") }}</h1>
-		{% set enable_taproot = (wallet_type == 'simple' and specter.taproot_support) %}
+		{% set enable_taproot = (wallet_type == 'simple' and specter.taproot_support and cosigners[0].taproot_support) %}
 		<nav class="row">
 			<label>
 				<input type="radio" name="type" value="{{'sh-wsh' if wallet_type == 'multisig' else 'sh-wpkh'}}"

--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -36,6 +36,7 @@ purposes = OrderedDict(
         "wsh": "Multisig (Segwit)",
         "sh-wsh": "Multisig (Nested)",
         "sh": "Multisig (Legacy)",
+        "tr": "Taproot",
     }
 )
 
@@ -46,6 +47,7 @@ addrtypes = {
     "sh": "legacy",
     "sh-wsh": "p2sh-segwit",
     "wsh": "bech32",
+    "tr": "taproot",  # not sure it'll work, but I don't think we are using it anyway
 }
 
 

--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -1724,8 +1724,26 @@ class Wallet:
             existing_psbt=psbt,
         )
 
-    def fill_psbt(self, b64psbt, non_witness: bool = True, xpubs: bool = True):
+    @property
+    def is_taproot(self):
+        return ("tr(" in self.recv_descriptor)
+
+    def fill_psbt(self, b64psbt, non_witness: bool = True, xpubs: bool = True, taproot_derivations: bool = False):
         psbt = PSBT.from_string(b64psbt)
+
+        # Core doesn't fill derivations yet, so we do it ourselves
+        if taproot_derivations and self.is_taproot:
+            from embit.psbt import DerivationPath
+            from embit.ec import PublicKey
+            net = get_network(self.manager.chain)
+            for sc in psbt.inputs + psbt.outputs:
+                addr = sc.script_pubkey.address(net)
+                info = self._addresses.get(addr)
+                if info and not info.is_external:
+                    desc = self.recv_descriptor if info.is_receiving else self.change_descriptor
+                    d = LDescriptor.from_string(desc).derive(info.index)
+                    for k in d.keys:
+                        sc.bip32_derivations[PublicKey.parse(k.sec())] = DerivationPath(k.origin.fingerprint, k.origin.derivation)
 
         if non_witness:
             for inp in psbt.inputs:

--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -1726,24 +1726,37 @@ class Wallet:
 
     @property
     def is_taproot(self):
-        return ("tr(" in self.recv_descriptor)
+        return "tr(" in self.recv_descriptor
 
-    def fill_psbt(self, b64psbt, non_witness: bool = True, xpubs: bool = True, taproot_derivations: bool = False):
+    def fill_psbt(
+        self,
+        b64psbt,
+        non_witness: bool = True,
+        xpubs: bool = True,
+        taproot_derivations: bool = False,
+    ):
         psbt = PSBT.from_string(b64psbt)
 
         # Core doesn't fill derivations yet, so we do it ourselves
         if taproot_derivations and self.is_taproot:
             from embit.psbt import DerivationPath
             from embit.ec import PublicKey
+
             net = get_network(self.manager.chain)
             for sc in psbt.inputs + psbt.outputs:
                 addr = sc.script_pubkey.address(net)
                 info = self._addresses.get(addr)
                 if info and not info.is_external:
-                    desc = self.recv_descriptor if info.is_receiving else self.change_descriptor
+                    desc = (
+                        self.recv_descriptor
+                        if info.is_receiving
+                        else self.change_descriptor
+                    )
                     d = LDescriptor.from_string(desc).derive(info.index)
                     for k in d.keys:
-                        sc.bip32_derivations[PublicKey.parse(k.sec())] = DerivationPath(k.origin.fingerprint, k.origin.derivation)
+                        sc.bip32_derivations[PublicKey.parse(k.sec())] = DerivationPath(
+                            k.origin.fingerprint, k.origin.derivation
+                        )
 
         if non_witness:
             for inp in psbt.inputs:


### PR DESCRIPTION
Adds single-key taproot support for regtest / signet if Bitcoin Core is compiled from master or branch 22.x.
Requires the latest version of `embit`.

Devices supporting taproot:
- Bitcoin Core
- Specter-DIY (with [this PR](https://github.com/cryptoadvance/specter-diy/pull/178) or from master)

Also changes hot wallet to use descriptors if possible.