### PR TITLE
fix rbf-edit with multiple destinations

### DIFF
--- a/src/cryptoadvance/specter/server_endpoints/wallets.py
+++ b/src/cryptoadvance/specter/server_endpoints/wallets.py
@@ -568,6 +568,12 @@ def send_new(wallet_alias):
                 decoded_tx = wallet.decode_tx(rbf_tx_id)
                 addresses = decoded_tx["addresses"]
                 amounts = decoded_tx["amounts"]
+                amount_units = decoded_tx.get("assets", ["btc"]*len(addresses))
+                # get_label returns a label or address if no label is set
+                labels = [wallet.getlabel(addr) for addr in addresses]
+                # set empty label to addresses that don't have labels
+                labels = [label if label != addr else "" for addr, label in zip(addresses, labels)]
+
                 selected_coins = [
                     f"{utxo['txid']}, {utxo['vout']}"
                     for utxo in decoded_tx["used_utxo"]


### PR DESCRIPTION
Close https://github.com/cryptoadvance/specter-desktop/issues/1160

Steps to reproduce:
- create tx with multiple recepients, sign and broadcast
- try to do full RBF edit (speed up - advanced - edit transaction)