### PR TITLE
Auto privacy settings

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -94,7 +94,7 @@ Run the server:
 
 ```sh
 cd specter-desktop
-python3 -m cryptoadvance.specter server --config DevelopmentConfig
+export FLASK_ENV=development && python3 -m cryptoadvance.specter server --config DevelopmentConfig
 ```
 
 #### If `pip install` fails on `cryptography==3.4.x`

--- a/src/cryptoadvance/specter/managers/config_manager.py
+++ b/src/cryptoadvance/specter/managers/config_manager.py
@@ -66,6 +66,8 @@ class ConfigManager(GenericDataManager):
             "fee_estimator": "mempool",
             "fee_estimator_custom_url": "",
             "hide_sensitive_info": False,
+            "autohide_sensitive_info_timeout_minutes": 10,
+            "autologout_timeout_hours": 4,
             # TODO: remove
             "bitcoind": False,
         }
@@ -267,6 +269,28 @@ class ConfigManager(GenericDataManager):
             self._save()
         else:
             user.set_hide_sensitive_info(hide_sensitive_info_bool)
+
+    def update_autohide_sensitive_info_timeout(self, timeout_minutes, user):
+        if isinstance(user, str):
+            raise Exception("Please pass a real user, not a string-user")
+        if timeout_minutes:
+            timeout_minutes = int(timeout_minutes)
+        if user.is_admin:
+            self.data["autohide_sensitive_info_timeout_minutes"] = timeout_minutes
+            self._save()
+        else:
+            user.set_autohide_sensitive_info_timeout(timeout_minutes)
+
+    def update_autologout_timeout(self, timeout_hours, user):
+        if isinstance(user, str):
+            raise Exception("Please pass a real user, not a string-user")
+        if timeout_hours:
+            timeout_hours = int(timeout_hours)
+        if user.is_admin:
+            self.data["autologout_timeout_hours"] = timeout_hours
+            self._save()
+        else:
+            user.set_autologout_timeout(timeout_hours)
 
     def update_price_provider(self, price_provider, user):
         if isinstance(user, str):

--- a/src/cryptoadvance/specter/managers/config_manager.py
+++ b/src/cryptoadvance/specter/managers/config_manager.py
@@ -66,7 +66,7 @@ class ConfigManager(GenericDataManager):
             "fee_estimator": "mempool",
             "fee_estimator_custom_url": "",
             "hide_sensitive_info": False,
-            "autohide_sensitive_info_timeout_minutes": 10,
+            "autohide_sensitive_info_timeout_minutes": 20,
             "autologout_timeout_hours": 4,
             # TODO: remove
             "bitcoind": False,
@@ -273,8 +273,6 @@ class ConfigManager(GenericDataManager):
     def update_autohide_sensitive_info_timeout(self, timeout_minutes, user):
         if isinstance(user, str):
             raise Exception("Please pass a real user, not a string-user")
-        if timeout_minutes:
-            timeout_minutes = int(timeout_minutes)
         if user.is_admin:
             self.data["autohide_sensitive_info_timeout_minutes"] = timeout_minutes
             self._save()
@@ -284,8 +282,6 @@ class ConfigManager(GenericDataManager):
     def update_autologout_timeout(self, timeout_hours, user):
         if isinstance(user, str):
             raise Exception("Please pass a real user, not a string-user")
-        if timeout_hours:
-            timeout_hours = int(timeout_hours)
         if user.is_admin:
             self.data["autologout_timeout_hours"] = timeout_hours
             self._save()

--- a/src/cryptoadvance/specter/server_endpoints/settings.py
+++ b/src/cryptoadvance/specter/server_endpoints/settings.py
@@ -63,7 +63,9 @@ def general():
         if autohide_sensitive_info_timeout == "NEVER":
             autohide_sensitive_info_timeout = None
         elif autohide_sensitive_info_timeout == "CUSTOM":
-            autohide_sensitive_info_timeout = request.form["custom_autohide_sensitive_info_timeout"]
+            autohide_sensitive_info_timeout = int(request.form["custom_autohide_sensitive_info_timeout"])
+        else:
+            autohide_sensitive_info_timeout = int(autohide_sensitive_info_timeout)
 
         if "autologout_timeout" in request.form:
             # Is only in the form if specter.config.auth.method != "none"
@@ -71,7 +73,9 @@ def general():
             if autologout_timeout == "NEVER":
                 autologout_timeout = None
             elif autologout_timeout == "CUSTOM":
-                autologout_timeout = request.form["custom_autologout_timeout"]
+                autologout_timeout = int(request.form["custom_autologout_timeout"])
+            else:
+                autologout_timeout = int(autologout_timeout)
         else:
             autologout_timeout = None
 

--- a/src/cryptoadvance/specter/server_endpoints/settings.py
+++ b/src/cryptoadvance/specter/server_endpoints/settings.py
@@ -58,6 +58,23 @@ def general():
     unit = app.specter.unit
     if request.method == "POST":
         action = request.form["action"]
+
+        autohide_sensitive_info_timeout = request.form["autohide_sensitive_info_timeout"]
+        if autohide_sensitive_info_timeout == "NEVER":
+            autohide_sensitive_info_timeout = None
+        elif autohide_sensitive_info_timeout == "CUSTOM":
+            autohide_sensitive_info_timeout = request.form["custom_autohide_sensitive_info_timeout"]
+
+        if "autologout_timeout" in request.form:
+            # Is only in the form if specter.config.auth.method != "none"
+            autologout_timeout = request.form["autologout_timeout"]
+            if autologout_timeout == "NEVER":
+                autologout_timeout = None
+            elif autologout_timeout == "CUSTOM":
+                autologout_timeout = request.form["custom_autologout_timeout"]
+        else:
+            autologout_timeout = None
+
         explorer_id = request.form["explorer"]
         explorer_data = app.config["EXPLORERS_LIST"][explorer_id]
         if explorer_id == "CUSTOM":
@@ -74,6 +91,9 @@ def general():
             if current_user.is_admin:
                 set_loglevel(app, loglevel)
 
+            app.specter.config_manager.update_autohide_sensitive_info_timeout(autohide_sensitive_info_timeout, current_user)
+            app.specter.config_manager.update_autologout_timeout(autologout_timeout, current_user)
+
             app.specter.update_explorer(explorer_id, explorer_data, current_user)
             app.specter.update_unit(unit, current_user)
             app.specter.update_merkleproof_settings(
@@ -85,6 +105,7 @@ def general():
                 user=current_user,
             )
             app.specter.check()
+
         elif action == "restore":
             restore_devices = []
             restore_wallets = []

--- a/src/cryptoadvance/specter/specter.py
+++ b/src/cryptoadvance/specter/specter.py
@@ -616,6 +616,14 @@ class Specter:
     def hide_sensitive_info(self):
         return self.user_config.get("hide_sensitive_info", False)
 
+    @property
+    def autohide_sensitive_info_timeout(self):
+        return self.user_config.get("autohide_sensitive_info_timeout_minutes", 10)
+
+    @property
+    def autologout_timeout(self):
+        return self.user_config.get("autologout_timeout_hours", 4)
+
     def requests_session(self, force_tor=False):
         requests_session = requests.Session()
         if self.only_tor or force_tor:

--- a/src/cryptoadvance/specter/specter.py
+++ b/src/cryptoadvance/specter/specter.py
@@ -618,7 +618,7 @@ class Specter:
 
     @property
     def autohide_sensitive_info_timeout(self):
-        return self.user_config.get("autohide_sensitive_info_timeout_minutes", 10)
+        return self.user_config.get("autohide_sensitive_info_timeout_minutes", 20)
 
     @property
     def autologout_timeout(self):

--- a/src/cryptoadvance/specter/templates/base.jinja
+++ b/src/cryptoadvance/specter/templates/base.jinja
@@ -294,6 +294,28 @@
 					showError(e);
 				}
 			}
+
+			{% if current_user.is_authenticated and not specter.hide_sensitive_info and specter.autohide_sensitive_info_timeout %}
+				document.addEventListener("DOMContentLoaded", function(){
+					var privacyTimeout = setTimeout(function(){
+							// Automatically trigger the privacy toggle
+							toggleHideSensitiveInfo();
+						},
+						{{ specter.autohide_sensitive_info_timeout }} * 60 * 1000
+					);
+				});
+			{% endif %}
+
+			{% if current_user.is_authenticated and specter.config.auth.method != "none" and specter.autologout_timeout %}
+				document.addEventListener("DOMContentLoaded", function(){
+					var logoutTimeout = setTimeout(function(){
+							// Automatically log out the user
+							location.href="{{ url_for('auth_endpoint.logout') }}?timeout=1";
+						},
+						{{ specter.autologout_timeout }} * 60 * 1000
+					);
+				});
+			{% endif %}
 		</script>
 	{% endif %}
 	{% block scripts %}

--- a/src/cryptoadvance/specter/templates/base.jinja
+++ b/src/cryptoadvance/specter/templates/base.jinja
@@ -312,7 +312,7 @@
 							// Automatically log out the user
 							location.href="{{ url_for('auth_endpoint.logout') }}?timeout=1";
 						},
-						{{ specter.autologout_timeout }} * 60 * 1000
+						{{ specter.autologout_timeout }} * 60 * 60 * 1000
 					);
 				});
 			{% endif %}

--- a/src/cryptoadvance/specter/templates/settings/auth_settings.jinja
+++ b/src/cryptoadvance/specter/templates/settings/auth_settings.jinja
@@ -79,12 +79,16 @@
 			var generateregistrationlinkDiv = document.getElementById("generateregistrationlink");
 			if (select.options[select.selectedIndex].value === 'usernamepassword'){
 				usernamepasswordDiv.style.display = 'block';
-				generateregistrationlinkDiv.style.display = 'flex';
+				if (generateregistrationlinkDiv !== null) {
+					generateregistrationlinkDiv.style.display = 'flex';
+				}
 			} else {
 				usernamepasswordDiv.style.display = 'none';
 				specterUsername.value = '{{ current_user.username }}';
 				specterPassword.value = '';
-				generateregistrationlinkDiv.style.display = 'none';
+				if (generateregistrationlinkDiv !== null) {
+					generateregistrationlinkDiv.style.display = 'none';
+				}
 			}
 
 			// Password Only mode

--- a/src/cryptoadvance/specter/templates/settings/general_settings.jinja
+++ b/src/cryptoadvance/specter/templates/settings/general_settings.jinja
@@ -11,6 +11,35 @@
 			{% include "includes/language/language_select.jinja" %}<br/>
 			<br><br>
 
+			<h1>{{ _("Privacy") }}</h1>
+		    </label>&nbsp;{{ _("Auto-hide sensitive info") }}:<br>
+			<select name="autohide_sensitive_info_timeout" id="autohide_sensitive_info_timeout" onchange="updateAutoHideSensitiveInfoTimeout()">
+				<option value="NEVER" {% if specter.autohide_sensitive_info_timeout %}selected{% endif %}>{{ _("Never") }}</option>
+				<option value="10" {% if specter.autohide_sensitive_info_timeout == 10 %}selected{% endif %}>{{ _("After being idle for 10 minutes") }}</option>
+				<option value="20" {% if specter.autohide_sensitive_info_timeout == 20 %}selected{% endif %}>{{ _("After being idle for 20 minutes") }}</option>
+				<option value="40" {% if specter.autohide_sensitive_info_timeout == 40 %}selected{% endif %}>{{ _("After being idle for 40 minutes") }}</option>
+				<option value="CUSTOM" {% if specter.autohide_sensitive_info_timeout and specter.autohide_sensitive_info_timeout not in [10, 20, 40] %}selected{% endif %}>{{ _("Custom idle time (minutes)") }}</option>
+			</select>
+			<br>
+			<input type="number" min="1" name="custom_autohide_sensitive_info_timeout" id="custom_autohide_sensitive_info_timeout" class="hidden" placeholder='{{ _("minutes") }}' {% if specter.autohide_sensitive_info_timeout and specter.autohide_sensitive_info_timeout not in [10, 20, 40] %}value="{{ specter.autohide_sensitive_info_timeout }}"{% endif %} style="margin-top: 15px; margin-bottom: 30px;"/>
+			<br>
+
+			{% if specter.config.auth.method != "none" %}
+				</label>&nbsp;{{ _("Auto-logout user") }}:<br>
+				<select name="autologout_timeout" id="autologout_timeout" onchange="updateAutoLogoutTimeout()">
+					<option value="NEVER" {% if not specter.autologout_timeout %}selected{% endif %}>{{ _("Never") }}</option>
+					<option value="1" {% if specter.autologout_timeout == 1 %}selected{% endif %}>{{ _("After being idle for 1 hour") }}</option>
+					<option value="4" {% if specter.autologout_timeout == 4 %}selected{% endif %}>{{ _("After being idle for 4 hours") }}</option>
+					<option value="24" {% if specter.autologout_timeout == 24 %}selected{% endif %}>{{ _("After being idle for 24 hours") }}</option>
+					<option value="CUSTOM" {% if specter.autologout_timeout and specter.autologout_timeout not in [1, 4, 24] %}selected{% endif %}>{{ _("Custom idle time (hours)") }}</option>
+				</select>
+				<br>
+				<input type="number" min="1" name="custom_autologout_timeout" id="custom_autologout_timeout" class="hidden" placeholder='{{ _("hours") }}' {% if specter.autologout_timeout and specter.autologout_timeout not in [1, 4, 24] %}value="{{ specter.autologout_timeout }}"{% endif %} style="margin-top: 15px; margin-bottom: 30px;"/>
+				<br>
+			{% endif %}
+			<br/>
+
+
 			<h1>{{ _("Backup and Restore") }}</h1>
 			<div class="tool-tip" style="float: right; margin-bottom: 5px;">
 				<i class="tool-tip__icon">i</i>
@@ -170,6 +199,28 @@
 				});
 			}
 		});
+
+    function updateAutoHideSensitiveInfoTimeout() {
+        if (document.getElementById('autohide_sensitive_info_timeout').value == "CUSTOM") {
+            document.getElementById('custom_autohide_sensitive_info_timeout').classList.remove('hidden');
+        } else {
+            document.getElementById('custom_autohide_sensitive_info_timeout').classList.add('hidden');
+        }
+    }
+    document.addEventListener("DOMContentLoaded", function(){
+        updateAutoHideSensitiveInfoTimeout();
+    });
+
+    function updateAutoLogoutTimeout() {
+        if (document.getElementById('autologout_timeout').value == "CUSTOM") {
+            document.getElementById('custom_autologout_timeout').classList.remove('hidden');
+        } else {
+            document.getElementById('custom_autologout_timeout').classList.add('hidden');
+        }
+    }
+    document.addEventListener("DOMContentLoaded", function(){
+        updateAutoLogoutTimeout();
+    });
 
 	{% include "includes/language/language_js.jinja" %}
 

--- a/src/cryptoadvance/specter/user.py
+++ b/src/cryptoadvance/specter/user.py
@@ -208,6 +208,14 @@ class User(UserMixin):
         self.config["hide_sensitive_info"] = hide_sensitive_info_bool
         self.save_info()
 
+    def set_autohide_sensitive_info_timeout(self, timeout_minutes):
+        self.config["autohide_sensitive_info_timeout_minutes"] = timeout_minutes
+        self.save_info()
+
+    def set_autologout_timeout(self, timeout_hours):
+        self.config["autologout_timeout_hours"] = timeout_hours
+        self.save_info()
+
     def set_price_provider(self, price_provider):
         self.config["price_provider"] = price_provider
         self.save_info()


### PR DESCRIPTION
Users shouldn't have to remember to click "Hide Sensitive Info" or logout from Specter. It's especially dangerous in our current era of doing everything over videoconferencing with users streaming their screens over the video feed. We should take pro-active measures to autohide sensitive info and auto logout users after appropriate timeouts. But users should still be able to customize or deactivate these safety measures as they see fit. 

NEW FEATURES:
* Automatically activates the Hide Sensitive Info mode after X minutes have elapsed on the current page. Defaults to 20 minute timeout but can be set to NEVER, 10, 20, 40min or custom.
* IF a login method is enabled, automatically logs a user out after Y hours have elapsed on the current page. Defaults to 1hr but can be set to NEVER, 1, 4, 24hrs or custom.
* These new settings can be applied to the `admin` user and each user account can have their own customized settings.

CHANGED BEHAVIOR:
The Hide Sensitive Info mode is now **always disabled** the next time the user logs in (i.e. sensitive info will be displayed again). Users who expect their info to remain hidden on login will need to take care. If there is enough trouble over this, a new setting can be added for something like "Always/Never show sensitive info after login".

Rationale for the change: Using the new defaults, a typical user will first trigger the auto hide timeout which, for better and worse, still writes to persistent user config. They will then get auto logged out after more time elapses. When they finally log back in, the "Show Sensitive Info" toggle would normally be set to `False` at this point (reflecting its last state). So the user who's session timed out while they were away returns to Specter with everything obscured.

This seems kind of silly as the user _just_ logged in; we shouldn't need to hide anything from them at that point (so perhaps letting that "Hide" setting persist through the next login was always kind of nonsensical).

MISC:
* minor js bugfix in `auth_settings.jinja` when selecting different auth types.
* minor note in docs to ensure debug mode is on in local dev