### PR TITLE
Refactor wallet class

### DIFF
--- a/src/cryptoadvance/specter/addresslist.py
+++ b/src/cryptoadvance/specter/addresslist.py
@@ -59,9 +59,11 @@ class Address(dict):
 
     @property
     def is_receiving(self):
-        # change can be True, False or None
-        # None means it's external
-        return not self.is_external and not self.change
+        return self.is_mine and not self.change
+
+    @property
+    def is_change(self):
+        return self.is_mine and self.change
 
     @property
     def index(self):
@@ -73,7 +75,7 @@ class Address(dict):
 
     @property
     def change(self):
-        return not self.is_external and self["change"]
+        return self["change"]
 
     @property
     def used(self):
@@ -210,7 +212,11 @@ class AddressList(dict):
         return max(
             0,
             0,
-            *[addr.index or 0 for addr in self.values() if addr.change == change],
+            *[
+                addr.index or 0
+                for addr in self.values()
+                if addr.is_mine and addr.change == change
+            ],
         )
 
     def max_used_index(self, change=False):
@@ -220,7 +226,7 @@ class AddressList(dict):
             *[
                 addr.index or -1
                 for addr in self.values()
-                if addr.used and addr.change == change
+                if addr.is_mine and addr.used and addr.change == change
             ],
         )
 

--- a/src/cryptoadvance/specter/addresslist.py
+++ b/src/cryptoadvance/specter/addresslist.py
@@ -206,7 +206,7 @@ class AddressList(dict):
         return max(
             0,
             0,
-            *[addr.index for addr in self.values() if addr.change == change],
+            *[addr.index or 0 for addr in self.values() if addr.change == change],
         )
 
     def max_used_index(self, change=False):
@@ -214,7 +214,7 @@ class AddressList(dict):
             -1,
             -1,
             *[
-                addr.index
+                addr.index or -1
                 for addr in self.values()
                 if addr.used and addr.change == change
             ],

--- a/src/cryptoadvance/specter/addresslist.py
+++ b/src/cryptoadvance/specter/addresslist.py
@@ -54,6 +54,10 @@ class Address(dict):
         return self.index is None
 
     @property
+    def is_mine(self):
+        return not self.is_external
+
+    @property
     def is_receiving(self):
         # change can be True, False or None
         # None means it's external

--- a/src/cryptoadvance/specter/addresslist.py
+++ b/src/cryptoadvance/specter/addresslist.py
@@ -69,7 +69,7 @@ class Address(dict):
 
     @property
     def change(self):
-        return self["change"]
+        return not self.is_external and self["change"]
 
     @property
     def used(self):

--- a/src/cryptoadvance/specter/api/rest/resource_psbt.py
+++ b/src/cryptoadvance/specter/api/rest/resource_psbt.py
@@ -26,7 +26,7 @@ class ResourcePsbt(SecureResource):
             user
         ).wallet_manager.get_by_alias(wallet_alias)
         pending_psbts = wallet.pending_psbts_dict()
-        return {"result": pending_psbts or []}
+        return {"result": pending_psbts or {}}
 
     def post(self, wallet_alias):
         user = auth.current_user()

--- a/src/cryptoadvance/specter/api/rest/resource_psbt.py
+++ b/src/cryptoadvance/specter/api/rest/resource_psbt.py
@@ -37,5 +37,5 @@ class ResourcePsbt(SecureResource):
         psbt_creator = PsbtCreator(
             app.specter, wallet, "json", request_json=request.json
         )
-        psbt_creator.create_psbt(wallet)
-        return {"result": psbt_creator.psbt}
+        psbt = psbt_creator.create_psbt(wallet)
+        return {"result": psbt}

--- a/src/cryptoadvance/specter/api/rest/resource_psbt.py
+++ b/src/cryptoadvance/specter/api/rest/resource_psbt.py
@@ -25,7 +25,7 @@ class ResourcePsbt(SecureResource):
         wallet: Wallet = app.specter.user_manager.get_user(
             user
         ).wallet_manager.get_by_alias(wallet_alias)
-        pending_psbts = wallet.pending_psbts
+        pending_psbts = wallet.pending_psbts_dict()
         return {"result": pending_psbts or []}
 
     def post(self, wallet_alias):

--- a/src/cryptoadvance/specter/devices/bitcoin_core.py
+++ b/src/cryptoadvance/specter/devices/bitcoin_core.py
@@ -24,6 +24,9 @@ class BitcoinCore(Device):
     hot_wallet = True
     taproot_support = True
 
+    # default sighash to use
+    SIGHASH = "ALL"
+
     def __init__(self, *args, **kwargs):
         self._use_descriptors = None
         super().__init__(*args, **kwargs)
@@ -212,7 +215,7 @@ class BitcoinCore(Device):
         )
         if file_password:
             rpc.walletpassphrase(file_password, 60)
-        signed_psbt = rpc.walletprocesspsbt(base64_psbt)
+        signed_psbt = rpc.walletprocesspsbt(base64_psbt, True, self.SIGHASH)
         if base64_psbt == signed_psbt["psbt"]:
             raise Exception(
                 "Make sure you have entered the wallet file password correctly. (If your wallet is not encrypted submit empty password)"

--- a/src/cryptoadvance/specter/devices/elements_core.py
+++ b/src/cryptoadvance/specter/devices/elements_core.py
@@ -58,3 +58,11 @@ class ElementsCore(BitcoinCore):
             return ""
         if not is_liquid(network):
             return "This wallet can only sign on Liquid"
+
+    def sign_psbt(self, base64_psbt, wallet, *args, **kwargs):
+        # TODO: remove after dynafed is activated
+        if not wallet.manager.rpc.is_dynafed:
+            self.SIGHASH = "ALL"
+        else:
+            self.SIGHASH = "ALL|RANGEPROOF"
+        return super().sign_psbt(base64_psbt, wallet, *args, **kwargs)

--- a/src/cryptoadvance/specter/devices/elements_core.py
+++ b/src/cryptoadvance/specter/devices/elements_core.py
@@ -16,6 +16,9 @@ class ElementsCore(BitcoinCore):
     bitcoin_core_support = False
     liquid_support = True
 
+    # default sighash to use
+    SIGHASH = "ALL|RANGEPROOF"
+
     def add_hot_wallet_keys(
         self,
         mnemonic,

--- a/src/cryptoadvance/specter/devices/generic.py
+++ b/src/cryptoadvance/specter/devices/generic.py
@@ -1,6 +1,5 @@
 from . import DeviceTypes
 from ..device import Device
-from ..liquid.util.pset import to_canonical_pset
 
 
 class GenericDevice(Device):
@@ -13,7 +12,6 @@ class GenericDevice(Device):
     taproot_support = True
 
     def create_psbts(self, base64_psbt, wallet):
-        base64_psbt = to_canonical_pset(base64_psbt)
         # in QR codes keep only xpubs
         qr_psbt = wallet.fill_psbt(base64_psbt, non_witness=False, xpubs=True)
         # in SD card put as much as possible

--- a/src/cryptoadvance/specter/helpers.py
+++ b/src/cryptoadvance/specter/helpers.py
@@ -345,4 +345,4 @@ def get_address_from_dict(data_dict):
         addr = data_dict.get("address")
     if addr and addr != "Fee":
         return addr
-    raise RuntimeError("Missing address info in object")
+    raise RuntimeError(f"Missing address info in object {data_dict}")

--- a/src/cryptoadvance/specter/key.py
+++ b/src/cryptoadvance/specter/key.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 from binascii import hexlify
 from embit import base58
 from .util.xpub import get_xpub_fingerprint
-
+from embit.descriptor import Key as DescriptorKey
 
 purposes = OrderedDict(
     {

--- a/src/cryptoadvance/specter/liquid/rpc.py
+++ b/src/cryptoadvance/specter/liquid/rpc.py
@@ -178,6 +178,16 @@ class LiquidRPC(BitcoinRPC):
             inputs, outputs, locktime, options, *args, **kwargs
         )
         psbt = res.get("psbt", None)
+
+        # remove strange zero-output
+        if psbt:
+            try:
+                tx = PSET.from_string(psbt)
+                tx.outputs = [out for out in tx.outputs if out.value > 0]
+                psbt = str(tx)
+                res["psbt"] = psbt
+            except:
+                pass
         # replace change addresses from the transactions if we can
         if change_addresses and psbt:
             try:

--- a/src/cryptoadvance/specter/liquid/rpc.py
+++ b/src/cryptoadvance/specter/liquid/rpc.py
@@ -179,7 +179,7 @@ class LiquidRPC(BitcoinRPC):
         )
         psbt = res.get("psbt", None)
 
-        # remove strange zero-output
+        # remove strange zero-output (bug in Elements?)
         if psbt:
             try:
                 tx = PSET.from_string(psbt)

--- a/src/cryptoadvance/specter/liquid/rpc.py
+++ b/src/cryptoadvance/specter/liquid/rpc.py
@@ -13,7 +13,6 @@ from embit.liquid import slip77
 from embit.psbt import read_string
 import copy
 from io import BytesIO
-
 from .util.pset import to_canonical_pset
 
 import logging

--- a/src/cryptoadvance/specter/liquid/rpc.py
+++ b/src/cryptoadvance/specter/liquid/rpc.py
@@ -229,6 +229,9 @@ class LiquidRPC(BitcoinRPC):
             # check that change is also blinded - fixes a bug in pset branch
             tx = PSET.from_string(psbt)
             changepos = res.get("changepos", None)
+            # no change output
+            if changepos < 0:
+                changepos = None
 
             # generate all blinding stuff ourselves in deterministic way
             tx.unblind(
@@ -299,9 +302,7 @@ class LiquidRPC(BitcoinRPC):
             tx.xpubs.update(t2.xpubs)
             tx.unknown.update(t2.unknown)
 
-            for i in range(len(tx.inputs)):
-                inp1 = tx.inputs[i]
-                inp2 = t2.inputs[i]
+            for inp1, inp2 in zip(tx.inputs, t2.inputs):
                 inp1.value = inp1.value or inp2.value
                 inp1.value_blinding_factor = (
                     inp1.value_blinding_factor or inp2.value_blinding_factor
@@ -326,9 +327,7 @@ class LiquidRPC(BitcoinRPC):
                 inp1.unknown.update(inp2.unknown)
                 inp1.range_proof = inp1.range_proof or inp2.range_proof
 
-            for i in range(len(tx.outputs)):
-                out1 = tx.outputs[i]
-                out2 = t2.outputs[i]
+            for out1, out2 in zip(tx.outputs, t2.outputs):
                 out1.value_commitment = out1.value_commitment or out2.value_commitment
                 out1.value_blinding_factor = (
                     out1.value_blinding_factor or out2.value_blinding_factor

--- a/src/cryptoadvance/specter/liquid/util/pset.py
+++ b/src/cryptoadvance/specter/liquid/util/pset.py
@@ -119,6 +119,14 @@ class SpecterPSET(SpecterPSBT):
         ]
 
     @property
+    def amounts(self):
+        return [
+            out.float_amount
+            for out in self.outputs
+            if out.scope.script_pubkey.data and not self.descriptor.owns(out.scope)
+        ]
+
+    @property
     def assets(self):
         return [
             out.assetid

--- a/src/cryptoadvance/specter/liquid/util/pset.py
+++ b/src/cryptoadvance/specter/liquid/util/pset.py
@@ -1,4 +1,10 @@
-from embit.liquid.pset import PSET
+from embit.liquid.pset import PSET, LInputScope, LOutputScope
+from embit.liquid.transaction import LTransaction, LTransactionOutput
+from embit.liquid.networks import get_network
+from embit.liquid.addresses import address as liquid_address
+from embit import bip32, ec
+from math import ceil
+import time
 
 
 def to_canonical_pset(pset):
@@ -24,3 +30,254 @@ def to_canonical_pset(pset):
             out.value = None
             out.value_blinding_factor = None
     return str(tx)
+
+
+def get_address(script_pubkey, network):
+    return script_pubkey.address(network) if script_pubkey.data else "Fee"
+
+
+class SpecterLTx(LTransaction):
+    def to_dict(self, network):
+        txid = self.txid().hex()
+        size = len(self.serialize())
+        return {
+            "txid": txid,
+            "hash": txid,  # not sure why it's the same
+            "version": self.version,
+            "size": size,
+            "vsize": size,
+            "weight": 4 * size,
+            "locktime": self.locktime,
+            "vin": [
+                {
+                    "txid": vin.txid.hex(),
+                    "vout": vin.vout,
+                    "sequence": vin.sequence,
+                }
+                for vin in self.vin
+            ],
+            "vout": [
+                {
+                    "value": round(1e-8 * vout.value, 8),
+                    "sats": vout.value,
+                    "n": i,
+                    "asset": vout.asset.hex(),
+                    "scriptPubKey": {
+                        "hex": vout.script_pubkey.data.hex(),
+                        "addresses": [get_address(vout.script_pubkey, network)],
+                    },
+                }
+                for i, vout in enumerate(self.vout)
+            ],
+        }
+
+
+class SpecterLTxOut(LTransactionOutput):
+    def to_dict(self, network):
+        return {
+            "amount": round(self.value * 1e-8, 8),
+            "sats": self.value,
+            "scriptPubKey": {
+                "hex": self.script_pubkey.data.hex(),
+                "addresses": [get_address(self.script_pubkey, network)],
+            },
+        }
+
+
+class SpecterLInputScope(LInputScope):
+    TX_CLS = SpecterLTx
+    TXOUT_CLS = SpecterLTxOut
+
+    def __init__(self, *args, **kwargs):
+        self.parent = None
+        super().__init__(*args, **kwargs)
+
+    @property
+    def network(self):
+        if self.parent:
+            return self.parent.network
+        return get_network("liquidv1")
+
+    @property
+    def address(self):
+        # TODO: blinding key?
+        return liquid_address(self.script_pubkey, network=self.network)
+
+    @property
+    def float_amount(self):
+        return round(self.value * 1e-8, 8)
+
+    def witness_utxo_dict(self, network):
+        return {
+            "amount": round(self.value * 1e-8, 8),
+            "sats": self.value,
+            "asset": self.asset.hex(),
+            "scriptPubKey": {
+                "hex": self.script_pubkey.data.hex(),
+                "addresses": [self.address],
+            },
+        }
+
+    def to_dict(self, network=None):
+        network = network or self.network
+        obj = {
+            "address": self.address,
+            "float_amount": self.float_amount,
+            "asset": self.asset,
+            "sat_amount": self.value,
+        }
+        obj["witness_utxo"] = self.witness_utxo_dict(network)
+        if self.bip32_derivations:
+            obj["bip32_derivs"] = [
+                {
+                    "pubkey": pub.sec().hex(),
+                    "master_fingerprint": der.fingerprint.hex(),
+                    "path": bip32.path_to_str(der.derivation),
+                }
+                for pub, der in self.bip32_derivations.items()
+            ]
+        return obj
+
+
+class SpecterLOutputScope(LOutputScope):
+    def __init__(self, *args, **kwargs):
+        self.parent = None
+        super().__init__(*args, **kwargs)
+
+    @property
+    def network(self):
+        if self.parent:
+            return self.parent.network
+        return get_network("liquidv1")
+
+    @property
+    def address(self):
+        if not self.script_pubkey.data:
+            return "Fee"
+        return liquid_address(
+            self.script_pubkey, self.blinding_eckey, network=self.network
+        )
+
+    @property
+    def blinding_eckey(self):
+        if self.blinding_pubkey:
+            return ec.PublicKey.parse(self.blinding_pubkey)
+
+    @property
+    def float_amount(self):
+        return round(self.value * 1e-8, 8)
+
+    def to_dict(self, network):
+        network = network or self.network
+        obj = {
+            "address": self.address,
+            "float_amount": self.float_amount,
+            "asset": self.asset,
+            "sat_amount": self.value,
+        }
+        if self.bip32_derivations:
+            obj["bip32_derivs"] = [
+                {
+                    "pubkey": pub.sec().hex(),
+                    "master_fingerprint": der.fingerprint.hex(),
+                    "path": bip32.path_to_str(der.derivation),
+                }
+                for pub, der in self.bip32_derivations.items()
+            ]
+        return obj
+
+
+class SpecterPSET(PSET):
+    """Specter's PSBT class with some handy functions"""
+
+    PSBTIN_CLS = SpecterLInputScope
+    PSBTOUT_CLS = SpecterLOutputScope
+    TX_CLS = SpecterLTx
+
+    def __init__(self, *args, **kwargs):
+        self.descriptor = None
+        self.network = get_network("liquidv1")
+        if "descriptor" in kwargs:
+            self.descriptor = kwargs.pop("descriptor")
+        if "network" in kwargs:
+            self.network = kwargs.pop("network")
+        super().__init__(*args, **kwargs)
+        # set parent to self so we know about descriptor and network
+        for sc in self.inputs + self.outputs:
+            sc.parent = self
+
+    def utxo_dict(self):
+        return [{"txid": inp.txid.hex(), "vout": inp.vout} for inp in self.inputs]
+
+    @classmethod
+    def from_dict(cls, obj, descriptor, chain):
+        psbt = cls.from_string(obj["base64"])
+        psbt.descriptor = descriptor
+        psbt.network = get_network(chain)
+        return psbt
+
+    @property
+    def extra_input_weight(self):
+        redeem_script = self.descriptor.redeem_script()
+        witness_script = self.descriptor.witness_script()
+        weight = 0
+        if redeem_script:
+            weight += len(redeem_script.data) * 4
+        if witness_script:
+            weight += len(witness_script.data)
+            if self.descriptor.is_basic_multisig:
+                threshold = self.descriptor.miniscript.args[0].num
+                num_keys = len(self.descriptor.keys)
+                weight += num_keys * 34
+                weight += threshold * 75
+        else:
+            # pubkey, signature
+            weight += 75 + 34
+        return weight
+
+    @property
+    def full_size(self):
+        size = len(self.tx.serialize()) * 4
+        size += len(self.inputs) * self.extra_input_weight
+        return ceil(size / 4)
+
+    @property
+    def sigs_count(self):
+        # not quite true
+        return max([len(inp.partial_sigs) for inp in self.inputs])
+
+    @property
+    def addresses(self):
+        return [
+            out.address
+            for out in self.outputs
+            if (not self.descriptor.owns(out)) and out.script_pubkey.data
+        ]
+
+    @property
+    def amounts(self):
+        return [
+            round(out.value * 1e-8, 8)
+            for out in self.outputs
+            if (not self.descriptor.owns(out)) and out.script_pubkey.data
+        ]
+
+    @property
+    def sats(self):
+        return [out.value for out in self.outputs if not self.descriptor.owns(out)]
+
+    def to_dict(self):
+        return {
+            "tx": self.tx.to_dict(self.network),
+            "inputs": [inp.to_dict(self.network) for inp in self.inputs],
+            "outputs": [out.to_dict(self.network) for out in self.outputs],
+            "base64": str(self),
+            "fee": round(self.fee() * 1e-8, 8),
+            "fee_sat": self.fee(),
+            "address": self.addresses,
+            "amount": self.amounts,
+            "sats": self.sats,
+            "tx_full_size": self.full_size,
+            "sigs_count": self.sigs_count,
+            "time": round(time.time(), 6),  # TODO: remove
+        }

--- a/src/cryptoadvance/specter/liquid/util/pset.py
+++ b/src/cryptoadvance/specter/liquid/util/pset.py
@@ -75,7 +75,6 @@ class SpecterLInputScope(SpecterInputScope):
 
 
 class SpecterLOutputScope(SpecterOutputScope):
-
     @property
     def assetid(self):
         return self.scope.asset[::-1].hex()
@@ -105,6 +104,7 @@ class SpecterLOutputScope(SpecterOutputScope):
 
 class SpecterPSET(SpecterPSBT):
     """Specter's PSBT class with some handy functions"""
+
     PSBTCls = PSET
     InputCls = SpecterLInputScope
     OutputCls = SpecterLOutputScope
@@ -128,7 +128,5 @@ class SpecterPSET(SpecterPSBT):
 
     def to_dict(self):
         obj = super().to_dict()
-        obj.update({
-            "asset": self.assets
-        })
+        obj.update({"asset": self.assets})
         return obj

--- a/src/cryptoadvance/specter/liquid/util/pset.py
+++ b/src/cryptoadvance/specter/liquid/util/pset.py
@@ -5,6 +5,7 @@ from embit.liquid.addresses import address as liquid_address
 from embit import bip32, ec
 from math import ceil
 import time
+from cryptoadvance.specter.util.psbt import *
 
 
 def to_canonical_pset(pset):
@@ -36,276 +37,85 @@ def get_address(script_pubkey, network):
     return script_pubkey.address(network) if script_pubkey.data else "Fee"
 
 
-class SpecterLTx(LTransaction):
-    def to_dict(self, network):
-        txid = self.txid().hex()
-        size = len(self.serialize())
+class SpecterLTx(SpecterTx):
+    def vout_to_dict(self, vout):
+        i = self.tx.vout.index(vout)
         return {
-            "txid": txid,
-            "hash": txid,  # not sure why it's the same
-            "version": self.version,
-            "size": size,
-            "vsize": size,
-            "weight": 4 * size,
-            "locktime": self.locktime,
-            "vin": [
-                {
-                    "txid": vin.txid.hex(),
-                    "vout": vin.vout,
-                    "sequence": vin.sequence,
-                }
-                for vin in self.vin
-            ],
-            "vout": [
-                {
-                    "value": round(1e-8 * vout.value, 8),
-                    "sats": vout.value,
-                    "n": i,
-                    "asset": vout.asset[::-1].hex(),
-                    "scriptPubKey": {
-                        "hex": vout.script_pubkey.data.hex(),
-                        "addresses": [get_address(vout.script_pubkey, network)],
-                    },
-                }
-                for i, vout in enumerate(self.vout)
-            ],
-        }
-
-
-class SpecterLTxOut(LTransactionOutput):
-    def to_dict(self, network):
-        return {
-            "amount": round(self.value * 1e-8, 8),
-            "sats": self.value,
+            "value": round(1e-8 * vout.value, 8),
+            "sats": vout.value,
+            "n": i,
+            "asset": vout.asset[::-1].hex(),
             "scriptPubKey": {
-                "hex": self.script_pubkey.data.hex(),
-                "addresses": [get_address(self.script_pubkey, network)],
+                "hex": vout.script_pubkey.data.hex(),
+                "addresses": [get_address(vout.script_pubkey, self.network)],
             },
         }
 
 
-class SpecterLInputScope(LInputScope):
-    TX_CLS = SpecterLTx
-    TXOUT_CLS = SpecterLTxOut
-
-    def __init__(self, *args, **kwargs):
-        self.parent = None
-        super().__init__(*args, **kwargs)
+class SpecterLInputScope(SpecterInputScope):
+    TxCls = SpecterLTx
 
     @property
     def assetid(self):
-        return self.asset[::-1].hex()
-
-    @property
-    def network(self):
-        if self.parent:
-            return self.parent.network
-        return get_network("liquidv1")
+        return self.scope.asset[::-1].hex()
 
     @property
     def address(self):
         # TODO: blinding key?
-        return liquid_address(self.script_pubkey, network=self.network)
-
-    @property
-    def float_amount(self):
-        return round(self.value * 1e-8, 8)
+        return liquid_address(self.scope.script_pubkey, network=self.network)
 
     @property
     def sat_amount(self):
-        return self.value
+        return self.scope.value
 
-    def witness_utxo_dict(self, network):
-        return {
-            "amount": round(self.value * 1e-8, 8),
-            "sats": self.value,
-            "asset": self.assetid,
-            "scriptPubKey": {
-                "hex": self.script_pubkey.data.hex(),
-                "addresses": [self.address],
-            },
-        }
-
-    def to_dict(self, network=None):
-        network = network or self.network
-        obj = {
-            "address": self.address,
-            "float_amount": self.float_amount,
-            "asset": self.assetid,
-            "sat_amount": self.value,
-            "txid": self.txid.hex(),
-            "vout": self.vout,
-        }
-        obj["witness_utxo"] = self.witness_utxo_dict(network)
-        if self.bip32_derivations:
-            obj["bip32_derivs"] = [
-                {
-                    "pubkey": pub.sec().hex(),
-                    "master_fingerprint": der.fingerprint.hex(),
-                    "path": bip32.path_to_str(der.derivation),
-                }
-                for pub, der in self.bip32_derivations.items()
-            ]
+    def to_dict(self):
+        obj = super().to_dict()
+        obj.update({"asset": self.assetid})
         return obj
 
 
-class SpecterLOutputScope(LOutputScope):
-    def __init__(self, *args, **kwargs):
-        self.parent = None
-        super().__init__(*args, **kwargs)
+class SpecterLOutputScope(SpecterOutputScope):
 
     @property
     def assetid(self):
-        return self.asset[::-1].hex()
-
-    @property
-    def network(self):
-        if self.parent:
-            return self.parent.network
-        return get_network("liquidv1")
-
-    @property
-    def descriptor(self):
-        if self.parent:
-            return self.parent.descriptor
-        return None
-
-    @property
-    def is_change(self):
-        if self.descriptor:
-            return self.descriptor.branch(1).owns(self)
-        return False
-
-    @property
-    def is_mine(self):
-        if self.descriptor:
-            return self.descriptor.owns(self)
-        return False
+        return self.scope.asset[::-1].hex()
 
     @property
     def address(self):
-        if not self.script_pubkey.data:
+        if not self.scope.script_pubkey.data:
             return "Fee"
         return liquid_address(
-            self.script_pubkey, self.blinding_eckey, network=self.network
+            self.scope.script_pubkey, self.blinding_key, network=self.network
         )
 
     @property
-    def blinding_eckey(self):
-        if self.blinding_pubkey:
-            return ec.PublicKey.parse(self.blinding_pubkey)
-
-    @property
-    def float_amount(self):
-        return round(self.value * 1e-8, 8)
+    def blinding_key(self):
+        if self.scope.blinding_pubkey:
+            return ec.PublicKey.parse(self.scope.blinding_pubkey)
 
     @property
     def sat_amount(self):
-        return self.value
+        return self.scope.value
 
-    def to_dict(self, network):
-        network = network or self.network
-        obj = {
-            "address": self.address,
-            "float_amount": self.float_amount,
-            "asset": self.assetid,
-            "sat_amount": self.value,
-            "is_change": self.is_change,
-            "is_mine": self.is_mine,
-        }
-        if self.bip32_derivations:
-            obj["bip32_derivs"] = [
-                {
-                    "pubkey": pub.sec().hex(),
-                    "master_fingerprint": der.fingerprint.hex(),
-                    "path": bip32.path_to_str(der.derivation),
-                }
-                for pub, der in self.bip32_derivations.items()
-            ]
+    def to_dict(self):
+        obj = super().to_dict()
+        obj.update({"asset": self.assetid})
         return obj
 
 
-class SpecterPSET(PSET):
+class SpecterPSET(SpecterPSBT):
     """Specter's PSBT class with some handy functions"""
-
-    PSBTIN_CLS = SpecterLInputScope
-    PSBTOUT_CLS = SpecterLOutputScope
-    TX_CLS = SpecterLTx
-
-    def __init__(self, *args, **kwargs):
-        self.descriptor = None
-        self.network = get_network("liquidv1")
-        if "descriptor" in kwargs:
-            self.descriptor = kwargs.pop("descriptor")
-        if "network" in kwargs:
-            self.network = kwargs.pop("network")
-        self.time = time.time()
-        if "time" in kwargs:
-            self.time = kwargs.pop("time")
-        super().__init__(*args, **kwargs)
-        # set parent to self so we know about descriptor and network
-        for sc in self.inputs + self.outputs:
-            sc.parent = self
-
-    @property
-    def txid(self):
-        return self.tx.txid().hex()
-
-    @classmethod
-    def from_string(cls, *args, **kwargs):
-        psbt = super(cls, cls).from_string(*args, **kwargs)
-        # set parent to self so we know about descriptor and network
-        for sc in psbt.inputs + psbt.outputs:
-            sc.parent = psbt
-        return psbt
-
-    def utxo_dict(self):
-        return [{"txid": inp.txid.hex(), "vout": inp.vout} for inp in self.inputs]
-
-    @classmethod
-    def from_dict(cls, obj, descriptor, chain):
-        psbt = cls.from_string(obj["base64"])
-        psbt.descriptor = descriptor
-        psbt.network = get_network(chain)
-        psbt.time = obj.get("time", time.time())
-        return psbt
-
-    @property
-    def extra_input_weight(self):
-        redeem_script = self.descriptor.redeem_script()
-        witness_script = self.descriptor.witness_script()
-        weight = 0
-        if redeem_script:
-            weight += len(redeem_script.data) * 4
-        if witness_script:
-            weight += len(witness_script.data)
-            if self.descriptor.is_basic_multisig:
-                threshold = self.descriptor.miniscript.args[0].num
-                num_keys = len(self.descriptor.keys)
-                weight += num_keys * 34
-                weight += threshold * 75
-        else:
-            # pubkey, signature
-            weight += 75 + 34
-        return weight
-
-    @property
-    def full_size(self):
-        size = len(self.tx.serialize()) * 4
-        size += len(self.inputs) * self.extra_input_weight
-        return ceil(size / 4)
-
-    @property
-    def sigs_count(self):
-        # not quite true
-        return max([len(inp.partial_sigs) for inp in self.inputs])
+    PSBTCls = PSET
+    InputCls = SpecterLInputScope
+    OutputCls = SpecterLOutputScope
+    TxCls = SpecterLTx
 
     @property
     def addresses(self):
         return [
             out.address
             for out in self.outputs
-            if (not self.descriptor.owns(out)) and out.script_pubkey.data
+            if out.scope.script_pubkey.data and not self.descriptor.owns(out.scope)
         ]
 
     @property
@@ -313,34 +123,12 @@ class SpecterPSET(PSET):
         return [
             out.assetid
             for out in self.outputs
-            if (not self.descriptor.owns(out)) and out.script_pubkey.data
+            if out.scope.script_pubkey.data and not self.descriptor.owns(out.scope)
         ]
-
-    @property
-    def amounts(self):
-        return [
-            round(out.value * 1e-8, 8)
-            for out in self.outputs
-            if (not self.descriptor.owns(out)) and out.script_pubkey.data
-        ]
-
-    @property
-    def sats(self):
-        return [out.value for out in self.outputs if not self.descriptor.owns(out)]
 
     def to_dict(self):
-        return {
-            "tx": self.tx.to_dict(self.network),
-            "inputs": [inp.to_dict(self.network) for inp in self.inputs],
-            "outputs": [out.to_dict(self.network) for out in self.outputs],
-            "base64": str(self),
-            "fee": round(self.fee() * 1e-8, 8),
-            "fee_sat": self.fee(),
-            "address": self.addresses,
-            "amount": self.amounts,
-            "asset": self.assets,
-            "sats": self.sats,
-            "tx_full_size": self.full_size,
-            "sigs_count": self.sigs_count,
-            "time": self.time,
-        }
+        obj = super().to_dict()
+        obj.update({
+            "asset": self.assets
+        })
+        return obj

--- a/src/cryptoadvance/specter/liquid/wallet.py
+++ b/src/cryptoadvance/specter/liquid/wallet.py
@@ -263,6 +263,12 @@ class LWallet(Wallet):
             self.save_pending_psbt(psbt)
         return psbt.to_dict()
 
+    def canceltx(self, *args, **kwargs):
+        raise SpecterError("RBF is not implemented on Liquid")
+
+    def bumpfee(self, *args, **kwargs):
+        raise SpecterError("RBF is not implemented on Liquid")
+
     def addresses_info(self, is_change):
         """Create a list of (receive or change) addresses from cache and retrieve the
         related UTXO and amount.

--- a/src/cryptoadvance/specter/liquid/wallet.py
+++ b/src/cryptoadvance/specter/liquid/wallet.py
@@ -9,6 +9,7 @@ from .txlist import LTxList
 from .addresslist import LAddressList
 from embit.liquid.addresses import to_unconfidential
 from ..specter_error import SpecterError
+from .util.pset import SpecterPSET
 
 
 class LWallet(Wallet):
@@ -16,7 +17,7 @@ class LWallet(Wallet):
     AddressListCls = LAddressList
     TxListCls = LTxList
     TxCls = LTransaction
-    PSBTCls = PSET
+    PSBTCls = SpecterPSET
     DescriptorCls = LDescriptor
 
     @classmethod

--- a/src/cryptoadvance/specter/liquid/wallet.py
+++ b/src/cryptoadvance/specter/liquid/wallet.py
@@ -311,7 +311,12 @@ class LWallet(Wallet):
         psbt["time"] = time.time()
         psbt["sigs_count"] = 0
 
-        psbt = self.PSBTCls.from_dict(psbt, self.descriptor, self.manager.chain)
+        psbt = self.PSBTCls.from_dict(
+            psbt,
+            self.descriptor,
+            self.manager.chain,
+            devices=list(zip(self.keys, self._devices)),
+        )
         if not readonly:
             self.save_pending_psbt(psbt)
         return psbt.to_dict()

--- a/src/cryptoadvance/specter/liquid/wallet.py
+++ b/src/cryptoadvance/specter/liquid/wallet.py
@@ -33,7 +33,7 @@ class LWallet(Wallet):
         )
 
         # get blinding key for the wallet if it's not provided
-        if len(devices) == 1:
+        if len(devices) == 1 and blinding_key is None:
             blinding_key = devices[0].blinding_key
             if not blinding_key:
                 raise SpecterError(

--- a/src/cryptoadvance/specter/liquid/wallet.py
+++ b/src/cryptoadvance/specter/liquid/wallet.py
@@ -310,10 +310,11 @@ class LWallet(Wallet):
             psbt["asset"] = assets
         psbt["time"] = time.time()
         psbt["sigs_count"] = 0
+
+        psbt = self.PSBTCls.from_dict(psbt, self.descriptor, self.manager.chain)
         if not readonly:
             self.save_pending_psbt(psbt)
-
-        return psbt
+        return psbt.to_dict()
 
     def adjust_fee(self, psbt, fee_rate):
         psbt_fees_sats = int(psbt.get("fees", {}).get("bitcoin", 0) * 1e8)

--- a/src/cryptoadvance/specter/liquid/wallet.py
+++ b/src/cryptoadvance/specter/liquid/wallet.py
@@ -3,6 +3,8 @@ from ..addresslist import Address
 from embit import ec
 from embit.liquid.pset import PSET
 from embit.liquid.transaction import LTransaction
+from embit.liquid.descriptor import LDescriptor
+from embit.descriptor.checksum import add_checksum
 from .txlist import LTxList
 from .addresslist import LAddressList
 from embit.liquid.addresses import to_unconfidential
@@ -15,49 +17,22 @@ class LWallet(Wallet):
     TxListCls = LTxList
     TxCls = LTransaction
     PSBTCls = PSET
+    DescriptorCls = LDescriptor
 
     @classmethod
-    def create(
-        cls,
-        rpc,
-        rpc_path,
-        working_folder,
-        device_manager,
-        wallet_manager,
-        name,
-        alias,
-        sigs_required,
-        key_type,
-        keys,
-        devices,
-        core_version=None,
+    def construct_descriptor(
+        cls, sigs_required, key_type, keys, devices, blinding_key=None
     ):
-        """Creates a wallet. If core_version is not specified - get it from rpc"""
-        # get xpubs in a form [fgp/der]xpub from all keys
-        xpubs = [key.metadata["combined"] for key in keys]
-        recv_keys = ["%s/0/*" % xpub for xpub in xpubs]
-        change_keys = ["%s/1/*" % xpub for xpub in xpubs]
-        is_multisig = len(keys) > 1
-        # we start by constructing an argument for descriptor wrappers
-        if is_multisig:
-            recv_descriptor = "sortedmulti({},{})".format(
-                sigs_required, ",".join(recv_keys)
-            )
-            change_descriptor = "sortedmulti({},{})".format(
-                sigs_required, ",".join(change_keys)
-            )
-        else:
-            recv_descriptor = recv_keys[0]
-            change_descriptor = change_keys[0]
-        # now we iterate over script-type in reverse order
-        # to get sh(wpkh(xpub)) from sh-wpkh and xpub
-        arr = key_type.split("-")
-        for el in arr[::-1]:
-            recv_descriptor = "%s(%s)" % (el, recv_descriptor)
-            change_descriptor = "%s(%s)" % (el, change_descriptor)
+        """
+        Creates a wallet descriptor from arguments.
+        We need to pass `devices` for Liquid wallet, here it's not used.
+        """
+        # construct normal bitcoin descriptor first
+        btcdescriptor = Wallet.construct_descriptor(
+            sigs_required, key_type, keys, devices
+        )
 
-        # get blinding key for the wallet
-        blinding_key = None
+        # get blinding key for the wallet if it's not provided
         if len(devices) == 1:
             blinding_key = devices[0].blinding_key
             if not blinding_key:
@@ -68,14 +43,13 @@ class LWallet(Wallet):
         # if we don't have slip77 key for a device or it is multisig
         # we use chaincodes to generate slip77 key.
         if not blinding_key:
-            desc = LDescriptor.from_string(recv_descriptor)
             # For now we use sha256(b"blinding_key", xor(chaincodes)) as a blinding key
             # where chaincodes are corresponding to xpub of the first receiving address.
             # It's not a standard but we use that until musig(blinding_xpubs) is implemented.
             # Chaincodes of the first address are not used anywhere else so they can be used
             # as a source for the blinding keys. They are also independent of the xpub's origin.
             xor = bytearray(32)
-            desc_keys = desc.derive(0).keys
+            desc_keys = btcdescriptor.derive(0, branch_index=0).keys
             for k in desc_keys:
                 if k.is_extended:
                     chaincode = k.key.chain_code
@@ -83,80 +57,36 @@ class LWallet(Wallet):
                         xor[i] = xor[i] ^ chaincode[i]
             secret = hashlib.sha256(b"blinding_key" + bytes(xor)).digest()
             blinding_key = ec.PrivateKey(secret).wif()
-        if blinding_key:
-            recv_descriptor = f"blinded(slip77({blinding_key}),{recv_descriptor})"
-            change_descriptor = f"blinded(slip77({blinding_key}),{change_descriptor})"
 
-        recv_descriptor = AddChecksum(recv_descriptor)
-        change_descriptor = AddChecksum(change_descriptor)
-        assert recv_descriptor != change_descriptor
-
-        # get Core version if we don't know it
-        if core_version is None:
-            core_version = rpc.getnetworkinfo().get("version", 0)
-
-        use_descriptors = core_version >= 209900
-        # v20.99 is pre-v21 Elements Core for descriptors
-        if use_descriptors:
-            # Use descriptor wallet
-            rpc.createwallet(os.path.join(rpc_path, alias), True, True, "", False, True)
-        else:
-            rpc.createwallet(os.path.join(rpc_path, alias), True)
-
-        wallet_rpc = rpc.wallet(os.path.join(rpc_path, alias))
-        # import descriptors
-        args = [
-            {
-                "desc": desc,
-                "internal": change,
-                "timestamp": "now",
-                "watchonly": True,
-            }
-            for (change, desc) in [(False, recv_descriptor), (True, change_descriptor)]
-        ]
-        for arg in args:
-            if use_descriptors:
-                arg["active"] = True
-            else:
-                arg["keypool"] = True
-                arg["range"] = [0, cls.GAP_LIMIT]
-
-        assert args[0] != args[1]
-
-        # Descriptor wallets were introduced in v0.21.0, but upgraded nodes may
-        # still have legacy wallets. Use getwalletinfo to check the wallet type.
-        # The "keypool" for descriptor wallets is automatically refilled
-        if use_descriptors:
-            res = wallet_rpc.importdescriptors(args)
-        else:
-            res = wallet_rpc.importmulti(args, {"rescan": False})
-
-        assert all([r["success"] for r in res])
-
-        return cls(
-            name,
-            alias,
-            "{} of {} {}".format(sigs_required, len(keys), purposes[key_type])
-            if len(keys) > 1
-            else purposes[key_type],
-            addrtypes[key_type],
-            "",
-            -1,
-            "",
-            -1,
-            0,
-            0,
-            recv_descriptor,
-            change_descriptor,
-            keys,
-            devices,
-            sigs_required,
-            {},
-            [],
-            os.path.join(working_folder, "%s.json" % alias),
-            device_manager,
-            wallet_manager,
+        return cls.DescriptorCls.from_string(
+            f"blinded(slip77({blinding_key}),{str(btcdescriptor)})"
         )
+
+    def get_descriptor(self, index=None, change=False, address=None):
+        """
+        Returns address descriptor from index, change
+        or from address belonging to the wallet.
+        """
+        if address is not None:
+            # only ask rpc if address is not known directly
+            if address not in self._addresses:
+                return self.rpc.getaddressinfo(address).get("desc", "")
+            else:
+                a = self._addresses[address]
+                index = a.index
+                change = a.change
+        if index is None:
+            index = self.change_index if change else self.address_index
+        desc = self.change_descriptor if change else self.recv_descriptor
+        # remove blinding stuff from descriptor so HWI Descriptor can work
+        ldesc = self.DescriptorCls.from_string(desc)
+        ldesc.blinding_key = None
+        desc = str(ldesc)
+        derived_desc = Descriptor.parse(desc).derive(index).serialize()
+        derived_desc_xpubs = (
+            Descriptor.parse(desc).derive(index, keep_xpubs=True).serialize()
+        )
+        return {"descriptor": derived_desc, "xpubs_descriptor": derived_desc_xpubs}
 
     def getdata(self):
         self.fetch_transactions()

--- a/src/cryptoadvance/specter/managers/wallet_manager.py
+++ b/src/cryptoadvance/specter/managers/wallet_manager.py
@@ -285,7 +285,7 @@ class WalletManager:
             logger.debug(f"Updating WalletManager rpc {self._rpc} with None")
         self._rpc = value
 
-    def create_wallet(self, name, sigs_required, key_type, keys, devices):
+    def create_wallet(self, name, sigs_required, key_type, keys, devices, **kwargs):
         try:
             walletsindir = [
                 wallet["name"] for wallet in self.rpc.listwalletdir()["wallets"]
@@ -314,6 +314,7 @@ class WalletManager:
             keys,
             devices,
             self.bitcoin_core_version_raw,
+            **kwargs,
         )
         # save wallet file to disk
         if w and self.working_folder is not None:

--- a/src/cryptoadvance/specter/managers/wallet_manager.py
+++ b/src/cryptoadvance/specter/managers/wallet_manager.py
@@ -161,16 +161,11 @@ class WalletManager:
                                 for psbt in loaded_wallet.pending_psbts:
                                     logger.info(
                                         "lock %s " % wallet_alias,
-                                        loaded_wallet.pending_psbts[psbt]["tx"]["vin"],
+                                        loaded_wallet.pending_psbts[psbt].utxo_dict(),
                                     )
                                     loaded_wallet.rpc.lockunspent(
                                         False,
-                                        [
-                                            utxo
-                                            for utxo in loaded_wallet.pending_psbts[
-                                                psbt
-                                            ]["tx"]["vin"]
-                                        ],
+                                        loaded_wallet.pending_psbts[psbt].utxo_dict(),
                                     )
                             if len(loaded_wallet.frozen_utxo) > 0:
                                 loaded_wallet.rpc.lockunspent(

--- a/src/cryptoadvance/specter/server_endpoints/filters.py
+++ b/src/cryptoadvance/specter/server_endpoints/filters.py
@@ -17,6 +17,12 @@ def ascii20(context, name):
 
 
 @contextfilter
+@filters_bp.app_template_filter("unique")
+def unique(context, arr):
+    return len(set(arr))
+
+
+@contextfilter
 @filters_bp.app_template_filter("datetime")
 def timedatetime(context, s):
     return format(datetime.fromtimestamp(s), "%d.%m.%Y %H:%M")

--- a/src/cryptoadvance/specter/server_endpoints/filters.py
+++ b/src/cryptoadvance/specter/server_endpoints/filters.py
@@ -17,8 +17,8 @@ def ascii20(context, name):
 
 
 @contextfilter
-@filters_bp.app_template_filter("unique")
-def unique(context, arr):
+@filters_bp.app_template_filter("unique_len")
+def unique_len(context, arr):
     return len(set(arr))
 
 

--- a/src/cryptoadvance/specter/server_endpoints/filters.py
+++ b/src/cryptoadvance/specter/server_endpoints/filters.py
@@ -3,7 +3,6 @@ from flask import current_app as app
 from flask import Blueprint
 from jinja2 import contextfilter
 from ..helpers import to_ascii20
-from ..liquid.util.pset import to_canonical_pset
 
 filters_bp = Blueprint("filters", __name__)
 
@@ -35,12 +34,6 @@ def btcamount(context, value):
         return "Confidential"
     value = round(float(value), 8)
     return "{:,.8f}".format(value).rstrip("0").rstrip(".")
-
-
-@contextfilter
-@filters_bp.app_template_filter("to_canonical")
-def to_canonical(context, psbt):
-    return to_canonical_pset(psbt)
 
 
 @contextfilter

--- a/src/cryptoadvance/specter/server_endpoints/wallets.py
+++ b/src/cryptoadvance/specter/server_endpoints/wallets.py
@@ -29,7 +29,6 @@ from ..helpers import (
     get_devices_with_keys_by_type,
     get_txid,
 )
-from ..liquid.util.pset import to_canonical_pset
 from ..key import Key
 from ..persistence import delete_file
 from ..rpc import RpcError
@@ -893,9 +892,6 @@ def combine(wallet_alias):
         return e.error_msg, e.status_code
     except Exception as e:
         return _("Unknown error: {}").format(e), 500
-    if "psbt" in raw:
-        # returned psbt should be valid for Bitcoin or Elements Core decoding
-        raw["psbt"] = to_canonical_pset(raw["psbt"])
     return json.dumps(raw)
 
 

--- a/src/cryptoadvance/specter/server_endpoints/wallets.py
+++ b/src/cryptoadvance/specter/server_endpoints/wallets.py
@@ -186,8 +186,8 @@ def new_wallet(wallet_type):
                     cosigners=wallet_importer.cosigners,
                     unknown_cosigners=wallet_importer.unknown_cosigners,
                     unknown_cosigners_types=wallet_importer.unknown_cosigners_types,
-                    sigs_required=wallet_importer.descriptor.multisig_M,
-                    sigs_total=wallet_importer.descriptor.multisig_N,
+                    sigs_required=wallet_importer.sigs_required,
+                    sigs_total=wallet_importer.sigs_total,
                     specter=app.specter,
                     rand=rand,
                 )

--- a/src/cryptoadvance/specter/server_endpoints/wallets.py
+++ b/src/cryptoadvance/specter/server_endpoints/wallets.py
@@ -580,7 +580,7 @@ def send_new(wallet_alias):
         elif action == "signhotwallet":
             passphrase = request.form["passphrase"]
             psbt = json.loads(request.form["psbt"])
-            b64psbt = wallet.pending_psbts[psbt["tx"]["txid"]]["base64"]
+            b64psbt = str(wallet.pending_psbts[psbt["tx"]["txid"]])
             device = request.form["device"]
             if "devices_signed" not in psbt or device not in psbt["devices_signed"]:
                 try:
@@ -683,13 +683,7 @@ def send_pending(wallet_alias):
                 specter=app.specter,
                 rand=rand,
             )
-    pending_psbts = wallet.pending_psbts
-    ######## Migration to multiple recipients format ###############
-    for psbt in pending_psbts:
-        if not isinstance(pending_psbts[psbt]["address"], list):
-            pending_psbts[psbt]["address"] = [pending_psbts[psbt]["address"]]
-            pending_psbts[psbt]["amount"] = [pending_psbts[psbt]["amount"]]
-    ###############################################################
+    pending_psbts = wallet.pending_psbts_dict()
     return render_template(
         "wallet/send/pending/wallet_sendpending.jinja",
         pending_psbts=pending_psbts,

--- a/src/cryptoadvance/specter/templates/includes/tx-row.html
+++ b/src/cryptoadvance/specter/templates/includes/tx-row.html
@@ -230,11 +230,8 @@
             if (newFee <= 1.02) {
                 newFee = 1;
             }
-            if (rbfType == 'cancel') {
-                newFee *= 1.5; // Tx likely to have lower size so will need higher fee
-            } else {
-                newFee += 2;
-            }
+            // TODO: get fee diff from specter
+            newFee += 2;
             txDataPopup.innerHTML = `
             <form action="${url}" method="POST">
             <h1>${rbfType == 'cancel' ? '{{ _("Cancel") }}' : '{{ _("Speed up") }}'} {{ _("the Transaction") }}</h1>

--- a/src/cryptoadvance/specter/templates/wallet/send/pending/components/pending_psbt_item.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/send/pending/components/pending_psbt_item.jinja
@@ -18,7 +18,15 @@
             {% endif %}
         </td>
         <td>
+            {% if specter.is_liquid %}
+                {% if pending_psbt['asset'] | unique == 1 %}
+                {{ (pending_psbt['amount'] | sum) | btcunitamount }} <asset-label data-asset="{{pending_psbt['asset'][0]}}" data-label="{{pending_psbt['asset'][0] | assetlabel}}"></asset-label>
+                {% else %}
+                {{ pending_psbt['asset'] | unique }} assets
+                {% endif %}
+            {% else %}
             {{ (pending_psbt['amount'] | sum) | btcunitamount }}{% if specter.price_check %}<span class="note">&nbsp;({{ (pending_psbt['amount'] | sum) | altunit }})</span>{% endif %}
+            {% endif %}
         </td>
         <td class="optional">
             {{ pending_psbt['time'] | datetime }}

--- a/src/cryptoadvance/specter/templates/wallet/send/pending/components/pending_psbt_item.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/send/pending/components/pending_psbt_item.jinja
@@ -19,10 +19,10 @@
         </td>
         <td>
             {% if specter.is_liquid %}
-                {% if pending_psbt['asset'] | unique == 1 %}
+                {% if pending_psbt['asset'] | unique_len == 1 %}
                 {{ (pending_psbt['amount'] | sum) | btcunitamount }} <asset-label data-asset="{{pending_psbt['asset'][0]}}" data-label="{{pending_psbt['asset'][0] | assetlabel}}"></asset-label>
                 {% else %}
-                {{ pending_psbt['asset'] | unique }} assets
+                {{ pending_psbt['asset'] | unique_len }} assets
                 {% endif %}
             {% else %}
             {{ (pending_psbt['amount'] | sum) | btcunitamount }}{% if specter.price_check %}<span class="note">&nbsp;({{ (pending_psbt['amount'] | sum) | altunit }})</span>{% endif %}

--- a/src/cryptoadvance/specter/templates/wallet/send/sign/wallet_send_sign_psbt.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/send/sign/wallet_send_sign_psbt.jinja
@@ -174,15 +174,15 @@
 						{% endif %}
 					</p>
 				{% endfor %}
-				{{ _("Raw PSBT:") }}<textarea id="raw-psbt" disabled style="background-color: #131a24;">{{ psbt['base64'] | to_canonical }}</textarea>
+				{{ _("Raw PSBT:") }}<textarea id="raw-psbt" disabled style="background-color: #131a24;">{{ psbt['base64'] }}</textarea>
 				<div class="row break-row-mobile" style="margin:auto">
 					<a id="download-psbt-btn" class="btn"
-					download="binary_{{ psbt['tx']['hash'] }}.psbt" href="data:application/octet-stream;base64;content-disposition=attachment,{{ psbt['base64'] | to_canonical }}">
+					download="binary_{{ psbt['tx']['hash'] }}.psbt" href="data:application/octet-stream;base64;content-disposition=attachment,{{ psbt['base64'] }}">
 						<img src="{{ url_for('static', filename='img/file.svg') }}" style="width: 26px; margin: 0px;" class="svg-white">
 						{{ _("Save binary") }}
 					</a>&nbsp;
 					<a id="download-psbt-btn" class="btn"
-					download="base64_{{ psbt['tx']['hash'] }}.psbt" href="data:text/plain;content-disposition=attachment,{{ psbt['base64'] | to_canonical }}">
+					download="base64_{{ psbt['tx']['hash'] }}.psbt" href="data:text/plain;content-disposition=attachment,{{ psbt['base64'] }}">
 						<img src="{{ url_for('static', filename='img/file.svg') }}" style="width: 26px; margin: 0px;" class="svg-white">
 						{{ _("Save base64") }}
 					</a>&nbsp;
@@ -237,7 +237,7 @@
     <input type="hidden" class="csrf-token" name="csrf_token" value="{{ csrf_token() }}"/>
 	<div class="row" style="min-height: 400px;">
         <span style="margin: auto;" id="raw-psbt-qr-holder">
-            <qr-code id="raw-psbt-qr" class='center' value="{{ psbt['base64'] | to_canonical }}" width="400" scalable></qr-code>
+            <qr-code id="raw-psbt-qr" class='center' value="{{ psbt['base64'] }}" width="400" scalable></qr-code>
         </span>
     </div>
 </form>

--- a/src/cryptoadvance/specter/templates/wallet/send/sign/wallet_send_sign_psbt.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/send/sign/wallet_send_sign_psbt.jinja
@@ -127,48 +127,15 @@
 					<b>{{ _("Inputs count:") }}</b> {{ psbt['tx']['vin'] | length }}<br>
 					<b>{{ _("Outputs count:") }}</b> {{ psbt['tx']['vout'] | length }}
 				</p>
-				<h2 class="tx_details_header">{{ _("Inputs") }} ({{psbt['tx']['vin'] | length}})</h2>
-				{% for input in psbt['tx']['vin'] %}
-					{% set tx = wallet.gettransaction(input['txid'], decode=true) %}
+				<h2 class="tx_details_header">{{ _("Inputs") }} ({{psbt['inputs'] | length}})</h2>
+				{% for input in psbt['inputs'] %}
 					{% set bg_color = '#131a24' %}
-					{% if tx and tx.vout and tx.vout|length > input['vout'] and 'addresses' in tx.vout[input['vout']] and tx.vout[input['vout']].addresses|length > 0 %}
-						{% set address = tx.vout[input['vout']].addresses[0] %}
-						{% set bg_color = '#925d07' if wallet.is_address_mine(address) else bg_color %}
-					{% endif %}
+					{% set address=input['address'] %}
+					{% set bg_color = '#925d07' if wallet.is_address_mine(address) else bg_color %}
 					<p class="tx_info" style="text-align: left; background-color: {{ bg_color }};">
 						<b style="margin: auto;">Input #{{loop.index0}}</b><br><br>
 						<b>{{ _("Transaction id:") }}</b><br>
-						{{ explorer_link('tx', input['txid'], input['txid'], specter.explorer) }}
-						({{ _("Output") }} #{{ input['vout'] }})<br>
-						{% if tx %}
-							{% if address %}
-								{% set addr_label = wallet.getlabel(address) %}
-								<b>{{ _("Address:") }}</b>
-								{{ address }}
-								<br>
-								{% if addr_label != address %}
-									<b>{{ _("Label:") }}</b>
-									<address-label data-address="{{ address }}" data-label="{{ addr_label }}" data-wallet="{{ wallet_alias }}"></address-label>
-									<br>
-								{% endif %}
-							{% endif %}
-							{% if specter.is_liquid %}
-								{% set amount = psbt['inputs'][loop.index0].get('value', -1) %}
-								{% set asset = psbt['inputs'][loop.index0].get('asset', "") %}
-								<b>{{ _("Amount:") }}</b> {{ amount|btcamount }} <asset-label data-asset="{{asset}}" data-label="{{asset | assetlabel}}"></asset-label>
-							{% else %}
-								{% set amount = psbt['inputs'][loop.index0].get('witness_utxo',{}).get('amount', -1) %}
-								<b>{{ _("Amount:") }}</b> {{ amount|btcamount }} BTC {% if specter.price_check %}<span class="note">&nbsp;({{ amount | altunit }})</span>{% endif %}
-							{% endif %}
-						{% endif %}
-					</p>
-				{% endfor %}
-				<h2 class="tx_details_header">{{ _("Outputs") }} ({{psbt['tx']['vout']|length}})</h2>
-				{% for output in psbt['tx']['vout'] if output['scriptPubKey']['type'] != 'fee' %}
-					{% set address = output['scriptPubKey']['addresses'][0] if "addresses" in output["scriptPubKey"] else output["scriptPubKey"]["address"] %}
-					{% set bg_color = '#154984' if wallet.is_address_mine(address) else '#131a24' %}
-					<p class="tx_info" style="text-align: left; background-color: {{ bg_color }};">
-						<b>{{ _("Output") }} #{{loop.index0}}</b> {% if address not in psbt['address'] %}(Change){% endif %}<br><br>
+						{{ explorer_link('tx', input['txid'], input['txid'], specter.explorer) }} : {{ input['vout'] }}<br>
 						{% set addr_label = wallet.getlabel(address) %}
 						<b>{{ _("Address:") }}</b>
 						{{ address }}
@@ -178,7 +145,33 @@
 							<address-label data-address="{{ address }}" data-label="{{ addr_label }}" data-wallet="{{ wallet_alias }}"></address-label>
 							<br>
 						{% endif %}
-						<b>{{ _("Amount:") }}</b> {{ output['value']|btcamount }} BTC {% if specter.price_check %}<span class="note">&nbsp;({{ output['value'] | altunit }})</span>{% endif %}
+						{% if specter.is_liquid %}
+							<b>{{ _("Amount:") }}</b> {{ input['float_amount']|btcamount }} <asset-label data-asset="{{input['asset']}}" data-label="{{input['asset'] | assetlabel}}"></asset-label>
+						{% else %}
+							<b>{{ _("Amount:") }}</b> {{ input['float_amount']|btcamount }} BTC {% if specter.price_check %}<span class="note">&nbsp;({{ input['float_amount'] | altunit }})</span>{% endif %}
+						{% endif %}
+					</p>
+				{% endfor %}
+				<h2 class="tx_details_header">{{ _("Outputs") }} ({{psbt['outputs']|length}})</h2>
+				{% for output in psbt['outputs'] %}
+					{% set address = output['address'] %}
+					{% set bg_color = '#154984' if output['is_mine'] else '#131a24' %}
+					<p class="tx_info" style="text-align: left; background-color: {{ bg_color }};">
+						<b>{{ _("Output") }} #{{loop.index0}}</b> {% if output['is_change'] %}(Change){% endif %}<br><br>
+						{% set addr_label = wallet.getlabel(address) %}
+						<b>{{ _("Address:") }}</b>
+						{{ address }}
+						<br>
+						{% if addr_label != address %}
+							<b>{{ _("Label:") }}</b>
+							<address-label data-address="{{ address }}" data-label="{{ addr_label }}" data-wallet="{{ wallet_alias }}"></address-label>
+							<br>
+						{% endif %}
+						{% if specter.is_liquid %}
+							<b>{{ _("Amount:") }}</b> {{ output['float_amount']|btcamount }} <asset-label data-asset="{{output['asset']}}" data-label="{{output['asset'] | assetlabel}}"></asset-label>
+						{% else %}
+							<b>{{ _("Amount:") }}</b> {{ output['float_amount']|btcamount }} BTC {% if specter.price_check %}<span class="note">&nbsp;({{ output['float_amount'] | altunit }})</span>{% endif %}
+						{% endif %}
 					</p>
 				{% endfor %}
 				{{ _("Raw PSBT:") }}<textarea id="raw-psbt" disabled style="background-color: #131a24;">{{ psbt['base64'] | to_canonical }}</textarea>

--- a/src/cryptoadvance/specter/templates/wallet/send/sign/wallet_send_sign_psbt.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/send/sign/wallet_send_sign_psbt.jinja
@@ -201,7 +201,8 @@
 		<div id="signing_container" class="signing_container flex-column {% if psbt['raw'] %}hidden{% endif %}" style="text-align: center;">
 			<p style="margin-bottom: 15px; margin-top: 0px;">{{ _("Sign transaction with your:") }}</p>
 			{% for device in wallet.devices %}
-				<button type="button" class="btn signing-column-btn" id="{{ device.alias }}_tx_sign_btn" {{ 'disabled style=background-color:#303c49;' if device.alias in psbt.get("devices_signed",[]) else '' }}>
+				{% set device_signed = (device.alias in psbt.get("devices_signed")) %}
+				<button type="button" class="btn signing-column-btn" id="{{ device.alias }}_tx_sign_btn" {% if device_signed %} disabled style="background-color:#303c49;" {% endif %}>
 					{{ device.name }} {% if device.alias in psbt.get('devices_signed',[]) %} (&#10004;) {% endif %}
 				</button>
 			{% endfor %}

--- a/src/cryptoadvance/specter/txlist.py
+++ b/src/cryptoadvance/specter/txlist.py
@@ -181,6 +181,18 @@ class TxList(dict):
             write_csv(self.path, list(self.values()), self.ItemCls)
         self._file_exists = True
 
+    def getfetch(self, txid):
+        """
+        Returns TxItem instance if it is known,
+        otherwise tries to get it from rpc, adds to self and returns TxItem
+        """
+        if txid not in self:
+            tx = self.rpc.gettransaction(txid)
+            if "time" not in tx:
+                tx["time"] = tx["timereceived"]
+            self.add({txid: tx})
+        return self[txid]
+
     def gettransaction(self, txid, blockheight=None, decode=False, full=True):
         """
         Will ask Bitcoin Core for a transaction if blockheight is None or txid not known

--- a/src/cryptoadvance/specter/util/psbt.py
+++ b/src/cryptoadvance/specter/util/psbt.py
@@ -3,7 +3,7 @@ The goal of this module is to slowly migrate from json-like representation of PS
 to a normal PSBT class that does not require RPC calls and can do more things.
 to_dict and from_dict methods are maintained for backward-compatibility
 """
-from embit.psbt import PSBT, InputScope, OutputScope
+from embit.psbt import PSBT, InputScope, OutputScope, DerivationPath
 from embit.transaction import Transaction, TransactionOutput
 from embit.liquid.networks import get_network
 from embit import bip32
@@ -339,3 +339,21 @@ class SpecterPSBT:
 
     def __str__(self):
         return str(self.psbt)
+
+    @classmethod
+    def fill_output(cls, out, desc):
+        """
+        Fills derivations and all other information in PSBT output
+        from derived descriptor
+        """
+        if desc.script_pubkey() != out.script_pubkey:
+            return False
+        out.redeem_script = desc.redeem_script()
+        out.witness_script = desc.witness_script()
+        out.bip32_derivations = {
+            key.get_public_key(): DerivationPath(
+                key.origin.fingerprint, key.origin.derivation
+            )
+            for key in desc.keys
+        }
+        return True

--- a/src/cryptoadvance/specter/util/psbt.py
+++ b/src/cryptoadvance/specter/util/psbt.py
@@ -5,210 +5,192 @@ to_dict and from_dict methods are maintained for backward-compatibility
 """
 from embit.psbt import PSBT, InputScope, OutputScope
 from embit.transaction import Transaction, TransactionOutput
-from embit.networks import NETWORKS
+from embit.liquid.networks import get_network
 from embit import bip32
 from math import ceil
 import time
 
 
-class SpecterTx(Transaction):
-    def to_dict(self, network):
-        txid = self.txid().hex()
-        size = len(self.serialize())
+class SpecterTx:
+    def __init__(self, parent, tx):
+        self.parent = parent
+        self.tx = tx
+
+    @property
+    def network(self):
+        return self.parent.network
+
+    def vin_to_dict(self, vin):
         return {
-            "txid": txid,
-            "hash": txid,  # not sure why it's the same
-            "version": self.version,
-            "size": size,
-            "vsize": size,
-            "weight": 4 * size,
-            "locktime": self.locktime,
-            "vin": [
-                {
-                    "txid": vin.txid.hex(),
-                    "vout": vin.vout,
-                    "sequence": vin.sequence,
-                }
-                for vin in self.vin
-            ],
-            "vout": [
-                {
-                    "value": round(1e-8 * vout.value, 8),
-                    "sats": vout.value,
-                    "n": i,
-                    "scriptPubKey": {
-                        "hex": vout.script_pubkey.data.hex(),
-                        "addresses": [vout.script_pubkey.address(network)],
-                    },
-                }
-                for i, vout in enumerate(self.vout)
-            ],
+            "txid": vin.txid.hex(),
+            "vout": vin.vout,
+            "sequence": vin.sequence,
         }
 
-
-class SpecterTxOut(TransactionOutput):
-    def to_dict(self, network):
+    def vout_to_dict(self, vout):
+        i = self.tx.vout.index(vout)
         return {
-            "amount": round(self.value * 1e-8, 8),
-            "sats": self.value,
+            "value": round(1e-8 * vout.value, 8),
+            "sats": vout.value,
+            "n": i,
             "scriptPubKey": {
-                "hex": self.script_pubkey.data.hex(),
-                "addresses": [self.script_pubkey.address(network)],
+                "hex": vout.script_pubkey.data.hex(),
+                "addresses": [vout.script_pubkey.address(self.network)],
             },
         }
 
-
-class SpecterInputScope(InputScope):
-    TX_CLS = SpecterTx
-    TXOUT_CLS = SpecterTxOut
-
-    def __init__(self, *args, **kwargs):
-        self.parent = None
-        super().__init__(*args, **kwargs)
-
-    @property
-    def network(self):
-        if self.parent:
-            return self.parent.network
-        return NETWORKS["main"]
-
-    @property
-    def address(self):
-        return self.script_pubkey.address(self.network)
-
-    @property
-    def float_amount(self):
-        return round(self.utxo.value * 1e-8, 8)
-
-    @property
-    def sat_amount(self):
-        return self.utxo.value
-
-    def to_dict(self, network=None):
-        network = network or self.network
-        obj = {
-            "address": self.address,
-            "float_amount": self.float_amount,
-            "sat_amount": self.utxo.value,
-            "txid": self.txid.hex(),
-            "vout": self.vout,
+    def to_dict(self):
+        txid = self.tx.txid().hex()
+        size = len(self.tx.serialize())
+        return {
+            "txid": txid,
+            "hash": txid,  # not sure why it's the same
+            "version": self.tx.version,
+            "size": size,
+            "vsize": size,
+            "weight": 4 * size,
+            "locktime": self.tx.locktime,
+            "vin": [
+                self.vin_to_dict(vin)
+                for vin in self.tx.vin
+            ],
+            "vout": [
+                self.vout_to_dict(vout)
+                for vout in self.tx.vout
+            ],
         }
-        if self.witness_utxo:
-            obj["witness_utxo"] = self.witness_utxo.to_dict(network)
-        else:
-            obj["non_witness_utxo"] = self.non_witness_utxo.to_dict(network)
-        if self.bip32_derivations:
-            obj["bip32_derivs"] = [
-                {
-                    "pubkey": pub.sec().hex(),
-                    "master_fingerprint": der.fingerprint.hex(),
-                    "path": bip32.path_to_str(der.derivation),
-                }
-                for pub, der in self.bip32_derivations.items()
-            ]
-        return obj
 
 
-class SpecterOutputScope(OutputScope):
-    def __init__(self, *args, **kwargs):
-        self.parent = None
-        super().__init__(*args, **kwargs)
+class SpecterScope:
+    def __init__(self, parent, scope):
+        self.parent = parent
+        self.scope = scope
 
     @property
     def network(self):
-        if self.parent:
-            return self.parent.network
-        return NETWORKS["main"]
+        return self.parent.network
 
     @property
     def descriptor(self):
-        if self.parent:
-            return self.parent.descriptor
-        return None
-
-    @property
-    def is_change(self):
-        if self.descriptor:
-            return self.descriptor.branch(1).owns(self)
-        return False
+        return self.parent.descriptor
 
     @property
     def is_mine(self):
-        if self.descriptor:
-            return self.descriptor.owns(self)
-        return False
+        return self.descriptor.owns(self.scope)
+
+    @property
+    def is_change(self):
+        return self.descriptor.branch(1).owns(self.scope)
+
+    @property
+    def is_receiving(self):
+        return self.is_mine and not self.is_change
 
     @property
     def address(self):
-        return self.script_pubkey.address(self.network)
-
-    @property
-    def float_amount(self):
-        return round(self.value * 1e-8, 8)
+        return self.scope.script_pubkey.address(self.network)
 
     @property
     def sat_amount(self):
-        return self.value
+        """Implement this!"""
+        raise NotImplementedError("Not implemented for this scope")
 
-    def to_dict(self, network):
-        network = network or self.network
+    @property
+    def float_amount(self):
+        return round(self.sat_amount * 1e-8, 8)
+
+    def to_dict(self):
         obj = {
             "address": self.address,
             "float_amount": self.float_amount,
-            "sat_amount": self.value,
+            "sat_amount": self.sat_amount,
             "change": self.is_change,
             "is_mine": self.is_mine,
         }
-        if self.bip32_derivations:
+        if self.scope.bip32_derivations:
             obj["bip32_derivs"] = [
                 {
                     "pubkey": pub.sec().hex(),
                     "master_fingerprint": der.fingerprint.hex(),
                     "path": bip32.path_to_str(der.derivation),
                 }
-                for pub, der in self.bip32_derivations.items()
+                for pub, der in self.scope.bip32_derivations.items()
             ]
         return obj
 
+class SpecterInputScope(SpecterScope):
+    TxCls = SpecterTx
 
-class SpecterPSBT(PSBT):
+    @property
+    def inp(self):
+        return self.scope
+
+    @property
+    def sat_amount(self):
+        return self.scope.utxo.value
+
+    @property
+    def txid(self):
+        return self.scope.txid
+
+    @property
+    def vout(self):
+        return self.scope.vout
+
+    def to_dict(self):
+        obj = super().to_dict()
+        obj.update({
+            "txid": self.scope.txid.hex(),
+            "vout": self.scope.vout,
+        })
+        if self.scope.witness_utxo:
+            obj["witness_utxo"] = {
+                "amount": self.float_amount,
+                "sats": self.sat_amount,
+                "scriptPubKey": {
+                    "hex": self.scope.script_pubkey.data.hex(),
+                    "addresses": [self.address],
+                },
+            }
+        else:
+            obj["non_witness_utxo"] = self.TxCls(self, self.scope.non_witness_utxo)
+        return obj
+
+
+class SpecterOutputScope(SpecterScope):
+
+    @property
+    def out(self):
+        return self.scope
+
+    @property
+    def sat_amount(self):
+        return self.out.value
+
+
+class SpecterPSBT:
     """Specter's PSBT class with some handy functions"""
+    PSBTCls = PSBT
+    InputCls = SpecterInputScope
+    OutputCls = SpecterOutputScope
+    TxCls = SpecterTx
 
-    PSBTIN_CLS = SpecterInputScope
-    PSBTOUT_CLS = SpecterOutputScope
-    TX_CLS = SpecterTx
-
-    def __init__(self, *args, **kwargs):
-        self.descriptor = None
-        self.network = NETWORKS["main"]
-        if "descriptor" in kwargs:
-            self.descriptor = kwargs.pop("descriptor")
-        if "network" in kwargs:
-            self.network = kwargs.pop("network")
-        self.time = time.time()
-        if "time" in kwargs:
-            self.time = kwargs.pop("time")
-        self.signed_devices = []
-        super().__init__(*args, **kwargs)
-
-    @classmethod
-    def from_string(cls, *args, **kwargs):
-        psbt = super(cls, cls).from_string(*args, **kwargs)
-        # set parent to self so we know about descriptor and network
-        for sc in psbt.inputs + psbt.outputs:
-            sc.parent = psbt
-        return psbt
+    def __init__(self,
+        psbt,
+        descriptor,
+        network,
+        **kwargs
+    ):
+        if isinstance(psbt, str):
+            psbt = self.PSBTCls.from_string(psbt)
+        self.psbt = psbt
+        self.descriptor = descriptor
+        self.network = network
+        self.time = kwargs.get("time", time.time())
+        self.devices = kwargs.get("devices", [])
 
     def utxo_dict(self):
-        return [{"txid": inp.txid.hex(), "vout": inp.vout} for inp in self.inputs]
-
-    @classmethod
-    def from_dict(cls, obj, descriptor, chain):
-        psbt = cls.from_string(obj["base64"])
-        psbt.descriptor = descriptor
-        psbt.network = NETWORKS.get(chain, NETWORKS["main"])
-        psbt.time = obj.get("time", time.time())
-        return psbt
+        return [{"txid": inp.txid.hex(), "vout": inp.vout} for inp in self.psbt.inputs]
 
     @property
     def extra_input_weight(self):
@@ -231,20 +213,20 @@ class SpecterPSBT(PSBT):
 
     @property
     def full_size(self):
-        size = len(self.tx.serialize()) * 4
+        size = len(self.psbt.tx.serialize()) * 4
         size += len(self.inputs) * self.extra_input_weight
         return ceil(size / 4)
 
     @property
     def sigs_count(self):
-        # not quite true
-        return max([len(inp.partial_sigs) for inp in self.inputs])
+        # not quite true but ok for most cases
+        return max([len(inp.partial_sigs) for inp in self.psbt.inputs])
 
     @property
     def addresses(self):
         return [
             out.script_pubkey.address(self.network)
-            for out in self.outputs
+            for out in self.psbt.outputs
             if not self.descriptor.owns(out)
         ]
 
@@ -252,24 +234,48 @@ class SpecterPSBT(PSBT):
     def amounts(self):
         return [
             round(out.value * 1e-8, 8)
-            for out in self.outputs
+            for out in self.psbt.outputs
             if not self.descriptor.owns(out)
         ]
 
     @property
     def sats(self):
-        return [out.value for out in self.outputs if not self.descriptor.owns(out)]
+        return [out.value for out in self.psbt.outputs if not self.descriptor.owns(out)]
 
     @property
     def txid(self):
-        return self.tx.txid().hex()
+        return self.psbt.tx.txid().hex()
+
+    def fee(self):
+        return self.psbt.fee()
+
+    @property
+    def inputs(self):
+        return [self.InputCls(self, inp) for inp in self.psbt.inputs]
+
+    @property
+    def outputs(self):
+        return [self.OutputCls(self, out) for out in self.psbt.outputs]
+
+    @property
+    def tx(self):
+        return self.TxCls(self, self.psbt.tx)
+
+    @classmethod
+    def from_dict(cls, obj, descriptor, chain):
+        psbt = cls.PSBTCls.from_string(obj["base64"])
+        network = get_network(chain)
+        kwargs = {}
+        kwargs.update(obj)
+        kwargs.pop("base64")
+        return cls(psbt, descriptor, network, **kwargs)
 
     def to_dict(self):
         return {
-            "tx": self.tx.to_dict(self.network),
-            "inputs": [inp.to_dict(self.network) for inp in self.inputs],
-            "outputs": [out.to_dict(self.network) for out in self.outputs],
-            "base64": str(self),
+            "tx": self.tx.to_dict(),
+            "inputs": [inp.to_dict() for inp in self.inputs],
+            "outputs": [out.to_dict() for out in self.outputs],
+            "base64": str(self.psbt),
             "fee": round(self.fee() * 1e-8, 8),
             "fee_sat": self.fee(),
             "address": self.addresses,
@@ -279,3 +285,11 @@ class SpecterPSBT(PSBT):
             "sigs_count": self.sigs_count,
             "time": self.time,
         }
+
+    @classmethod
+    def from_string(cls, b64psbt):
+        """Returns PSBTCls, not cls"""
+        return cls.PSBTCls.from_string(b64psbt)
+
+    def to_string(self):
+        return str(self.psbt)

--- a/src/cryptoadvance/specter/util/psbt.py
+++ b/src/cryptoadvance/specter/util/psbt.py
@@ -307,20 +307,23 @@ class SpecterPSBT:
         return cls(psbt, descriptor, network, devices=devices, **kwargs)
 
     def to_dict(self):
+        fee = self.fee()
+        full_size = self.full_size
         obj = {
             "tx": self.tx.to_dict(),
             "inputs": [inp.to_dict() for inp in self.inputs],
             "outputs": [out.to_dict() for out in self.outputs],
             "base64": str(self.psbt),
-            "fee": round(self.fee() * 1e-8, 8),
-            "fee_sat": self.fee(),
+            "fee": round(fee * 1e-8, 8),
+            "fee_sat": fee,
             "address": self.addresses,
             "amount": self.amounts,
             "sats": self.sats,
-            "tx_full_size": self.full_size,
+            "tx_full_size": full_size,
             "sigs_count": self.sigs_count,
             "time": self.time,
             "devices_signed": self.get_signed_devices(),
+            "fee_rate": round(fee / full_size, 2),
         }
         if self.raw:
             obj.update({"raw": self.raw.hex()})

--- a/src/cryptoadvance/specter/util/psbt.py
+++ b/src/cryptoadvance/specter/util/psbt.py
@@ -50,14 +50,8 @@ class SpecterTx:
             "vsize": size,
             "weight": 4 * size,
             "locktime": self.tx.locktime,
-            "vin": [
-                self.vin_to_dict(vin)
-                for vin in self.tx.vin
-            ],
-            "vout": [
-                self.vout_to_dict(vout)
-                for vout in self.tx.vout
-            ],
+            "vin": [self.vin_to_dict(vin) for vin in self.tx.vin],
+            "vout": [self.vout_to_dict(vout) for vout in self.tx.vout],
         }
 
 
@@ -118,6 +112,7 @@ class SpecterScope:
             ]
         return obj
 
+
 class SpecterInputScope(SpecterScope):
     TxCls = SpecterTx
 
@@ -139,10 +134,12 @@ class SpecterInputScope(SpecterScope):
 
     def to_dict(self):
         obj = super().to_dict()
-        obj.update({
-            "txid": self.scope.txid.hex(),
-            "vout": self.scope.vout,
-        })
+        obj.update(
+            {
+                "txid": self.scope.txid.hex(),
+                "vout": self.scope.vout,
+            }
+        )
         if self.scope.witness_utxo:
             obj["witness_utxo"] = {
                 "amount": self.float_amount,
@@ -158,7 +155,6 @@ class SpecterInputScope(SpecterScope):
 
 
 class SpecterOutputScope(SpecterScope):
-
     @property
     def out(self):
         return self.scope
@@ -170,17 +166,13 @@ class SpecterOutputScope(SpecterScope):
 
 class SpecterPSBT:
     """Specter's PSBT class with some handy functions"""
+
     PSBTCls = PSBT
     InputCls = SpecterInputScope
     OutputCls = SpecterOutputScope
     TxCls = SpecterTx
 
-    def __init__(self,
-        psbt,
-        descriptor,
-        network,
-        **kwargs
-    ):
+    def __init__(self, psbt, descriptor, network, **kwargs):
         if isinstance(psbt, str):
             psbt = self.PSBTCls.from_string(psbt)
         self.psbt = psbt

--- a/src/cryptoadvance/specter/util/psbt.py
+++ b/src/cryptoadvance/specter/util/psbt.py
@@ -1,7 +1,237 @@
-from embit.psbt import PSBT
+"""
+The goal of this module is to slowly migrate from json-like representation of PSBT received from Bitcoin RPC
+to a normal PSBT class that does not require RPC calls and can do more things.
+to_dict and from_dict methods are maintained for backward-compatibility
+"""
+from embit.psbt import PSBT, InputScope, OutputScope
+from embit.transaction import Transaction, TransactionOutput
+from embit.networks import NETWORKS
+from embit import bip32
+from math import ceil
+import time
+
+
+class SpecterTx(Transaction):
+    def to_dict(self, network):
+        txid = self.txid().hex()
+        size = len(self.serialize())
+        return {
+            "txid": txid,
+            "hash": txid,  # not sure why it's the same
+            "version": self.version,
+            "size": size,
+            "vsize": size,
+            "weight": 4 * size,
+            "locktime": self.locktime,
+            "vin": [
+                {
+                    "txid": vin.txid.hex(),
+                    "vout": vin.vout,
+                    "sequence": vin.sequence,
+                }
+                for vin in self.vin
+            ],
+            "vout": [
+                {
+                    "value": round(1e-8 * vout.value, 8),
+                    "sats": vout.value,
+                    "n": i,
+                    "scriptPubKey": {
+                        "hex": vout.script_pubkey.data.hex(),
+                        "addresses": [vout.script_pubkey.address(network)],
+                    },
+                }
+                for i, vout in enumerate(self.vout)
+            ],
+        }
+
+
+class SpecterTxOut(TransactionOutput):
+    def to_dict(self, network):
+        return {
+            "amount": round(self.value * 1e-8, 8),
+            "sats": self.value,
+            "scriptPubKey": {
+                "hex": self.script_pubkey.data.hex(),
+                "addresses": [self.script_pubkey.address(network)],
+            },
+        }
+
+
+class SpecterInputScope(InputScope):
+    TX_CLS = SpecterTx
+    TXOUT_CLS = SpecterTxOut
+
+    def __init__(self, *args, **kwargs):
+        self.parent = None
+        super().__init__(*args, **kwargs)
+
+    @property
+    def network(self):
+        if self.parent:
+            return self.parent.network
+        return NETWORKS["main"]
+
+    @property
+    def address(self):
+        return self.script_pubkey.address(self.network)
+
+    @property
+    def float_amount(self):
+        return round(self.utxo.value * 1e-8, 8)
+
+    def to_dict(self, network=None):
+        network = network or self.network
+        obj = {
+            "address": self.address,
+            "float_amount": self.float_amount,
+            "sat_amount": self.utxo.value,
+        }
+        if self.witness_utxo:
+            obj["witness_utxo"] = self.witness_utxo.to_dict(network)
+        else:
+            obj["non_witness_utxo"] = self.non_witness_utxo.to_dict(network)
+        if self.bip32_derivations:
+            obj["bip32_derivs"] = [
+                {
+                    "pubkey": pub.sec().hex(),
+                    "master_fingerprint": der.fingerprint.hex(),
+                    "path": bip32.path_to_str(der.derivation),
+                }
+                for pub, der in self.bip32_derivations.items()
+            ]
+        return obj
+
+
+class SpecterOutputScope(OutputScope):
+    def __init__(self, *args, **kwargs):
+        self.parent = None
+        super().__init__(*args, **kwargs)
+
+    @property
+    def network(self):
+        if self.parent:
+            return self.parent.network
+        return NETWORKS["main"]
+
+    @property
+    def address(self):
+        return self.script_pubkey.address(self.network)
+
+    @property
+    def float_amount(self):
+        return round(self.value * 1e-8, 8)
+
+    def to_dict(self, network):
+        network = network or self.network
+        obj = {
+            "address": self.address,
+            "float_amount": self.float_amount,
+            "sat_amount": self.value,
+        }
+        if self.bip32_derivations:
+            obj["bip32_derivs"] = [
+                {
+                    "pubkey": pub.sec().hex(),
+                    "master_fingerprint": der.fingerprint.hex(),
+                    "path": bip32.path_to_str(der.derivation),
+                }
+                for pub, der in self.bip32_derivations.items()
+            ]
+        return obj
 
 
 class SpecterPSBT(PSBT):
     """Specter's PSBT class with some handy functions"""
 
-    pass
+    PSBTIN_CLS = SpecterInputScope
+    PSBTOUT_CLS = SpecterOutputScope
+    TX_CLS = SpecterTx
+
+    def __init__(self, *args, **kwargs):
+        self.descriptor = None
+        self.network = NETWORKS["main"]
+        if "descriptor" in kwargs:
+            self.descriptor = kwargs.pop("descriptor")
+        if "network" in kwargs:
+            self.network = kwargs.pop("network")
+        super().__init__(*args, **kwargs)
+        # set parent to self so we know about descriptor and network
+        for sc in self.inputs + self.outputs:
+            sc.parent = self
+
+    def utxo_dict(self):
+        return [{"txid": inp.txid.hex(), "vout": inp.vout} for inp in self.inputs]
+
+    @classmethod
+    def from_dict(cls, obj, descriptor, chain):
+        psbt = cls.from_string(obj["base64"])
+        psbt.descriptor = descriptor
+        psbt.network = NETWORKS.get(chain, NETWORKS["main"])
+        return psbt
+
+    @property
+    def extra_input_weight(self):
+        redeem_script = self.descriptor.redeem_script()
+        witness_script = self.descriptor.witness_script()
+        weight = 0
+        if redeem_script:
+            weight += len(redeem_script.data) * 4
+        if witness_script:
+            weight += len(witness_script.data)
+            if self.descriptor.is_basic_multisig:
+                threshold = self.descriptor.miniscript.args[0].num
+                num_keys = len(self.descriptor.keys)
+                weight += num_keys * 34
+                weight += threshold * 75
+        else:
+            # pubkey, signature
+            weight += 75 + 34
+        return weight
+
+    @property
+    def full_size(self):
+        size = len(self.tx.serialize()) * 4
+        size += len(self.inputs) * self.extra_input_weight
+        return ceil(size / 4)
+
+    @property
+    def sigs_count(self):
+        # not quite true
+        return max([len(inp.partial_sigs) for inp in self.inputs])
+
+    @property
+    def addresses(self):
+        return [
+            out.script_pubkey.address(self.network)
+            for out in self.outputs
+            if not self.descriptor.owns(out)
+        ]
+
+    @property
+    def amounts(self):
+        return [
+            round(out.value * 1e-8, 8)
+            for out in self.outputs
+            if not self.descriptor.owns(out)
+        ]
+
+    @property
+    def sats(self):
+        return [out.value for out in self.outputs if not self.descriptor.owns(out)]
+
+    def to_dict(self):
+        return {
+            "tx": self.tx.to_dict(self.network),
+            "inputs": [inp.to_dict(self.network) for inp in self.inputs],
+            "outputs": [out.to_dict(self.network) for out in self.outputs],
+            "base64": str(self),
+            "fee": round(self.fee() * 1e-8, 8),
+            "fee_sat": self.fee(),
+            "address": self.addresses,
+            "amount": self.amounts,
+            "sats": self.sats,
+            "tx_full_size": self.full_size,
+            "sigs_count": self.sigs_count,
+            "time": round(time.time(), 6),  # TODO: remove
+        }

--- a/src/cryptoadvance/specter/util/psbt.py
+++ b/src/cryptoadvance/specter/util/psbt.py
@@ -187,6 +187,8 @@ class SpecterPSBT:
     def update(self, b64psbt, raw=None):
         if raw and "hex" in raw:
             self.raw = bytes.fromhex(raw["hex"])
+        if not b64psbt:
+            return
         psbt = self.PSBTCls.from_string(b64psbt)
         for inp1, inp2 in zip(self.psbt.inputs, psbt.inputs):
             inp1.update(inp2)

--- a/src/cryptoadvance/specter/util/psbt.py
+++ b/src/cryptoadvance/specter/util/psbt.py
@@ -224,6 +224,14 @@ class SpecterPSBT:
         return ceil(size / 4)
 
     @property
+    def fee(self):
+        return self.psbt.fee()
+
+    @property
+    def fee_rate(self):
+        return self.fee / self.full_size
+
+    @property
     def threshold(self):
         if self.descriptor.is_basic_multisig:
             return self.descriptor.miniscript.args[0].num
@@ -260,9 +268,6 @@ class SpecterPSBT:
     @property
     def txid(self):
         return self.psbt.tx.txid().hex()
-
-    def fee(self):
-        return self.psbt.fee()
 
     @property
     def inputs(self):
@@ -307,7 +312,7 @@ class SpecterPSBT:
         return cls(psbt, descriptor, network, devices=devices, **kwargs)
 
     def to_dict(self):
-        fee = self.fee()
+        fee = self.fee
         full_size = self.full_size
         obj = {
             "tx": self.tx.to_dict(),

--- a/src/cryptoadvance/specter/util/psbt.py
+++ b/src/cryptoadvance/specter/util/psbt.py
@@ -1,0 +1,7 @@
+from embit.psbt import PSBT
+
+
+class SpecterPSBT(PSBT):
+    """Specter's PSBT class with some handy functions"""
+
+    pass

--- a/src/cryptoadvance/specter/util/psbt_creator.py
+++ b/src/cryptoadvance/specter/util/psbt_creator.py
@@ -257,9 +257,13 @@ class PsbtCreator:
         rbf = bool(request_form.get("rbf", False))
         # workaround for making the tests work with a dict
         if hasattr(request_form, "getlist"):
-            selected_coins = request_form.getlist("coinselect")
+            coins = [coin.split(",") for coin in request_form.getlist("coinselect")]
+            # convert to tuples
+            selected_coins = [
+                {"txid": txid.strip(), "vout": int(vout)} for txid, vout in coins
+            ]
         else:
-            selected_coins = None
+            selected_coins = []
         rbf_tx_id = request_form.get("rbf_tx_id", "")
         kwargs = {
             "subtract": subtract,
@@ -267,8 +271,8 @@ class PsbtCreator:
             "fee_rate": fee_rate,
             "rbf": rbf,
             "selected_coins": selected_coins,
-            "readonly": "estimate_fee"
-            in request_form,  # determines whether the psbt gets persisted
+            # determines whether the psbt gets persisted
+            "readonly": "estimate_fee" in request_form,
             "rbf_edit_mode": (rbf_tx_id != ""),
         }
         return kwargs

--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -1957,7 +1957,7 @@ class Wallet:
         addresses_info = []
 
         addresses_cache = [
-            v for _, v in self._addresses.items() if v.change == is_change
+            v for _, v in self._addresses.items() if v.change == is_change and v.is_mine
         ]
 
         for addr in addresses_cache:

--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -1808,7 +1808,9 @@ class Wallet:
         psbt = self.psbt_from_txid(txid)
         fee_delta = fee_rate * psbt.full_size - psbt.fee
         if fee_delta < self.MIN_FEE_RATE * psbt.full_size:
-            raise SpecterError("Fee difference is too small to relay the RBF transaction")
+            raise SpecterError(
+                "Fee difference is too small to relay the RBF transaction"
+            )
         # find change output
         change_index = None
         for i, out in enumerate(psbt.outputs):

--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -1808,7 +1808,7 @@ class Wallet:
         psbt = self.psbt_from_txid(txid)
         fee_delta = fee_rate * psbt.full_size - psbt.fee
         if fee_delta < self.MIN_FEE_RATE * psbt.full_size:
-            raise SpecterError("Fee difference is too small to relay the fee")
+            raise SpecterError("Fee difference is too small to relay the RBF transaction")
         # find change output
         change_index = None
         for i, out in enumerate(psbt.outputs):

--- a/tests/elements_gitrev_pinned
+++ b/tests/elements_gitrev_pinned
@@ -1,0 +1,1 @@
+elements-0.21.0_rc1

--- a/tests/elements_gitrev_pinned
+++ b/tests/elements_gitrev_pinned
@@ -1,1 +1,0 @@
-elements-0.21.0_rc1

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -55,7 +55,7 @@ def test_rr_psbt_get(client, caplog):
     )
     assert result.status_code == 200
     data = json.loads(result.data)
-    assert data["result"] == []
+    assert data["result"] == {}
 
 
 def test_rr_psbt_post(specter_regtest_configured, client, caplog):
@@ -125,7 +125,7 @@ def test_rr_psbt_post(specter_regtest_configured, client, caplog):
     assert data["result"]["tx"]
     assert data["result"]["inputs"]
     assert data["result"]["outputs"]
-    assert data["result"]["fee_rate"] == "0.00064000"
+    assert data["result"]["fee_rate"] == 64
     assert data["result"]["tx_full_size"]
     assert data["result"]["base64"]
     assert data["result"]["time"]

--- a/tests/test_util_psbt_creator.py
+++ b/tests/test_util_psbt_creator.py
@@ -52,7 +52,7 @@ def test_PsbtCreator_ui(caplog):
         "rbf": True,
         "rbf_edit_mode": False,
         "readonly": False,
-        "selected_coins": None,
+        "selected_coins": [],
         "subtract": False,
         "subtract_from": 0,
     }
@@ -107,7 +107,7 @@ bcrt1q3kfetuxpxvujasww6xas94nawklvpz0e52uw8a, 0.5
         "rbf": True,
         "rbf_edit_mode": False,
         "readonly": False,
-        "selected_coins": None,
+        "selected_coins": [],
         "subtract": False,
         "subtract_from": 0,
     }

--- a/tests/test_util_wallet_importer.py
+++ b/tests/test_util_wallet_importer.py
@@ -39,7 +39,9 @@ def test_WalletImporter_unit():
         {"label": "MyTestTrezor", "type": "trezor"},
     ]
     # The descriptor (very briefly)
-    assert wallet_importer.descriptor.origin_fingerprint == ["fb7c1f11", "1ef4e492"]
+    assert [
+        key.origin.fingerprint.hex() for key in wallet_importer.descriptor.keys
+    ] == ["fb7c1f11", "1ef4e492"]
     assert len(wallet_importer.keys) == 0
     assert len(wallet_importer.cosigners) == 0
     assert len(wallet_importer.unknown_cosigners) == 2

--- a/tests/test_wallet_manager.py
+++ b/tests/test_wallet_manager.py
@@ -142,9 +142,8 @@ def test_wallet_createpsbt(docker, request, devices_filled_data_folder, device_m
         unspents = wallet.rpc.listunspent(0)
         # Lets take 3 more or less random txs from the unspents:
         selected_coins = [
-            "{},{}".format(unspents[5]["txid"], unspents[5]["vout"]),
-            "{},{}".format(unspents[9]["txid"], unspents[9]["vout"]),
-            "{},{}".format(unspents[12]["txid"], unspents[12]["vout"]),
+            {"txid": u["txid"], "vout": u["vout"]}
+            for u in [unspents[5], unspents[9], unspents[12]]
         ]
         selected_coins_amount_sum = (
             unspents[5]["amount"] + unspents[9]["amount"] + unspents[12]["amount"]
@@ -163,7 +162,7 @@ def test_wallet_createpsbt(docker, request, devices_filled_data_folder, device_m
         assert len(psbt["tx"]["vin"]) == 3
         psbt_txs = [tx["txid"] for tx in psbt["tx"]["vin"]]
         for coin in selected_coins:
-            assert coin.split(",")[0] in psbt_txs
+            assert coin["txid"] in psbt_txs
 
         # Now let's spend more coins than we have selected. This should result in an exception:
         try:


### PR DESCRIPTION
This PR makes a lot of changes in the wallets logic.
The most noticeable changes:
- now internally wallets use combined Embit descriptor. It simplifies address derivation and PSBT parsing
- PSBT decoding is done internally using `util.psbt.SpecterPSBT` and `liquid.util.pset.SpecterPSET` classes - they are independent of the PSBT version, can detect which outputs or inputs belong to wallet etc.
- Refactors RBF logic
- Simplifies PSBT creation logic

Other changes:
- If Bitcoin Core is compiles without SQLite support we fall back to BDB wallets (before Specter was failing)
- Locktime for new transactions is set to current blockchain height

Liquid-related changes:
- Wallet import/export now works
- PSBT import/export now works
- Added SIGHASH_RANGEPROOF for elements hot wallet
- Added check for dynafed activation (either to use SIGHASH_RANGEPROOF or not)

Close https://github.com/cryptoadvance/specter-desktop/issues/1394
Close https://github.com/cryptoadvance/specter-desktop/issues/1367
Close https://github.com/cryptoadvance/specter-desktop/issues/1241
Close https://github.com/cryptoadvance/specter-desktop/issues/1101
