### PR TITLE
Improve Jade support

### DIFF
--- a/src/cryptoadvance/specter/devices/hwi/jade.py
+++ b/src/cryptoadvance/specter/devices/hwi/jade.py
@@ -35,6 +35,8 @@ from hwilib._script import (
 import logging
 import os
 
+from embit import ec
+
 JADE_VENDOR_ID = 0x10C4
 JADE_DEVICE_ID = 0xEA60
 
@@ -120,6 +122,14 @@ class JadeClient(HardwareWalletClient):
         xpub = self.jade.get_xpub(self._network(), path)
         ext_key = ExtendedKey.deserialize(xpub)
         return ext_key
+
+    @jade_exception
+    def get_master_blinding_key(self) -> str:
+        mbk = self.jade.get_master_blinding_key()
+        assert len(mbk) == 32
+        bkey = ec.PrivateKey(mbk)
+        # TODO: use correct network here
+        return bkey.wif()
 
     # Walk the PSBT looking for inputs we can sign.  Push any signatures into the
     # 'partial_sigs' map in the input, and return the updated PSBT.

--- a/src/cryptoadvance/specter/devices/hwi/jade.py
+++ b/src/cryptoadvance/specter/devices/hwi/jade.py
@@ -35,6 +35,7 @@ from hwilib._script import (
 import logging
 import os
 
+# embit-related things
 from embit import ec
 
 JADE_VENDOR_ID = 0x10C4
@@ -43,6 +44,8 @@ JADE_DEVICE_ID = 0xEA60
 py_enumerate = (
     enumerate  # To use the enumerate built-in, since the name is overridden below
 )
+
+logger = logging.getLogger(__name__)
 
 
 def jade_exception(f):
@@ -128,7 +131,6 @@ class JadeClient(HardwareWalletClient):
         mbk = self.jade.get_master_blinding_key()
         assert len(mbk) == 32
         bkey = ec.PrivateKey(mbk)
-        # TODO: use correct network here
         return bkey.wif()
 
     # Walk the PSBT looking for inputs we can sign.  Push any signatures into the

--- a/src/cryptoadvance/specter/devices/hwi/jade.py
+++ b/src/cryptoadvance/specter/devices/hwi/jade.py
@@ -81,8 +81,14 @@ def jade_exception(f):
 class JadeClient(HardwareWalletClient):
 
     NETWORKS = {Chain.MAIN: "mainnet", Chain.TEST: "testnet", Chain.REGTEST: "regtest"}
+    liquid_network = None
+
+    def set_liquid_network(self, chain):
+        self.liquid_network = "liquid" if chain == "liquidv1" else "localtest-liquid"
 
     def _network(self):
+        if self.liquid_network:
+            return self.liquid_network
         return JadeClient.NETWORKS.get(self.chain, "mainnet")
 
     ADDRTYPES = {

--- a/src/cryptoadvance/specter/devices/hwi/jadepy/jade_error.py
+++ b/src/cryptoadvance/specter/devices/hwi/jadepy/jade_error.py
@@ -1,4 +1,16 @@
 class JadeError(Exception):
+    # RPC error codes
+    INVALID_REQUEST = -32600
+    UNKNOWN_METHOD = -32601
+    BAD_PARAMETERS = -32602
+    INTERNAL_ERROR = -32603
+
+    # Implementation specific error codes: -32000 to -32099
+    USER_CANCELLED = -32000
+    PROTOCOL_ERROR = -32001
+    HW_LOCKED = -32002
+    NETWORK_MISMATCH = -32003
+
     def __init__(self, code, message, data):
         self.code = code
         self.message = message

--- a/src/cryptoadvance/specter/devices/hwi/jadepy/jade_serial.py
+++ b/src/cryptoadvance/specter/devices/hwi/jadepy/jade_serial.py
@@ -37,11 +37,11 @@ class JadeSerialImpl:
         logger.info("Connected")
 
     def disconnect(self):
-        if self.ser is not None:
-            self.ser.__exit__()
+        assert self.ser is not None
+        self.ser.__exit__()
 
-            # Reset state
-            self.ser = None
+        # Reset state
+        self.ser = None
 
     def write(self, bytes_):
         assert self.ser is not None

--- a/src/cryptoadvance/specter/devices/hwi/jadepy/jade_tcp.py
+++ b/src/cryptoadvance/specter/devices/hwi/jadepy/jade_tcp.py
@@ -1,0 +1,60 @@
+import socket
+import logging
+
+
+logger = logging.getLogger('jade.tcp')
+
+
+#
+# Low-level Serial-via-TCP backend interface to Jade
+# Calls to send and receive bytes over the interface.
+# Intended for use via JadeInterface wrapper.
+#
+# Either:
+#  a) use via JadeInterface.create_serial() (see JadeInterface)
+# (recommended)
+# or:
+#  b) use JadeTCPImpl() directly, and call connect() before
+#     using, and disconnect() when finished,
+# (caveat cranium)
+#
+class JadeTCPImpl:
+    PROTOCOL_PREFIX = 'tcp:'
+
+    @classmethod
+    def isSupportedDevice(cls, device):
+        return device is not None and device.startswith(cls.PROTOCOL_PREFIX)
+
+    def __init__(self, device):
+        assert self.isSupportedDevice(device)
+        self.device = device
+        self.tcp_sock = None
+
+    def connect(self):
+        assert self.isSupportedDevice(self.device)
+        assert self.tcp_sock is None
+
+        logger.info('Connecting to {}'.format(self.device))
+        self.tcp_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+        url = self.device[len(self.PROTOCOL_PREFIX):].split(':')
+        self.tcp_sock.connect((url[0], int(url[1])))
+        assert self.tcp_sock is not None
+
+        self.tcp_sock.__enter__()
+        logger.info('Connected')
+
+    def disconnect(self):
+        assert self.tcp_sock is not None
+        self.tcp_sock.__exit__()
+
+        # Reset state
+        self.tcp_sock = None
+
+    def write(self, bytes_):
+        assert self.tcp_sock is not None
+        return self.tcp_sock.send(bytes_)
+
+    def read(self, n):
+        assert self.tcp_sock is not None
+        return self.tcp_sock.recv(n)

--- a/src/cryptoadvance/specter/devices/hwi/jadepy/jade_tcp.py
+++ b/src/cryptoadvance/specter/devices/hwi/jadepy/jade_tcp.py
@@ -2,7 +2,7 @@ import socket
 import logging
 
 
-logger = logging.getLogger('jade.tcp')
+logger = logging.getLogger("jade.tcp")
 
 
 #
@@ -19,7 +19,7 @@ logger = logging.getLogger('jade.tcp')
 # (caveat cranium)
 #
 class JadeTCPImpl:
-    PROTOCOL_PREFIX = 'tcp:'
+    PROTOCOL_PREFIX = "tcp:"
 
     @classmethod
     def isSupportedDevice(cls, device):
@@ -34,15 +34,15 @@ class JadeTCPImpl:
         assert self.isSupportedDevice(self.device)
         assert self.tcp_sock is None
 
-        logger.info('Connecting to {}'.format(self.device))
+        logger.info("Connecting to {}".format(self.device))
         self.tcp_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
-        url = self.device[len(self.PROTOCOL_PREFIX):].split(':')
+        url = self.device[len(self.PROTOCOL_PREFIX) :].split(":")
         self.tcp_sock.connect((url[0], int(url[1])))
         assert self.tcp_sock is not None
 
         self.tcp_sock.__enter__()
-        logger.info('Connected')
+        logger.info("Connected")
 
     def disconnect(self):
         assert self.tcp_sock is not None

--- a/src/cryptoadvance/specter/devices/hwi/specter_diy.py
+++ b/src/cryptoadvance/specter/devices/hwi/specter_diy.py
@@ -99,8 +99,10 @@ class SpecterClient(HardwareWalletClient):
 
     def sign_b64psbt(self, psbt: str) -> str:
         # works with both PSBT and PSET
-        print("sign %s" % psbt)
         return self.query("sign %s" % psbt)
+
+    def sign_pset(self, pset: str) -> str:
+        return self.sign_b64psbt(pset)
 
     def sign_tx(self, psbt: PSBT) -> PSBT:
         """

--- a/src/cryptoadvance/specter/devices/jade.py
+++ b/src/cryptoadvance/specter/devices/jade.py
@@ -2,6 +2,7 @@ from . import DeviceTypes
 from .hwi_device import HWIDevice
 from .hwi.jade import JadeClient
 from .hwi.jade import enumerate as jade_enumerate
+from ..helpers import is_liquid
 
 
 class Jade(HWIDevice):
@@ -20,3 +21,13 @@ class Jade(HWIDevice):
     @classmethod
     def enumerate(cls, *args, **kwargs):
         return jade_enumerate(*args, **kwargs)
+
+    def has_key_types(self, wallet_type, network="main"):
+        if wallet_type == "multisig" and is_liquid(network):
+            return False
+        return super().has_key_types(wallet_type, network)
+
+    def no_key_found_reason(self, wallet_type, network="main"):
+        if wallet_type == "multisig" and is_liquid(network):
+            return "Jade does not support multisig wallets on Liquid."
+        return super().no_key_found_reason(wallet_type, network)

--- a/src/cryptoadvance/specter/devices/jade.py
+++ b/src/cryptoadvance/specter/devices/jade.py
@@ -1,6 +1,7 @@
 from . import DeviceTypes
 from .hwi_device import HWIDevice
-from .hwi.jade import JadeClient, enumerate
+from .hwi.jade import JadeClient
+from .hwi.jade import enumerate as jade_enumerate
 
 
 class Jade(HWIDevice):
@@ -17,14 +18,4 @@ class Jade(HWIDevice):
 
     @classmethod
     def enumerate(cls, *args, **kwargs):
-        return enumerate(*args, **kwargs)
-
-    def has_key_types(self, wallet_type, network="main"):
-        if wallet_type == "multisig":
-            return False
-        return super().has_key_types(wallet_type, network)
-
-    def no_key_found_reason(self, wallet_type, network="main"):
-        if wallet_type == "multisig":
-            return "Jade does not yet support multisig wallets."
-        return super().no_key_found_reason(wallet_type, network)
+        return jade_enumerate(*args, **kwargs)

--- a/src/cryptoadvance/specter/devices/jade.py
+++ b/src/cryptoadvance/specter/devices/jade.py
@@ -11,6 +11,7 @@ class Jade(HWIDevice):
 
     supports_hwi_toggle_passphrase = False
     supports_hwi_multisig_display_address = False
+    liquid_support = True
 
     @classmethod
     def get_client(cls, *args, **kwargs):

--- a/src/cryptoadvance/specter/hwi_rpc.py
+++ b/src/cryptoadvance/specter/hwi_rpc.py
@@ -14,7 +14,13 @@ import logging
 import bitbox02
 from typing import Callable
 from flask import current_app as app
-from .helpers import deep_update, hwi_get_config, save_hwi_bridge_config, is_testnet, is_liquid
+from .helpers import (
+    deep_update,
+    hwi_get_config,
+    save_hwi_bridge_config,
+    is_testnet,
+    is_liquid,
+)
 from hwilib.devices.bitbox02 import Bitbox02Client
 from .devices.hwi.specter_diy import SpecterClient
 from .devices.hwi.jade import JadeClient

--- a/src/cryptoadvance/specter/hwi_rpc.py
+++ b/src/cryptoadvance/specter/hwi_rpc.py
@@ -319,8 +319,10 @@ class HWIBridge(JSONRPC):
             passphrase=passphrase,
             chain=chain,
         ) as client:
-            if isinstance(client, SpecterClient):
-                return client.sign_b64psbt(psbt)
+            if is_liquid(chain):
+                if not hasattr(client, "sign_pset"):
+                    raise Exception("Device can't sign liquid transaction")
+                return client.sign_pset(psbt)
             status = hwi_commands.signtx(client, psbt)
             if "error" in status:
                 raise Exception(status["error"])

--- a/src/cryptoadvance/specter/static/hwi.js
+++ b/src/cryptoadvance/specter/static/hwi.js
@@ -179,7 +179,7 @@ class HWIBridge {
         if(!('passphrase' in device)){
             device.passphrase = passphrase;
         }
-        return await hwi.fetch('display_address', {
+        return await this.fetch('display_address', {
             device_type: device.type,
             path: device.path,
             passphrase: device.passphrase,


### PR DESCRIPTION
Changes:
1. Enables multisig for Jade on Bitcoin. Even though Jade doesn't support multisig change verification, it still can sign multisig transactions. So it's pretty much like using Ledger.
2. Enables single-sig wallets with Jade on Liquid. Multisig with Jade on Liquid does not work even in theory - they require blinding transaction on Jade itself, and can't work with tx blinded by someone else.