### PR TITLE
Default blockchain rescan to first Taproot block for Taproot wallets

### DIFF
--- a/src/cryptoadvance/specter/config.py
+++ b/src/cryptoadvance/specter/config.py
@@ -157,8 +157,8 @@ class TestConfig(BaseConfig):
     SPECTER_API_ACTIVE = _get_bool_env_var("SPECTER_API_ACTIVE", "True")
 
     # See #1316 since Bitcoin v0.21.1 (not only) the importmulti-call takes longer than 10 seconds on cirrus
-    BITCOIN_RPC_TIMEOUT = 20
-    LIQUID_RPC_TIMEOUT = 30
+    BITCOIN_RPC_TIMEOUT = 60
+    LIQUID_RPC_TIMEOUT = 60
 
 
 class CypressTestConfig(TestConfig):

--- a/src/cryptoadvance/specter/templates/wallet/settings/wallet_settings.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/settings/wallet_settings.jinja
@@ -223,7 +223,11 @@
 					{{ _("Rescan blockchain from block:") }}<br>
 					<div class="row aligned">
 						{% if specter.info.chain == "main" %}
-							{% set startblock=(481824 if not specter.info['pruned'] or specter.info['pruneheight'] < 481824 else specter.info['pruneheight']) %}
+							{% if wallet.is_taproot %}
+								{% set startblock=(709632 if not specter.info['pruned'] or specter.info['pruneheight'] < 709632 else specter.info['pruneheight']) %}
+							{% else %}
+								{% set startblock=(481824 if not specter.info['pruned'] or specter.info['pruneheight'] < 481824 else specter.info['pruneheight']) %}
+							{% endif %}
 						{% else %}
 							{% set startblock=(0 if not specter.info['pruned'] else specter.info['pruneheight']) %}
 						{% endif %}
@@ -233,7 +237,11 @@
 					{% if specter.info['pruned']  %}
 						<div class="note center full-width">{{ _("Note: You are using a pruned node. Rescan is limited by the pruned height to block:") }} {{specter.info['pruneheight']}}</div>
 					{% endif %}
-					<div class="note center"><b>481824</b> {{ _("was the first Segwit block.") }}</div>
+					{% if wallet.is_taproot %}
+						<div class="note center"><b>709632</b> {{ _("was the first Taproot block.") }}</div>
+					{% else %}
+						<div class="note center"><b>481824</b> {{ _("was the first Segwit block.") }}</div>
+					{% endif %}
 				{% endif %}
 			</form>
 			<form action="." method="POST" class="padded" style="max-width: 500px">


### PR DESCRIPTION
Minor convenience when importing Taproot wallets: Automatically sets the `startblock` height in the blockchain rescan field to the first Taproot block for Taproot wallets.

Additional timeout fix for inconsistent Cirrus CI runs.