### PR TITLE
Remove Specter-DIY simulator warning

### DIFF
--- a/src/cryptoadvance/specter/devices/hwi/specter_diy.py
+++ b/src/cryptoadvance/specter/devices/hwi/specter_diy.py
@@ -245,9 +245,8 @@ def enumerate(password=""):
         s.close()
         ports.append("127.0.0.1:8789")
     except ConnectionRefusedError as e:
-        logger.warning(
-            f"Warning: Specter DIY failed to establish socket connection. Error: {e}"
-        )
+        # simulator is probably not running
+        pass
 
     for port in ports:
         # for every port try to get a fingerprint


### PR DESCRIPTION
Remove unnecessary warning in Specter-DIY module when it can't connect to the simulator.
Close https://github.com/cryptoadvance/specter-desktop/issues/1384
