### PR TITLE
Bugfix: CI failure because of missing wget dependency

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,7 @@ container:
 #  image: python:slim
 #  image: ubuntu:focal
 #  image: python:3.8-buster
-  image: registry.gitlab.com/cryptoadvance/specter-desktop/cirrus-focal:latest
+  image: registry.gitlab.com/cryptoadvance/specter-desktop/cirrus-focal:20210831
 
 # We assume here that we're having a proper python3 system including virtualenv and pip
 prep_stuff_template: &PREP_STUFF_TEMPLATE

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,7 +12,7 @@ prep_stuff_template: &PREP_STUFF_TEMPLATE
       - cat pytest.ini | grep "addopts = " | cut -d'=' -f2 |  sed 's/--/+/g' | tr '+' '\n' | grep bitcoin |  cut -d' ' -f2 
       - cat tests/bitcoin_gitrev_pinned 2> /dev/null || true
       - cat /etc/os-release | grep VERSION
-    populate_script: ./tests/install_noded.sh binary
+    populate_script: ./tests/install_noded.sh --debug --bitcoin binary
   elementsd_installation_cache:
     folder: ./tests/elements
     fingerprint_script: 

--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,6 @@ cypress/screenshots
 node_modules
 btcd-conn.json
 elmd-conn.json
-tests/bitcoin
-tests/bitcoin.binary
-tests/bitcoin.compile
+tests/bitcoin*
 token.sh
 src/cryptoadvance/specter/translations/**/messages.mo

--- a/docker/cirrus-focal/Dockerfile
+++ b/docker/cirrus-focal/Dockerfile
@@ -6,7 +6,8 @@ from ubuntu:focal
 RUN apt update && DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
     libusb-1.0-0-dev libudev-dev python3 python3-virtualenv \
     build-essential libtool autotools-dev automake autoconf pkg-config bsdmainutils libevent-dev libboost-dev libboost-system-dev libboost-filesystem-dev libboost-test-dev bc  \
-    nodejs npm libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+    nodejs npm libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb \
+    wget
 
 # Stuff needed for Elements (compilation)
 RUN DEBIAN_FRONTEND="noninteractive" apt-get install  --no-install-recommends -y  libboost-thread-dev libsqlite3-dev git

--- a/docker/cirrus-focal/README.md
+++ b/docker/cirrus-focal/README.md
@@ -2,9 +2,11 @@ An image used to run the build on cirrus (tests only, not cypress-tests).
 
 Create it like this:
 
-``` 
-docker build . -t registry.gitlab.com/cryptoadvance/specter-desktop/cirrus-focal:latest
-docker push registry.gitlab.com/cryptoadvance/specter-desktop/cirrus-focal:latest
+```
+current_date=$(date +"%Y%m%d")
+docker build . -t registry.gitlab.com/cryptoadvance/specter-desktop/cirrus-focal:${current_date}
+docker push registry.gitlab.com/cryptoadvance/specter-desktop/cirrus-focal:${current_date}
+# Do not forget to update the $current_date in .cirrus.yml
 ```
 
-Check the `.cirrus.yml` on how this is used
+Check the `.cirrus.yml` on how this is used and update the $current_date there.

--- a/tests/install_noded.sh
+++ b/tests/install_noded.sh
@@ -207,6 +207,8 @@ function sub_binary {
     ln -s ./bitcoin-${version} bitcoin
     echo "    --> Listing binaries"
     find ./bitcoin/bin -maxdepth 1 -type f -executable -exec ls -ld {} \;
+    echo "    --> checking for bitcoind"
+    test -x ./bitcoin/bin/bitcodind || (echo "not found" && exit 2)
     echo "    --> Finished installing bitcoind binary"
     END=$(date +%s.%N)
     DIFF=$(echo "$END - $START" | bc)

--- a/tests/install_noded.sh
+++ b/tests/install_noded.sh
@@ -196,11 +196,12 @@ function sub_compile {
 }
 
 function sub_binary {
+    node_impl=$1
     if [ "$node_impl" = "elements" ]; then
         echo "    --> binary installation of elements not supported, exiting"
         exit 2
     fi
-    echo "    --> install_noded.sh Start $(date) (binary)"
+    echo "    --> install_noded.sh Start $(date) (binary) for node_impl $node_impl"
     START=$(date +%s.%N)
     check_binary_prerequisites
     # todo: Parametrize this
@@ -267,7 +268,7 @@ function parse_and_execute() {
         shift
         ;;
       binary)
-        sub_binary || exit 2
+        sub_binary $node_impl || exit 2
         shift
         ;;
       *)

--- a/tests/install_noded.sh
+++ b/tests/install_noded.sh
@@ -162,7 +162,19 @@ function check_compile_prerequisites {
             apt-get --yes install $REQUIRED_PKG 
         fi
     done
+}
 
+function check_binary_prerequisites {
+    REQUIRED_PKGS="wget"
+    for REQUIRED_PKG in $REQUIRED_PKGS; do
+        PKG_OK=$(dpkg-query -W --showformat='${Status}\n' $REQUIRED_PKG|grep "install ok installed")
+        echo Checking for $REQUIRED_PKG: $PKG_OK
+        if [ "" = "$PKG_OK" ]; then
+            echo "No $REQUIRED_PKG. Setting up $REQUIRED_PKG."
+            echo "WARNING: THIS SHOULD NOT BE NECESSARY, PLEASE FIX!"
+            apt-get --yes install $REQUIRED_PKG 
+        fi
+    done
 }
 
 function sub_compile {
@@ -190,6 +202,7 @@ function sub_binary {
     fi
     echo "    --> install_noded.sh Start $(date) (binary)"
     START=$(date +%s.%N)
+    check_binary_prerequisites
     # todo: Parametrize this
     version=$(calc_pytestinit_nodeimpl_version $node_impl)
     # remove the v-prefix

--- a/tests/install_noded.sh
+++ b/tests/install_noded.sh
@@ -152,6 +152,7 @@ function sub_help {
 function check_compile_prerequisites {
     REQUIRED_PKGS="build-essential libtool autotools-dev automake pkg-config bsdmainutils python3 autoconf"
     REQUIRED_PKGS="$REQUIRED_PKGS libevent-dev libevent-dev libboost-dev libboost-system-dev libboost-filesystem-dev libboost-test-dev bc nodejs npm libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb"
+    REQUIRED_PKGS="$REQUIRED_PKGS wget"
     for REQUIRED_PKG in $REQUIRED_PKGS; do
         PKG_OK=$(dpkg-query -W --showformat='${Status}\n' $REQUIRED_PKG|grep "install ok installed")
         echo Checking for $REQUIRED_PKG: $PKG_OK

--- a/tests/install_noded.sh
+++ b/tests/install_noded.sh
@@ -205,6 +205,7 @@ function sub_binary {
     check_binary_prerequisites
     # todo: Parametrize this
     version=$(calc_pytestinit_nodeimpl_version $node_impl)
+    echo "    --> install version $version"
     # remove the v-prefix
     version=$(echo $version | sed -e 's/v//')
     if [[ ! -f bitcoin-${version}-x86_64-linux-gnu.tar.gz ]]; then
@@ -262,11 +263,11 @@ function parse_and_execute() {
         shift
         ;;
       compile)
-        sub_compile $node_impl
+        sub_compile $node_impl || exit 2
         shift
         ;;
       binary)
-        sub_binary
+        sub_binary || exit 2
         shift
         ;;
       *)


### PR DESCRIPTION
For yet unknown reasons, the cache missed for `bitcoind_installation_cache` (`cirrus.yml`) and for yet again unknown reasons, the wget command was not available in registry.gitlab.com/cryptoadvance/specter-desktop/cirrus-focal:latest