### PR TITLE
Bugfix: refactor WalletManager and Wallet

### DIFF
--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -838,7 +838,7 @@ class Wallet:
 
     def save_to_file(self):
         write_json_file(self.to_json(), self.fullpath)
-        self.manager.update()
+        # self.manager.update()
 
     def delete_files(self):
         delete_file(self.fullpath)


### PR DESCRIPTION
This PR is targetting too many calls of WalletManager._update. After that is done, this should also remove the dependency from `Wallet` to `WalletManager` but one thing at a time.