### PR TITLE
fix changing type of a device

### DIFF
--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -104,14 +104,10 @@ class Wallet:
         self.recv_descriptor = recv_descriptor
         self.change_descriptor = change_descriptor
         self.keys = keys
-        self.devices = [
-            (
-                device
-                if isinstance(device, Device)
-                else device_manager.get_by_alias(device)
-            )
-            for device in devices
-        ]
+
+        self.device_manager = device_manager
+        self._devices = devices
+        # check that all of the devices exist
         if None in self.devices:
             raise Exception("A device used by this wallet could not have been found!")
         self.sigs_required = int(sigs_required)
@@ -142,6 +138,17 @@ class Wallet:
         self.update()
         if old_format_detected or self.last_block != last_block:
             self.save_to_file()
+
+    @property
+    def devices(self):
+        return [
+            (
+                device
+                if isinstance(device, Device)
+                else self.device_manager.get_by_alias(device)
+            )
+            for device in self._devices
+        ]
 
     @classmethod
     def create(


### PR DESCRIPTION
Changing type of the device on the device page didn't cause any changes in wallets using this device.
So if I initially had "Other" device type and changed it to "Trezor" it will still offer me to use QR codes or SD card, not USB.
This PR makes sure wallets are referencing devices by alias instead of storing devices in the wallet itself.

Close https://github.com/cryptoadvance/specter-desktop/issues/1400
Close https://github.com/cryptoadvance/specter-desktop/issues/1257
Close https://github.com/cryptoadvance/specter-desktop/issues/575