### PR TITLE
Fix last release liquid issues

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -16,7 +16,7 @@ requests==2.25.0
 pysocks==1.7.1
 six==1.12.0
 stem==1.8.0
-embit==0.4.5
+embit==0.4.8
 psutil==5.7.3
 pyopenssl==20.0.1
 flask_wtf==0.14.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -108,8 +108,8 @@ ecdsa==0.17.0 \
     --hash=sha256:5cf31d5b33743abe0dfc28999036c849a69d548f994b535e527ee3cb7f3ef676 \
     --hash=sha256:b9f500bb439e4153d0330610f5d26baaf18d17b8ced1bc54410d189385ea68aa \
     # via bitbox02, hwi
-embit==0.4.5 \
-    --hash=sha256:fcc9f27c12c64d026dfe3a6d10f1fa8303433f9d96544caf3feb536244448577 \
+embit==0.4.8 \
+    --hash=sha256:c3164bbe33ad4fa3694a89a2cbf9cc00c63252c86c3dfb141513fb1fb6897e6d \
     # via -r requirements.in
 flask-babel==2.0.0 \
     --hash=sha256:e6820a052a8d344e178cdd36dd4bb8aea09b4bda3d5f9fa9f008df2c7f2f5468 \

--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -1773,7 +1773,7 @@ class Wallet:
         xpubs: bool = True,
         taproot_derivations: bool = False,
     ):
-        psbt = PSBT.from_string(b64psbt)
+        psbt = self.PSBTCls.from_string(b64psbt)
 
         # Core doesn't fill derivations yet, so we do it ourselves
         if taproot_derivations and self.is_taproot:
@@ -1802,7 +1802,7 @@ class Wallet:
                 txid = inp.txid.hex()
                 try:
                     res = self.gettransaction(txid)
-                    inp.non_witness_utxo = Transaction.from_string(res["hex"])
+                    inp.non_witness_utxo = self.TxCls.from_string(res["hex"])
                 except Exception as e:
                     logger.error(
                         f"Can't find previous transaction in the wallet. Signing might not be possible for certain devices... Txid: {txid}, Exception: {e}"


### PR DESCRIPTION
Fixes two things that were broken in the last release:
- Removes `wallet.fill_psbt` from Liquid wallets as we can use `Wallet.TxCls` and `Wallet.PSBTCls` - this fixes the issue that taproot support on Bitcoin was breaking Liquid wallets
- Updates `embit` library - new release properly manages threads (probably was making troubles in flaky tests) and fixes c-bindings
