### PR TITLE
Bugfix: no threading for update after creation of wallets

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -103,7 +103,7 @@ release_pip:
     - if [[ ${CI_PROJECT_ROOT_NAMESPACE} = "cryptoadvance" ]]; then  python3 -m twine upload --verbose --user __token__ dist/* ; fi
     - cd dist
     - sha256sum cryptoadvance.specter-*.tar.gz > SHA256SUMS-pip
-    - ../utils/sign_artifact.sh --artifact ./SHA256SUMS-pip
+    - ../utils/artifact_signer.sh sign --artifact ./SHA256SUMS-pip
     - cd ..
     - cat ./dist/SHA256SUMS-pip
     #- python ./utils/github.py upload ./dist/SHA256SUMS-pip
@@ -181,8 +181,8 @@ release_electron_linux_windows:
     - sha256sum  Specter-Setup-${CI_COMMIT_TAG}.exe > ./SHA256SUMS-win
     - cat ./SHA256SUMS-win
     - cd ..
-    - ../utils/sign_artifact.sh --artifact ./release-win/SHA256SUMS-win
-    - ../utils/sign_artifact.sh --artifact ./release-linux/SHA256SUMS-linux
+    - ../utils/artifact_signer.sh sign --artifact ./release-win/SHA256SUMS-win
+    - ../utils/artifact_signer.sh sign --artifact ./release-linux/SHA256SUMS-linux
     - python3 ../utils/github.py upload ./release-win/Specter-Setup-${CI_COMMIT_TAG}.exe
     - python3 ../utils/github.py upload ./release-linux/specterd-${CI_COMMIT_TAG}-x86_64-linux-gnu.zip 
     - python3 ../utils/github.py upload ./release-linux/specter_desktop-${CI_COMMIT_TAG}-x86_64-linux-gnu.tar.gz 
@@ -221,7 +221,7 @@ release_signatures:
     - source .env/bin/activate
     - pip3 install -r test_requirements.txt
     - ./utils/create-gitlab-cli-cfg.sh
-    - gpg --import --no-tty --batch --yes /credentials/private.key
+    - ./utils/artifact_signer.sh init # prepare .gnupg
   script:
     - python3 -m utils.release-helper download          # downloads the job-artifacts from gitlab
     - python3 -m utils.release-helper downloadgithub    # downloads additional artifacts from github (if not there and is they have SHA256SUMS-something)
@@ -229,7 +229,7 @@ release_signatures:
     - python3 -m utils.release-helper checksigs          # checks the signatures of all SHA256SUMM*.asc files
     - python3 -m utils.release-helper create            # creates a SHA256SUM.txt
     - python3 -m utils.release-helper upload            # uploads it to github
-    - ./utils/sign_artifact.sh --artifact ./signing_dir/SHA256SUMS
+    - ./utils/artifact_signer.sh sign --artifact ./signing_dir/SHA256SUMS
     - python3 ./utils/github.py upload ./signing_dir/SHA256SUMS.asc
 
 release_docker:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -226,7 +226,7 @@ release_signatures:
     - python3 -m utils.release-helper download          # downloads the job-artifacts from gitlab
     - python3 -m utils.release-helper downloadgithub    # downloads additional artifacts from github (if not there and is they have SHA256SUMS-something)
     - python3 -m utils.release-helper checkhashes       # checks all SHA256SUM* files
-    - python3 -m utils.release-helper checksig          # checks the signatures of all SHA256SUMM*.asc files
+    - python3 -m utils.release-helper checksigs          # checks the signatures of all SHA256SUMM*.asc files
     - python3 -m utils.release-helper create            # creates a SHA256SUM.txt
     - python3 -m utils.release-helper upload            # uploads it to github
     - ./utils/sign_artifact.sh --artifact ./signing_dir/SHA256SUMS

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -225,8 +225,8 @@ release_signatures:
   script:
     - python3 -m utils.release-helper download          # downloads the job-artifacts from gitlab
     - python3 -m utils.release-helper downloadgithub    # downloads additional artifacts from github (if not there and is they have SHA256SUMS-something)
-    - python3 -m utils.release-helper checkhashes       # checks all SHA256SUM* files
-    - python3 -m utils.release-helper checksigs          # checks the signatures of all SHA256SUMM*.asc files
+    - python3 -m utils.release-helper checksigs         # checks the signatures of all SHA256SUMM*.asc files
+    - python3 -m utils.release-helper checkhashes       # checks all SHA256SUM* files (might modify files on the fly due to windows line endings)
     - python3 -m utils.release-helper create            # creates a SHA256SUM.txt
     - python3 -m utils.release-helper upload            # uploads it to github
     - ./utils/artifact_signer.sh sign --artifact ./signing_dir/SHA256SUMS

--- a/src/cryptoadvance/specter/managers/wallet_manager.py
+++ b/src/cryptoadvance/specter/managers/wallet_manager.py
@@ -62,7 +62,7 @@ class WalletManager:
         self.WalletClass = LWallet if is_liquid(chain) else Wallet
         self.update(data_folder, rpc, chain)
 
-    def update(self, data_folder=None, rpc=None, chain=None):
+    def update(self, data_folder=None, rpc=None, chain=None, allow_threading=True):
         if self.is_loading:
             return
         self.is_loading = True
@@ -102,7 +102,7 @@ class WalletManager:
             for k in list(self.wallets.keys()):
                 if k not in self.wallets_update_list:
                     self.wallets.pop(k)
-            if self.allow_threading:
+            if allow_threading and self.allow_threading:
                 t = threading.Thread(
                     target=self._update,
                     args=(

--- a/src/cryptoadvance/specter/server_endpoints/settings.py
+++ b/src/cryptoadvance/specter/server_endpoints/settings.py
@@ -147,9 +147,13 @@ def general():
                             ),
                             "error",
                         )
+                        handle_exception(e)
                         continue
+                    logger.debug(
+                        f"Wallet {wallet['alias']} already exists, skipping creation"
+                    )
                 write_wallet(wallet)
-                app.specter.wallet_manager.update()
+                app.specter.wallet_manager.update(allow_threading=False)
                 try:
                     wallet_obj = app.specter.wallet_manager.get_by_alias(
                         wallet["alias"]
@@ -180,10 +184,11 @@ def general():
                             "error",
                         )
                     wallet_obj.getdata()
-                except Exception:
+                except Exception as e:
                     flash(
                         _("Failed to import wallet {}").format(wallet["name"]), "error"
                     )
+                    handle_exception(e)
             flash(_("Specter data was successfully loaded from backup"), "info")
             if rescanning:
                 flash(

--- a/utils/artifact_signer.sh
+++ b/utils/artifact_signer.sh
@@ -10,6 +10,14 @@ case $key in
     shift
     shift
     ;;
+    sign)
+    action=sign
+    shift
+    ;;
+    init)
+    action=init
+    shift
+    ;;
     --debug)
     set -x
     shift # past argument
@@ -30,16 +38,21 @@ fi
 # We want a detached signature in cleartext. Extension: .asc (as in bitcoin)
 output_file=${artifact}.asc
 
-if [[ -f /credentials/private.key ]]; then 
-    echo "Importing single private key"
-    gpg --import --no-tty --batch --yes /credentials/private.key
-fi
-
+# lazy init: We're initializing anytime.
+# So that action "init" is just to have a bit more semantics and enable to call 
+# this script to do this:
 if [[ -f /credentials/gnupg.tar.gz ]]; then 
-    echo "extracting gnupg.tar.gz"
+    echo "Init: extracting gnupg.tar.gz"
     tar -xzf /credentials/gnupg.tar.gz -C /root
     chown -R root:root ~/.gnupg
 fi
 
-echo "signing ..."
-echo $GPG_PASSPHRASE | gpg --detach-sign --armor --no-tty --batch --yes --passphrase-fd 0  --pinentry-mode loopback $artifact 
+if [[ -f /credentials/private.key ]]; then 
+    echo "Init: Importing single private key"
+    gpg --import --no-tty --batch --yes /credentials/private.key
+fi
+
+if [ "action" = sign ]; then
+    echo "signing ..."
+    echo $GPG_PASSPHRASE | gpg --detach-sign --armor --no-tty --batch --yes --passphrase-fd 0  --pinentry-mode loopback $artifact 
+fi

--- a/utils/artifact_signer.sh
+++ b/utils/artifact_signer.sh
@@ -29,12 +29,6 @@ case $key in
 esac
 done
 
-if [[ -z $artifact ]]; then
-    echo "no --artifact given "
-    exit 1
-fi
-
-
 # We want a detached signature in cleartext. Extension: .asc (as in bitcoin)
 output_file=${artifact}.asc
 
@@ -53,6 +47,10 @@ if [[ -f /credentials/private.key ]]; then
 fi
 
 if [ "action" = sign ]; then
+    if [[ -z $artifact ]]; then
+        echo "no --artifact given "
+        exit 1
+    fi
     echo "signing ..."
     echo $GPG_PASSPHRASE | gpg --detach-sign --armor --no-tty --batch --yes --passphrase-fd 0  --pinentry-mode loopback $artifact 
 fi

--- a/utils/artifact_signer.sh
+++ b/utils/artifact_signer.sh
@@ -1,10 +1,24 @@
 #!/bin/bash
 
+function sub_help {
+    echo "This script is to sign artifacts or to prepare the gpg-system to be able to verify artifacts."
+    echo "Do one of these:"
+    echo "$  ./utils/artifact_signer.sh init"
+    echo "This makes sense only on a gitlab-runner. It'll unpack a gpg-directory to be ready to sign and verify"
+    echo "$ ./utils/artifact_signer.sh sign --artifact ./release-win/SHA256SUMS-win"
+    echo "Signs a specific artifact. Will do the init on the fly. So no need to call it extra."
+}
+
 while [[ $# -gt 0 ]]
 do
 key="$1"
 command="main"
 case $key in
+    --help)
+    sub_help
+    exit
+    shift
+    ;;
     --artifact)
     artifact=$2
     shift
@@ -32,21 +46,32 @@ done
 # We want a detached signature in cleartext. Extension: .asc (as in bitcoin)
 output_file=${artifact}.asc
 
-# lazy init: We're initializing anytime.
-# So that action "init" is just to have a bit more semantics and enable to call 
-# this script to do this:
-if [[ -f /credentials/gnupg.tar.gz ]]; then 
-    echo "Init: extracting gnupg.tar.gz"
-    tar -xzf /credentials/gnupg.tar.gz -C /root
-    chown -R root:root ~/.gnupg
+# lazy init: We're initializing Each thime script is called with these two things.
+# So that action "init" is just to have a bit more semantics for the one calling this script
+
+function init {
+    if [[ -f /credentials/gnupg.tar.gz ]]; then 
+        echo "Init: extracting gnupg.tar.gz"
+        tar -xzf /credentials/gnupg.tar.gz -C /root
+        chown -R root:root ~/.gnupg
+    else
+        echo "Init: Could not find any /credentials/gnupg.tar.gz"
+    fi
+
+    if [[ -f /credentials/private.key ]]; then 
+        echo "Init: Importing single private key"
+        gpg --import --no-tty --batch --yes /credentials/private.key
+    else
+        echo "Init: Could not find any /credentials/private.key"
+    fi
+}
+
+if [ "$action" = "init" ]; then
+    init
 fi
 
-if [[ -f /credentials/private.key ]]; then 
-    echo "Init: Importing single private key"
-    gpg --import --no-tty --batch --yes /credentials/private.key
-fi
-
-if [ "action" = sign ]; then
+if [ "$action" = "sign" ]; then
+    init
     if [[ -z $artifact ]]; then
         echo "no --artifact given "
         exit 1

--- a/utils/release-helper.py
+++ b/utils/release-helper.py
@@ -128,7 +128,7 @@ class ReleaseHelper:
         logger.info(f"Using tag: {self.tag}")
 
         if os.environ.get("CI_PIPELINE_ID"):
-            pipeline_id = os.environ.get("CI_PIPELINE_ID")
+            self.pipeline_id = os.environ.get("CI_PIPELINE_ID")
         else:
             logger.info(
                 "no CI_PIPELINE_ID given, trying to find an appropriate one ..."
@@ -175,7 +175,6 @@ class ReleaseHelper:
                         zip.extract(zip_info, self.target_dir)
 
     def download_and_unpack_new_artifacts_from_github(self):
-        from utils import github
 
         gc = github.GithubConnection(self.github_project)
         release = gc.fetch_existing_release(self.tag)
@@ -257,14 +256,12 @@ class ReleaseHelper:
         artifact = os.path.join("signing_dir", "SHA256SUMS")
         self.calculate_publish_params()
 
-        if self.github.artifact_exists(
-            self.github_project, self.tag, Path(artifact).name
-        ):
+        if github.artifact_exists(self.github_project, self.tag, Path(artifact).name):
             logger.info(f"Github artifact {artifact} existing. Skipping upload.")
             exit(0)
         else:
             logger.info(f"Github artifact {artifact} does not exist. Let's upload!")
-        self.github.publish_release_from_tag(
+        github.publish_release_from_tag(
             self.github_project,
             self.tag,
             [artifact],
@@ -288,6 +285,8 @@ if __name__ == "__main__":
         exit(0)
     rh = ReleaseHelper()
     rh.init_gitlab()
+    from utils import github
+
     if "download" in sys.argv:
         rh.download_and_unpack_all_artifacts()
     if "downloadgithub" in sys.argv:

--- a/utils/release-helper.py
+++ b/utils/release-helper.py
@@ -145,7 +145,7 @@ class ReleaseHelper:
                     logger.info(f"Found matching pipeline: {pipeline}")
             if not hasattr(self, "pipeline"):
                 logger.error(
-                    f"Could not find tag {self.tag} in the peipline-refs {[pipeline.ref for pipeline in self.project.pipelines.list()]}"
+                    f"Could not find tag {self.tag} in the pipeline-refs {[pipeline.ref for pipeline in self.project.pipelines.list()]}"
                 )
                 raise Exception("no CI_PIPELINE_ID given ( export CI_PIPELINE_ID")
 


### PR DESCRIPTION
Importing a backup or a single Wallet results sometimes in flask-messages like "Failed to import wallet {}".
As the `handle_exception` call reavealed, this is due to "wallet_not existing" in get_by_alias in https://github.com/cryptoadvance/specter-desktop/blob/master/src/cryptoadvance/specter/server_endpoints/settings.py#L154
It makes sense when you look some lines before where the update-call will be done in threading-mode to improver performance.

When creating wallets, we have to wait on the update so the update-method now allows preventing threading.

On top, there are some changes for the upcoming release to make the release-process more smooth.