### PR TITLE
Some liquid fixes

### DIFF
--- a/cypress/integration/spec_elm_multi_segwit_wallet.js
+++ b/cypress/integration/spec_elm_multi_segwit_wallet.js
@@ -1,4 +1,8 @@
 describe('Operating with an elements multisig wallet', () => {
+    // 4000ms was often not enough for waiting a elm-transaction
+    // So let's try double as much:
+    const broadcast_timeout = 8000
+    
     it('Creates an two elements multisig hot wallets (segwit/nested) both 2/3', () => {
         cy.viewport(1200,660)
         cy.visit('/')
@@ -80,7 +84,7 @@ describe('Operating with an elements multisig wallet', () => {
             cy.get('#broadcast_local_btn').click()
             // gets redirected to "transactions"
 
-            cy.get('#fullbalance_amount')
+            cy.get('#fullbalance_amount', { timeout: broadcast_timeout })
             .should(($div) => {
                 const newBalance = parseFloat($div.text())
                 expect(newBalance).to.be.lte(oldBalance - 1.5)
@@ -123,7 +127,7 @@ describe('Operating with an elements multisig wallet', () => {
             cy.get('#broadcast_local_btn').click()
             // gets redirected to "transactions"
 
-            cy.get('#fullbalance_amount')
+            cy.get('#fullbalance_amount', { timeout: broadcast_timeout })
             .should(($div) => {
                 const newBalance = parseFloat($div.text())
                 expect(newBalance).to.be.lte(oldBalance - 1.5)
@@ -165,7 +169,7 @@ describe('Operating with an elements multisig wallet', () => {
             cy.get('#broadcast_local_btn').click()
             // gets redirected to "transactions"
 
-            cy.get('#fullbalance_amount')
+            cy.get('#fullbalance_amount', { timeout: broadcast_timeout })
             .should(($div) => {
                 const newBalance = parseFloat($div.text())
                 expect(newBalance).to.be.lte(oldBalance - 1.5)
@@ -207,7 +211,7 @@ describe('Operating with an elements multisig wallet', () => {
             cy.get('#send_tx_btn').click()
             cy.get('#broadcast_local_btn').click()
             // gets redirected to "transactions"
-            cy.get('#fullbalance_amount', { timeout: 10000})
+            cy.get('#fullbalance_amount', { timeout: broadcast_timeout})
             .should(($div) => {
                 const newBalance = parseFloat($div.text())
                 expect(newBalance).to.be.lte(oldBalance - 1.5)

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -134,7 +134,7 @@ Cypress.Commands.add("mine2wallet", (chain) => {
       } else {
         throw new Error("Unknown chain: " + chain)
       }
-      cy.wait(10000)
+      cy.wait(15000)
       cy.reload()
       cy.get('#fullbalance_amount')
           .should(($div) => {

--- a/requirements.in
+++ b/requirements.in
@@ -16,7 +16,7 @@ requests==2.25.0
 pysocks==1.7.1
 six==1.12.0
 stem==1.8.0
-embit==0.4.8
+embit==0.4.9
 psutil==5.7.3
 pyopenssl==20.0.1
 flask_wtf==0.14.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -108,8 +108,8 @@ ecdsa==0.17.0 \
     --hash=sha256:5cf31d5b33743abe0dfc28999036c849a69d548f994b535e527ee3cb7f3ef676 \
     --hash=sha256:b9f500bb439e4153d0330610f5d26baaf18d17b8ced1bc54410d189385ea68aa \
     # via bitbox02, hwi
-embit==0.4.8 \
-    --hash=sha256:c3164bbe33ad4fa3694a89a2cbf9cc00c63252c86c3dfb141513fb1fb6897e6d \
+embit==0.4.9 \
+    --hash=sha256:992332bd89af6e2d027e26fe437eb14aa33997db08c882c49064d49c3e6f4ab9 \
     # via -r requirements.in
 flask-babel==2.0.0 \
     --hash=sha256:e6820a052a8d344e178cdd36dd4bb8aea09b4bda3d5f9fa9f008df2c7f2f5468 \

--- a/src/cryptoadvance/specter/devices/generic.py
+++ b/src/cryptoadvance/specter/devices/generic.py
@@ -1,5 +1,6 @@
 from . import DeviceTypes
 from ..device import Device
+from ..liquid.util.pset import to_canonical_pset
 
 
 class GenericDevice(Device):
@@ -8,8 +9,11 @@ class GenericDevice(Device):
 
     sd_card_support = True
     qr_code_support = True
+    liquid_support = True
+    taproot_support = True
 
     def create_psbts(self, base64_psbt, wallet):
+        base64_psbt = to_canonical_pset(base64_psbt)
         # in QR codes keep only xpubs
         qr_psbt = wallet.fill_psbt(base64_psbt, non_witness=False, xpubs=True)
         # in SD card put as much as possible

--- a/src/cryptoadvance/specter/devices/specter.py
+++ b/src/cryptoadvance/specter/devices/specter.py
@@ -23,7 +23,11 @@ def fill_external_wallet_derivations(psbt, wallet):
             # check if output derivation is empty
             if out.bip32_derivations:
                 continue
-            addr = out.script_pubkey.address(net)
+            try:
+                # if there is no address representation - continue
+                addr = out.script_pubkey.address(net)
+            except:
+                continue
             for w in wallets:
                 # skip sending wallet
                 if w == wallet:

--- a/src/cryptoadvance/specter/liquid/rpc.py
+++ b/src/cryptoadvance/specter/liquid/rpc.py
@@ -14,6 +14,8 @@ from embit.psbt import read_string
 import copy
 from io import BytesIO
 
+from .util.pset import to_canonical_pset
+
 import logging
 
 logger = logging.getLogger(__name__)
@@ -225,33 +227,16 @@ class LiquidRPC(BitcoinRPC):
             res["psbt"] = str(tx)
         return res
 
-    def _cleanpsbt(self, psbt):
-        """Removes stuff that Core doesn't like"""
-        tx = PSET.from_string(psbt)
-        for inp in tx.inputs:
-            inp.value = None
-            inp.asset = None
-            inp.value_blinding_factor = None
-            inp.asset_blinding_factor = None
-
-        for out in tx.outputs:
-            if out.is_blinded:
-                out.asset = None
-                out.asset_blinding_factor = None
-                out.value = None
-                out.value_blinding_factor = None
-        return str(tx)
-
     def walletprocesspsbt(self, psbt, *args, **kwargs):
         try:
             if self.getwalletinfo().get("private_keys_enabled", False):
-                psbt = self._cleanpsbt(psbt)
+                psbt = to_canonical_pset(psbt)
         except Exception as e:
             logger.warn(f"Failed to clean psbt: {e}")
         return super().__getattr__("walletprocesspsbt")(psbt, *args, **kwargs)
 
     def finalizepsbt(self, psbt, *args, **kwargs):
-        psbt = self._cleanpsbt(psbt)
+        psbt = to_canonical_pset(psbt)
         res = super().__getattr__("finalizepsbt")(psbt, *args, **kwargs)
         if res["complete"] == False:
             try:

--- a/src/cryptoadvance/specter/liquid/util/pset.py
+++ b/src/cryptoadvance/specter/liquid/util/pset.py
@@ -1,0 +1,26 @@
+from embit.liquid.pset import PSET
+
+
+def to_canonical_pset(pset):
+    """
+    Removes unblinded information from the transaction
+    so Elements Core can decode it
+    """
+    # if we got psbt, not pset - just return
+    if not pset.startswith("cHNl"):
+        return pset
+    tx = PSET.from_string(pset)
+
+    for inp in tx.inputs:
+        inp.value = None
+        inp.asset = None
+        inp.value_blinding_factor = None
+        inp.asset_blinding_factor = None
+
+    for out in tx.outputs:
+        if out.is_blinded:
+            out.asset = None
+            out.asset_blinding_factor = None
+            out.value = None
+            out.value_blinding_factor = None
+    return str(tx)

--- a/src/cryptoadvance/specter/server_endpoints/filters.py
+++ b/src/cryptoadvance/specter/server_endpoints/filters.py
@@ -3,6 +3,7 @@ from flask import current_app as app
 from flask import Blueprint
 from jinja2 import contextfilter
 from ..helpers import to_ascii20
+from ..liquid.util.pset import to_canonical_pset
 
 filters_bp = Blueprint("filters", __name__)
 
@@ -28,6 +29,12 @@ def btcamount(context, value):
         return "Confidential"
     value = round(float(value), 8)
     return "{:,.8f}".format(value).rstrip("0").rstrip(".")
+
+
+@contextfilter
+@filters_bp.app_template_filter("to_canonical")
+def to_canonical(context, psbt):
+    return to_canonical_pset(psbt)
 
 
 @contextfilter

--- a/src/cryptoadvance/specter/server_endpoints/wallets.py
+++ b/src/cryptoadvance/specter/server_endpoints/wallets.py
@@ -482,7 +482,7 @@ def send_new(wallet_alias):
     subtract = False
     subtract_from = 1
     fee_options = "dynamic"
-    rbf = True
+    rbf = not app.specter.is_liquid
     rbf_utxo = []
     rbf_tx_id = ""
     selected_coins = request.form.getlist("coinselect")

--- a/src/cryptoadvance/specter/server_endpoints/wallets.py
+++ b/src/cryptoadvance/specter/server_endpoints/wallets.py
@@ -29,6 +29,7 @@ from ..helpers import (
     get_devices_with_keys_by_type,
     get_txid,
 )
+from ..liquid.util.pset import to_canonical_pset
 from ..key import Key
 from ..persistence import delete_file
 from ..rpc import RpcError
@@ -899,6 +900,9 @@ def combine(wallet_alias):
         return e.error_msg, e.status_code
     except Exception as e:
         return _("Unknown error: {}").format(e), 500
+    if "psbt" in raw:
+        # returned psbt should be valid for Bitcoin or Elements Core decoding
+        raw["psbt"] = to_canonical_pset(raw["psbt"])
     return json.dumps(raw)
 
 

--- a/src/cryptoadvance/specter/templates/device/device_blinding_key.jinja
+++ b/src/cryptoadvance/specter/templates/device/device_blinding_key.jinja
@@ -20,15 +20,15 @@
                             {{ _("Scan QR code") }}
                         </a>
                     </qr-scanner>
-                    <button {% if device.device_type not in ['electrum', 'other'] %}class="hidden"{% endif %} type="button" onclick="showPageOverlay('paste-xpub-popup')" class="btn centered" id="xpub-paste" style="max-width: 250px; width: 250px; margin: 20px auto;">
+                    <button {% if device.device_type not in ['electrum', 'other'] %}class="hidden"{% endif %} type="button" onclick="showPageOverlay('paste-mbk-popup')" class="btn centered" id="mbk-paste" style="max-width: 250px; width: 250px; margin: 20px auto;">
                         <img src="{{ url_for('static', filename='img/copy.svg') }}" style="width: 22px; margin: 0px;" class="svg-white">
-                        {{ _("Paste xpub") }}
+                        {{ _("Paste blinding key") }}
                     </button>
-                    <div class="hidden" id="paste-xpub-popup">
-                        <h1>{{ _("Paste xpub") }}</h1>
-                        <input type="text" id="paste-xpub-text" placeholder="Paste your xpub here">
+                    <div class="hidden" id="paste-mbk-popup">
+                        <h1>{{ _("Paste blinding key") }}</h1>
+                        <input type="text" id="paste-mbk-text" placeholder="Paste your master blinding key here">
                         <br><br>
-                        <button type="button" onclick="addXpubs(document.getElementById('paste-xpub-text').value);hidePageOverlay();document.getElementById('paste-xpub-text').value='';" class="btn centered">{{ _("Add xpub") }}</button>
+                        <button type="button" onclick="addBlindingKey(document.getElementById('paste-mbk-text').value);hidePageOverlay();document.getElementById('paste-mbk-text').value='';" class="btn centered">{{ _("Add blinding key") }}</button>
                     </div>
                 </div>
             </div>
@@ -96,6 +96,13 @@
                 document.getElementById('blinding_key').value = masterBlindingKey;
                 document.form.submit();
             });
+        }
+        function addBlindingKey(masterBlindingKey){
+            if (masterBlindingKey == null) {
+                return;
+            }
+            document.getElementById('blinding_key').value = masterBlindingKey;
+            document.form.submit();
         }
     </script>
 {% endblock %}

--- a/src/cryptoadvance/specter/templates/wallet/send/new/components/fee_selection.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/send/new/components/fee_selection.jinja
@@ -41,7 +41,7 @@
         </div>
     </div>
     <br>
-    <label><input type="checkbox" class="inline" name="rbf" id="rbf" {% if rbf %}checked{% endif %}> {{ _("RBF Enabled") }}</label>
+    <label  {% if specter.is_liquid %}style="display: none"{% endif %}><input type="checkbox" class="inline" name="rbf" id="rbf" {% if rbf %}checked{% endif %}> {{ _("RBF Enabled") }}</label>
 </div>
 
 <script>

--- a/src/cryptoadvance/specter/templates/wallet/send/new/wallet_send.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/send/new/wallet_send.jinja
@@ -346,13 +346,11 @@
 				showError(`{{ _("Please first enter a valid address") }}`);
 				return;
 			}
-			if(units[i] == 'sat' || units[i] == 'btc'){
-				let subtract = document.getElementById('subtract');
-				subtract.checked = true;
-				if (amounts.length > 1) {
-					document.getElementById('subtract_from').style.display = 'block';
-					document.getElementById('subtract_from_input').value = i + 1;
-				}
+			let subtract = document.getElementById('subtract');
+			subtract.checked = (units[i] == 'sat' || units[i] == 'btc');
+			if (amounts.length > 1) {
+				document.getElementById('subtract_from').style.display = 'block';
+				document.getElementById('subtract_from_input').value = i + 1;
 			}
 			let othersAmount = 0;
 			for(let j in amounts) {

--- a/src/cryptoadvance/specter/templates/wallet/send/sign/wallet_send_sign_psbt.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/send/sign/wallet_send_sign_psbt.jinja
@@ -181,15 +181,15 @@
 						<b>{{ _("Amount:") }}</b> {{ output['value']|btcamount }} BTC {% if specter.price_check %}<span class="note">&nbsp;({{ output['value'] | altunit }})</span>{% endif %}
 					</p>
 				{% endfor %}
-				{{ _("Raw PSBT:") }}<textarea id="raw-psbt" disabled style="background-color: #131a24;">{{ psbt['base64'] }}</textarea>
+				{{ _("Raw PSBT:") }}<textarea id="raw-psbt" disabled style="background-color: #131a24;">{{ psbt['base64'] | to_canonical }}</textarea>
 				<div class="row break-row-mobile" style="margin:auto">
 					<a id="download-psbt-btn" class="btn"
-					download="binary_{{ psbt['tx']['hash'] }}.psbt" href="data:application/octet-stream;base64;content-disposition=attachment,{{ psbt['base64'] }}">
+					download="binary_{{ psbt['tx']['hash'] }}.psbt" href="data:application/octet-stream;base64;content-disposition=attachment,{{ psbt['base64'] | to_canonical }}">
 						<img src="{{ url_for('static', filename='img/file.svg') }}" style="width: 26px; margin: 0px;" class="svg-white">
 						{{ _("Save binary") }}
 					</a>&nbsp;
 					<a id="download-psbt-btn" class="btn"
-					download="base64_{{ psbt['tx']['hash'] }}.psbt" href="data:text/plain;content-disposition=attachment,{{ psbt['base64'] }}">
+					download="base64_{{ psbt['tx']['hash'] }}.psbt" href="data:text/plain;content-disposition=attachment,{{ psbt['base64'] | to_canonical }}">
 						<img src="{{ url_for('static', filename='img/file.svg') }}" style="width: 26px; margin: 0px;" class="svg-white">
 						{{ _("Save base64") }}
 					</a>&nbsp;
@@ -244,7 +244,7 @@
     <input type="hidden" class="csrf-token" name="csrf_token" value="{{ csrf_token() }}"/>
 	<div class="row" style="min-height: 400px;">
         <span style="margin: auto;" id="raw-psbt-qr-holder">
-            <qr-code id="raw-psbt-qr" class='center' value="{{ psbt['base64'] }}" width="400" scalable></qr-code>
+            <qr-code id="raw-psbt-qr" class='center' value="{{ psbt['base64'] | to_canonical }}" width="400" scalable></qr-code>
         </span>
     </div>
 </form>


### PR DESCRIPTION
- bumps embit version that properly handles unconfidential inputs
- changes representation of PSET in the UI so it's decodable by Elements Core (removing some extra fields that Elements doesn't like)
- enables taproot and liquid for a generic device ("Other")
- fixes filling of derivations in PSET from other wallets (used by Specter-DIY to display where we are sending)