### PR TITLE
Feature: a framework for migrations

### DIFF
--- a/src/cryptoadvance/specter/migrations/migration_0000.py
+++ b/src/cryptoadvance/specter/migrations/migration_0000.py
@@ -1,0 +1,19 @@
+import logging
+from ..specter_migrator import SpecterMigration
+
+logger = logging.getLogger(__name__)
+
+
+class SpecterMigration_0000(SpecterMigration):
+    # the version that the stuff which is suppose to be migrated has been introduced
+    # If this instance has been started AFTER this version, then this migration will never
+    # get executed ( see the default-implementation of SpecterMigration.should_execute())
+    version = "v1.5.0"
+
+    def __init__(self, specter_migrator):
+        self.specter_migrator = specter_migrator
+
+    def execute(self):
+        logger.debug(
+            f"migration_0000 is an example method showing how to implement a migration"
+        )

--- a/src/cryptoadvance/specter/migrations/migration_0001.py
+++ b/src/cryptoadvance/specter/migrations/migration_0001.py
@@ -1,0 +1,85 @@
+import logging
+import os
+import shutil
+
+from cryptoadvance.specter.specter_error import SpecterError
+from ..specter_migrator import SpecterMigration
+from ..managers.node_manager import NodeManager
+
+logger = logging.getLogger(__name__)
+
+
+class SpecterMigration_0001(SpecterMigration):
+    version = "v1.6.1"  # the version this migration has been rolled out
+
+    def execute(self):
+        source_folder = os.path.join(self.data_folder, ".bitcoin")
+        if not os.path.isdir(source_folder):
+            logger.info(
+                "No .bitcoin directory found in {self.data_folder}. Nothing to do"
+            )
+            return
+        if not os.path.isdir(os.path.join(self.data_folder, "bitcoin-binaries")):
+            raise SpecterError(
+                "Could not proceed with migration as bitcoin-binaries are not existing."
+            )
+        # potentially we could dynamically figure out which version it is but 1.3.1 used:
+        bitcoin_version = "0.21.0"
+        logger.info(".bitcoin directory detected in {self.data_folder}. Migrating ...")
+        recommended_name = self._find_appropriate_name()
+        target_folder = os.path.join(self.data_folder, "nodes", recommended_name)
+        logger.info(f"Migrating to folder {target_folder}")
+        os.makedirs(target_folder)
+        logger.info(f"Moving .bitcoin to folder {target_folder}")
+        shutil.move(source_folder, os.path.join(target_folder, ".bitcoin-main"))
+        if os.path.isdir(os.path.join(source_folder, "bitcoin.conf")):
+            logger.info("Removing bitcoin.conf file")
+            os.remove(os.path.join(source_folder, "bitcoin.conf"))
+        definition_file = os.path.join(target_folder, "specter_bitcoin.json")
+        logger.info(f"Creating {definition_file}")
+        nm = NodeManager(
+            data_folder=os.path.join(self.data_folder, "nodes"),
+            bitcoind_path=os.path.join(
+                self.data_folder, "bitcoin-binaries", "bin", "bitcoind"
+            ),
+            internal_bitcoind_version=bitcoin_version,
+        )
+        node = nm.add_internal_node(recommended_name)
+
+        #         {
+        #     "name": "Specter Bitcoin",
+        #     "alias": "specter_bitcoin",
+        #     "autodetect": false,
+        #     "datadir": "/home/kim/.specter/nodes/specter_bitcoin/.bitcoin-main",
+        #     "user": "bitcoin",
+        #     "password": "3ah0yc-2dDEwUSqHuuZi-w",
+        #     "port": 8332,
+        #     "host": "localhost",
+        #     "protocol": "http",
+        #     "external_node": false,
+        #     "fullpath": "/home/kim/.specter/nodes/specter_bitcoin.json",
+        #     "bitcoind_path": "/home/kim/.specter/bitcoin-binaries/bin/bitcoind",
+        #     "bitcoind_network": "main",
+        #     "version": "0.21.1"
+        # }
+
+        logger.debug(
+            f"migration_0000 is an example method showing how to implement a migration"
+        )
+
+    def _find_appropriate_name(self):
+        if not os.path.isdir(os.path.join(self.data_folder, "nodes")):
+            return "specter_bitcoin"
+        if not os.path.isdir(
+            os.path.join(self.data_folder, "nodes", "specter_bitcoin")
+        ):
+            return "specter_bitcoin"
+        # Hmm, now it gets a bit trieckier
+        if not os.path.isdir(
+            os.path.join(self.data_folder, "nodes", "specter_migrated")
+        ):
+            return "specter_migrated"
+        # Now it's getting fishy
+        raise SpecterError(
+            "I found a node called 'specter_migrated'. This migration script should not run twice."
+        )

--- a/src/cryptoadvance/specter/server.py
+++ b/src/cryptoadvance/specter/server.py
@@ -18,7 +18,7 @@ from .specter import Specter
 from .hwi_server import hwi_server
 from .user import User
 from .util.version import VersionChecker
-
+from .specter_migrator import SpecterMigrator
 from werkzeug.middleware.proxy_fix import ProxyFix
 from jinja2 import select_autoescape
 
@@ -104,6 +104,10 @@ def create_app(config=None):
 
 def init_app(app, hwibridge=False, specter=None):
     """see blogpost 19nd Feb 2020"""
+    # First: Migrations
+    mm = SpecterMigrator(app.config["SPECTER_DATA_FOLDER"])
+    mm.execute_migrations()
+
     # Login via Flask-Login
     app.logger.info("Initializing LoginManager")
     app.secret_key = app.config["SECRET_KEY"]
@@ -118,11 +122,6 @@ def init_app(app, hwibridge=False, specter=None):
             config=app.config["DEFAULT_SPECTER_CONFIG"],
             internal_bitcoind_version=app.config["INTERNAL_BITCOIND_VERSION"],
         )
-
-    # version checker
-    # checks for new versions once per hour
-    specter.version = VersionChecker(specter=specter)
-    specter.version.start()
 
     login_manager = LoginManager()
     login_manager.session_protection = "strong"

--- a/src/cryptoadvance/specter/specter.py
+++ b/src/cryptoadvance/specter/specter.py
@@ -41,6 +41,7 @@ from .specter_error import ExtProcTimeoutException, SpecterError
 from .tor_daemon import TorDaemonController
 from .user import User
 from .util.checker import Checker
+from .util.version import VersionChecker
 from .util.price_providers import update_price
 from .util.setup_states import SETUP_STATES
 from .util.tor import get_tor_daemon_suffix
@@ -65,6 +66,11 @@ class Specter:
             os.makedirs(data_folder)
 
         self.data_folder = data_folder
+
+        # version checker
+        # checks for new versions once per hour
+        self.version = VersionChecker(specter=self)
+        self.version.start()
 
         self.user_manager = UserManager(self)
 

--- a/src/cryptoadvance/specter/specter_migrator.py
+++ b/src/cryptoadvance/specter/specter_migrator.py
@@ -1,0 +1,213 @@
+""" The migrationManager handles all things necessary migrating from one specter version to another.
+    It uses patterns from DB-migration-frameworks like flask-migrate and the like.
+    The idea is to keep adding migration scripts to the SpecterMigrator and they are executed exactly
+    once. In order to keep track of that, the SpecterMigrator uses a MigDataManager which stores
+    events and migration_executions in a file called migration_data.json.
+    * Events are purely informational and only for troubleshooting purposes.
+    * migration_executions simply keeps track of which scrips has been executed.
+
+"""
+import inspect
+import logging
+import os
+from datetime import datetime
+from importlib import import_module
+from inspect import isclass
+from pathlib import Path
+from pkgutil import iter_modules
+
+from cryptoadvance import specter
+
+from .managers.genericdata_manager import GenericDataManager
+from .specter_error import SpecterError
+from .util.version import VersionChecker, compare
+
+logger = logging.getLogger(__name__)
+
+
+class SpecterMigration:
+    """All Migrations should derive from this class. In order to create one, have a look at
+    the example in the migrations directory.
+    """
+
+    version = "custom"  # the version this has been introduced
+
+    def __init__(self, specter_migrator):
+        self.specter_migrator = specter_migrator
+        self.data_folder = specter_migrator.data_folder
+
+    def should_execute(self):
+        """You can override this to prevent execution for specific cases"""
+        version_first_started = self.specter_migrator.mig.first_event["version"]
+        # We need to compare the version we have been started first with the version this migration
+        # is suppose to migrate.
+        # If version_first_started > self.version we don't need to execute this migration and will return False
+        # Should we import semver? Ok, let's minimize dependencies and do it ourself here
+        try:
+            compare_version = compare(version_first_started, self.version)
+        except SpecterError:
+            # if in doubt because versions are unparsable, execute!
+            return True
+        if compare_version == 1:
+            return True
+        elif compare_version == -1:
+            return False
+        elif compare_version == 0:
+            return False
+
+    def execute(self):
+        logger.debug(
+            f"migration_0000 is an example method showing how to implement a migration"
+        )
+
+
+class MigDataManager(GenericDataManager):
+    """A class handling the data for the SpecterMigrator in migration_data.json with some convenience-methods"""
+
+    initial_data = {
+        "events": [],  # contains elements like {"timestamp": someTimestamp, "version": "v1.5.0"}
+        "migration_executions": [],  # contains elements like {"timestamp": someTimestamp, "migration_no": 0}
+    }
+    name_of_json_file = "migration_data.json"
+
+    def __init__(self, data_folder):
+        # creating folders if they don't exist
+        # Usually Specter is doing that but in the case of tests, we're instantiated before Specter
+        if not os.path.isdir(data_folder):
+            os.makedirs(data_folder)
+        super().__init__(data_folder)
+
+    @property
+    def events(self):
+        """A list of events where one event represents the initial use of a new specter-version which is a different
+        version than the one used before. Looks like: {"timestamp": someTimestamp, "version": "v1.5.0"}
+        """
+        return self.data["events"]
+
+    @property
+    def latest_event(self):
+        if self.events:
+            return self.events[-1]
+        return {"timestamp": None, "version": None}
+
+    @property
+    def first_event(self):
+        """Effectively the binary version the data has been created with FIRST"""
+        if self.events:
+            return self.events[0]
+        raise SpecterError("You should not check the first_event before you've set it!")
+
+    def create_new_event(self, version):
+        self.events.append({"timestamp": str(datetime.now()), "version": version})
+        self._save()
+
+    def create_new_execution_log(self, migration_no):
+        self.migration_executions.append(
+            {
+                "timestamp": str(datetime.now()),
+                "migration_no": migration_no,
+                "status": "started",
+            }
+        )
+        self._save()
+
+    def set_execution_log_status(self, number, status):
+        self._find_exec_log(number)["status"] = status
+        self._save()
+
+    def set_Execution_log_error_msg(self, number, msg):
+        self._find_exec_log(number)["error_msg"] = msg
+        self._save()
+
+    def _find_exec_log(self, number):
+        for migration in self.migration_executions:
+            if migration["migration_no"] == number:
+                return migration
+        raise SpecterError(f"Can't find migration_execution with number {number}")
+
+    @property
+    def migration_executions(self):
+        return self.data["migration_executions"]
+
+    def has_migration_executed(self, migration_no):
+        executed_list = [
+            migration_execution["migration_no"]
+            for migration_execution in self.migration_executions
+        ]
+        logger.debug(f"Executed migration_function numbers: {executed_list}")
+        return migration_no in executed_list
+
+
+class SpecterMigrator:
+    """A Class managing Migrations. Not calling it managers, as this is reserved for Instances attached to the specter instance"""
+
+    def __init__(self, data_folder):
+        version = VersionChecker(specter=self)
+        self.current_binary_version = version.current
+        self.current_data_version = "unknown"
+        self.data_folder = data_folder
+        self.mig = MigDataManager(data_folder)
+        if self.mig.latest_event["version"] != self.current_binary_version:
+            logger.info(
+                f"New version executing right now: {self.current_binary_version}"
+            )
+            self.mig.create_new_event(self.current_binary_version)
+            self.mig._save()
+
+    def plan_migration(self):
+        """Returns a list of instances from all the migration_1234-classes which hasn't been
+        executed yet (according to migration_data.json)
+        """
+        migration_function_list = []
+        # The path where all the migrations are located:
+        package_dir = str(Path(Path(__file__).resolve().parent, "migrations").resolve())
+        for (_, module_name, _) in iter_modules(
+            [package_dir]
+        ):  # import the module and iterate through its attributes
+            module = import_module(f"cryptoadvance.specter.migrations.{module_name}")
+            for attribute_name in dir(module):
+                attribute = getattr(module, attribute_name)
+                if isclass(attribute):
+                    if (
+                        issubclass(attribute, SpecterMigration)
+                        and not attribute.__name__ == "SpecterMigration"
+                    ):
+                        migration_obj = attribute(self)
+                        if self.needs_execution(migration_obj):
+                            logger.debug(
+                                f"Adding class {attribute.__name__} to list of planned migrations"
+                            )
+                            migration_function_list.append(migration_obj)
+        return migration_function_list
+
+    def execute_migrations(self, migration_object_list=None):
+        if migration_object_list == None:
+            migration_object_list = self.plan_migration()
+        for object in migration_object_list:
+            exec_id = SpecterMigrator.calculate_number(object)
+            try:
+                logger.info(f"  --> Starting Migration {object.__class__.__name__}")
+                self.mig.create_new_execution_log(exec_id)
+                object.execute()
+                logger.info(f"  --> Completed Migration {object.__class__.__name__}")
+                self.mig.set_execution_log_status(exec_id, "completed")
+            except Exception as e:
+                logger.error(f"  --> Error in Migration {object.__class__.__name__}")
+                logger.exception(e)
+                self.mig.set_execution_log_status(exec_id, "error")
+                self.mig.set_Execution_log_error_msg(exec_id, str(e))
+
+    @classmethod
+    def calculate_number(cls, migration_obj):
+        """Extract the number from ojects derived from classes like SpecterMigration_0123"""
+        prefix, number = migration_obj.__class__.__name__.split("_")
+        assert prefix == "SpecterMigration"
+        return int(number)
+
+    def needs_execution(self, migration_obj: SpecterMigration):
+        """returns true if the migrate_function hasn't been executed yet"""
+        migration_no = SpecterMigrator.calculate_number(migration_obj)
+        return (
+            not self.mig.has_migration_executed(migration_no)
+            and migration_obj.should_execute()
+        )

--- a/src/cryptoadvance/specter/util/version.py
+++ b/src/cryptoadvance/specter/util/version.py
@@ -8,6 +8,8 @@ import os
 import requests
 import importlib_metadata
 
+from cryptoadvance.specter.specter_error import SpecterError
+
 logger = logging.getLogger(__name__)
 
 
@@ -151,3 +153,53 @@ class VersionChecker:
         else:
             self.stop()
         return current, latest, False
+
+
+def compare(version1: str, version2: str) -> int:
+    """Compares two version strings like v1.5.1 and v1.6.0 and returns
+    * 1 : version2 is bigger that version1
+    * -1 : version1 is bigger than version2
+    * 0 : both are the same
+    This is not supporting semver and it doesn't take any postfix (-pre5)
+    into account and is therefore a naive implementation
+    """
+    version1 = _parse_version(version1)
+    version2 = _parse_version(version2)
+
+    if version1["postfix"] != "" or version2["postfix"] != "":
+        raise SpecterError(
+            f"Cannot compare if either version has a postfix : {version1} and {version2}"
+        )
+    if version1["major"] > version2["major"]:
+        return -1
+    elif version1["major"] < version2["major"]:
+        return 1
+    if version1["minor"] > version2["minor"]:
+        return -1
+    elif version1["minor"] < version2["minor"]:
+        return 1
+    if version1["patch"] > version2["patch"]:
+        return -1
+    elif version1["patch"] < version2["patch"]:
+        return 1
+    return 0
+
+
+def _parse_version(version: str) -> dict:
+    """Parses version-strings like v1.5.6-pre5 and returns a dict"""
+    if version[0] != "v":
+        raise SpecterError(f"version {version} does not have a preceding 'v'")
+    version = version[1:]
+    version_ar = version.split(".")
+    if len(version_ar) != 3:
+        raise SpecterError(f"version {version} does not have 3 separated digits")
+    postfix = ""
+    if "-" in version_ar[2]:
+        postfix = version_ar[2].split("-")[1]
+        version_ar[2] = version_ar[2].split("-")[0]
+    return {
+        "major": int(version_ar[0]),
+        "minor": int(version_ar[1]),
+        "patch": int(version_ar[2]),
+        "postfix": postfix,
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ from cryptoadvance.specter.specter import Specter
 from cryptoadvance.specter.user import User
 from cryptoadvance.specter.util.wallet_importer import WalletImporter
 from cryptoadvance.specter.util.common import str2bool
+from cryptoadvance.specter.util.shell import which
 import code, traceback, signal
 
 pytest_plugins = ["ghost_machine"]
@@ -154,6 +155,16 @@ def instantiate_elementsd_controller(request, rpcport=18643, extra_args=[]):
         % (running_version, requested_version)
     )
     return elementsd_controller
+
+
+@pytest.fixture(scope="session")
+def bitcoind_path():
+    if os.path.isfile("tests/bitcoin/src/bitcoind"):
+        return "tests/bitcoin/src/bitcoind"
+    elif os.path.isfile("tests/bitcoin/bin/bitcoind"):
+        return "tests/bitcoin/bin/bitcoind"
+    else:
+        return which("bitcoind")
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_managers_node.py
+++ b/tests/test_managers_node.py
@@ -1,5 +1,8 @@
 from enum import auto
 import tempfile
+import time
+import tarfile
+import os
 
 import pytest
 from cryptoadvance.specter.managers.node_manager import NodeManager
@@ -46,3 +49,46 @@ def test_NodeManager(
         assert nm.nodes_names == ["Bitcoin Core", "bitcoin_regtest", "elements_elreg"]
         nm.switch_node("elements_elreg")
         assert nm.active_node.get_rpc().getblockchaininfo()["chain"] == "elreg"
+        time.sleep(20)
+
+
+def test_NodeManager_import(bitcoind_path):
+    with tempfile.TemporaryDirectory("_some_datafolder_tmp") as data_folder:
+        print(f"data_folder={data_folder}")
+        nm = NodeManager(data_folder=data_folder, bitcoind_path=bitcoind_path)
+        print(os.getcwd())
+        # This .bitcoin folder doesn't have a config-file
+        btc_tar = tarfile.open(
+            "./tests/helpers_testdata/bitcoin_minimum_mainnet_datadir.tgz", "r:gz"
+        )
+        btc_tar.extractall(os.path.join(data_folder, "somename", ".bitcoin-main"))
+        #         # ... so let's create one
+        #         with open(
+        #             os.path.join(data_folder,"somename",".bitcoin-main","bitcoin.conf"),
+        #             "w+",
+        #         ) as file:
+        #             file.write('''
+        # rpcauth=bitcoin:044931c1d498b7c27080d8b981331a65$6ee7929513401c39ca1f7e376e55553c52dcb36a14e8410ac5f514fbf18bedbb
+        # server=1
+        # listen=1
+        # proxy=127.0.0.1:9050
+        # bind=127.0.0.1
+        # torcontrol=127.0.0.1:9051
+        # torpassword=gVzREfuHso6U2OfRRvqT3w
+        # fallbackfee=0.0002
+        # prune=1000
+        #             '''
+        #             )
+
+        node = nm.add_internal_node(
+            "somename",
+        )
+        try:
+            node.start()
+            time.sleep(5)
+            # assert node.get_rpc().password == None
+            nm.switch_node("somename")
+            time.sleep(5)
+            assert nm.active_node.get_rpc().getblockchaininfo()["chain"] == "main"
+        finally:
+            node.stop()

--- a/tests/test_specter_migrator.py
+++ b/tests/test_specter_migrator.py
@@ -1,0 +1,56 @@
+import logging
+import json
+import os
+import tarfile
+import time
+
+from cryptoadvance.specter.specter_migrator import SpecterMigrator
+
+logger = logging.getLogger(__name__)
+
+
+def test_SpecterMigrator(empty_data_folder, caplog):
+    caplog.set_level(logging.DEBUG)
+    # For migration1
+    btc_tar = tarfile.open(
+        "./tests/helpers_testdata/bitcoin_minimum_mainnet_datadir.tgz", "r:gz"
+    )
+    btc_tar.extractall(os.path.join(empty_data_folder, ".bitcoin"))
+    # Fake the existence of bitcoin-binaries
+    os.makedirs(os.path.join(empty_data_folder, "bitcoin-binaries"))
+
+    mm = SpecterMigrator(empty_data_folder)
+    # With instantiation, the event get stored just right away
+    assert mm.mig.latest_event["version"] == "custom"
+    mylist = mm.plan_migration()
+    # This assertion will break every time you create a new migration-script
+    assert len(mylist) == 2
+
+    mm.execute_migrations(mylist)
+    assert len(mm.mig.migration_executions) == 2
+
+    assert mm.mig.migration_executions[0]["migration_no"] == 0
+    # Nothing to test here
+
+    assert mm.mig.migration_executions[1]["migration_no"] == 1
+    assert os.path.isdir(
+        os.path.join(
+            empty_data_folder, "nodes", "specter_bitcoin", ".bitcoin-main", "chainstate"
+        )
+    )
+    specter_bitcoin_json = os.path.join(
+        empty_data_folder, "nodes", "specter_bitcoin.json"
+    )
+    assert os.path.isfile(specter_bitcoin_json)
+    with open(specter_bitcoin_json) as jsonfile:
+        config = json.loads(jsonfile.read())
+    assert config["name"] == "specter_bitcoin"
+    assert config["alias"] == "specter_bitcoin"
+    assert config["autodetect"] == False
+    assert config["datadir"].endswith("nodes/specter_bitcoin/.bitcoin-main")
+    assert config["user"] == "bitcoin"
+    assert config["password"]
+    assert config["port"] == 8332
+    assert config["host"] == "localhost"
+    assert config["external_node"] == False
+    # yeah, some more but should be ok

--- a/tests/test_util_version.py
+++ b/tests/test_util_version.py
@@ -1,0 +1,38 @@
+import pytest
+from cryptoadvance.specter.specter_error import SpecterError
+from cryptoadvance.specter.util.version import _parse_version, compare
+
+
+def test_parse_version():
+    assert _parse_version("v1.5.9") == {
+        "major": 1,
+        "minor": 5,
+        "patch": 9,
+        "postfix": "",
+    }
+    assert _parse_version("v3.4.5-pre12") == {
+        "major": 3,
+        "minor": 4,
+        "patch": 5,
+        "postfix": "pre12",
+    }
+    with pytest.raises(SpecterError):
+        _parse_version("3.4.5-pre12")
+    with pytest.raises(SpecterError):
+        _parse_version("3.4.5.6-pre12")
+
+
+def test_compare():
+    assert compare("v1.2.3", "v2.2.3") == 1
+    assert compare("v2.2.3", "v1.2.3") == -1
+
+    assert compare("v2.1.3", "v2.2.3") == 1
+    assert compare("v2.2.3", "v1.1.3") == -1
+
+    assert compare("v2.2.3", "v2.2.5") == 1
+    assert compare("v2.2.5", "v2.2.2") == -1
+
+    assert compare("v2.2.5", "v2.2.5") == 0
+
+    with pytest.raises(SpecterError):
+        assert compare("v2.2.3-pre2", "v1.2.3") == -1


### PR DESCRIPTION
We did not yet put enough attention on changes on the data-layer or the organisations of files in the .specter-folder
So this PR includes a framework for migrations and two examples where the second one is a real example migrating the single-bitcoind-instance implemented in v.1.3.0 to a multiple-instance.
