### PR TITLE
Adds `no_wait` option to rpc calls

### DIFF
--- a/src/cryptoadvance/specter/rpc.py
+++ b/src/cryptoadvance/specter/rpc.py
@@ -341,6 +341,11 @@ class BitcoinRPC:
         timeout = self.timeout
         if "timeout" in kwargs:
             timeout = kwargs["timeout"]
+
+        if kwargs.get("no_wait"):
+            # Zero is treated like None, i.e. infinite wait
+            timeout = 0.001
+
         url = self.url
         if "wallet" in kwargs:
             url = url + "/wallet/{}".format(kwargs["wallet"])
@@ -354,6 +359,11 @@ class BitcoinRPC:
             # ConnectTimeout: The request timed out while trying to connect to the remote server
             # ReadTimeout: The server did not send any data in the allotted amount of time.
             # ReadTimeoutError: Raised when a socket timeout occurs while receiving data from a server
+            if kwargs.get("no_wait"):
+                # Used for rpc calls that don't immediately return (e.g. rescanblockchain) so we don't
+                # expect any data back anyway. __getattr__ expects a list of formatted json.
+                return [{"error": None, "result": None}]
+
             logger.error(
                 "Timeout after {} secs while {} call({: <28}) payload:{} Exception: {}".format(
                     timeout,

--- a/src/cryptoadvance/specter/server_endpoints/settings.py
+++ b/src/cryptoadvance/specter/server_endpoints/settings.py
@@ -165,13 +165,10 @@ def general():
                             wallet["blockheight"]
                             if "blockheight" in wallet
                             else get_startblock_by_chain(app.specter),
-                            timeout=1,
+                            no_wait=True,
                         )
                         app.logger.info("Rescanning Blockchain ...")
                         rescanning = True
-                    except requests.exceptions.ReadTimeout:
-                        # this is normal behavior in our usecase
-                        pass
                     except Exception as e:
                         app.logger.error(
                             "Exception while rescanning blockchain for wallet {}: {}".format(

--- a/src/cryptoadvance/specter/server_endpoints/wallets.py
+++ b/src/cryptoadvance/specter/server_endpoints/wallets.py
@@ -337,10 +337,7 @@ def new_wallet(wallet_type):
                     app.logger.info("Rescanning Blockchain ...")
                     startblock = int(request.form["startblock"])
                     try:
-                        wallet.rpc.rescanblockchain(startblock, timeout=1)
-                    except requests.exceptions.ReadTimeout:
-                        # this is normal behavior in our usecase
-                        pass
+                        wallet.rpc.rescanblockchain(startblock, no_wait=True)
                     except Exception as e:
                         app.logger.error(
                             "Exception while rescanning blockchain: %e" % e
@@ -769,10 +766,9 @@ def settings(wallet_alias):
             try:
                 delete_file(wallet._transactions.path)
                 wallet.fetch_transactions()
-                res = wallet.rpc.rescanblockchain(startblock, timeout=1)
-            except requests.exceptions.ReadTimeout:
-                # this is normal behaviour in our usecase
-                pass
+
+                # This rpc call does not seem to return a result; use no_wait to ignore timeout errors
+                wallet.rpc.rescanblockchain(startblock, no_wait=True)
             except Exception as e:
                 app.logger.error("%s while rescanblockchain" % e)
                 error = "%r" % e

--- a/src/cryptoadvance/specter/util/wallet_importer.py
+++ b/src/cryptoadvance/specter/util/wallet_importer.py
@@ -210,11 +210,8 @@ class WalletImporter:
                         f"Using pruned node - we will only rescan from block {newstartblock}"
                     )
                     startblock = newstartblock
-            self.wallet.rpc.rescanblockchain(startblock, timeout=1)
+            self.wallet.rpc.rescanblockchain(startblock, no_wait=True)
             logger.info("Rescanning Blockchain ...")
-        except requests.exceptions.ReadTimeout:
-            # this is normal behavior in our usecase
-            pass
         except Exception as e:
             logger.error("Exception while rescanning blockchain: %r" % e)
             if potential_errors:


### PR DESCRIPTION
The expected exception from `requests` seems to have changed, causing an unnecessary "timeout=1" error to make it to the UI. And in my testing (w/Bitcoin Core v22.0) the `rescanblockchain` rpc call just never returns so there is no timeout long enough to avoid an Exception.

Instead I've implemented a new `no_wait` option on the rpc call that sets the timeout to immediately return and handle the expected error. It's cleaner to explicitly put that expected exception handling within the rpc call rather than catching it everywhere that `rescanblockchain` is called. This also makes it reusable if there are other rpc calls that don't return in a timely manner (if ever).

Fixes #1483