### PR TITLE
Bugfix: csrf-issues when /toggle_hide_sensitive_info endpoint got called

### DIFF
--- a/src/cryptoadvance/specter/server_endpoints/controller.py
+++ b/src/cryptoadvance/specter/server_endpoints/controller.py
@@ -252,6 +252,7 @@ def get_scantxoutset_status():
 
 @app.route("/toggle_hide_sensitive_info/", methods=["POST"])
 @login_required
+@app.csrf.exempt  # might get called by a timeout in the browser --> csrf-issues
 def toggle_hide_sensitive_info():
     try:
         app.specter.update_hide_sensitive_info(


### PR DESCRIPTION
When javascript times out and calls the /toggle_hide_sensitive_info endpoint, it shouldn't have any csrf-issues which could occur for a lot of reasons.
As this is only increasing security, shouldn't be an issue.