### PR TITLE
Tweaks to local dev setup

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -196,6 +196,14 @@ there is a git [pre-commit hook](https://ljvmiranda921.github.io/notebook/2018/0
 pre-commit install
 ```
 
+If this throws an error: `command not found: pre-commit`, you need to install `pre-commit`.
+
+macOS users can run:
+```
+brew install pre-commit
+```
+
+
 ## Developing on tests
 We use pytest and for frontend-testing the amazing [cypress.io](https://www.cypress.io/).
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -77,7 +77,6 @@ pip3 install virtualenv
 virtualenv --python=python3 .env 
 source .env/bin/activate
 pip3 install -r requirements.txt --require-hashes
-pip3 install -e .
 python3 setup.py install # also compiles the babel translation-files
 ```
 
@@ -93,8 +92,8 @@ virtualenv --python=python .env
 Run the server:
 
 ```sh
-cd specter-desktop
-export FLASK_ENV=development && python3 -m cryptoadvance.specter server --config DevelopmentConfig
+cd specter-desktop/src
+python3 -m cryptoadvance.specter server --config DevelopmentConfig --debug
 ```
 
 #### If `pip install` fails on `cryptography==3.4.x`


### PR DESCRIPTION
Previous versions of these instructions included this setup step:
```
pip3 install -e .
```
But this can make local dev behave in unexpected ways:
* If you start the server from the root dir, everything runs as expected but local code changes are ignored as it is using the version of the code that gets copied to the virtualenv's `site-packages` dir.
* If you start the server from the `src/` subdir, the above problem is solved but in many (all?) cases, local jinja template changes are ignored and only the versions that existed at the time of the `pip install -e .` are run.

Also fixing server launch instructions to properly make use of the `--debug` option.