### PR TITLE
fix keypoolrefill perfomance and adjusted callback logic

### DIFF
--- a/src/cryptoadvance/specter/internal_node.py
+++ b/src/cryptoadvance/specter/internal_node.py
@@ -55,6 +55,7 @@ class InternalNode(Node):
             protocol,
             False,
             fullpath,
+            "BTC",
             manager,
         )
 

--- a/src/cryptoadvance/specter/liquid/rpc.py
+++ b/src/cryptoadvance/specter/liquid/rpc.py
@@ -1,21 +1,21 @@
-from ..rpc import RpcError, BitcoinRPC
+import copy
+import logging
+from io import BytesIO
+
+from embit.descriptor.checksum import add_checksum
 from embit.ec import PrivateKey, PublicKey
 from embit.hashes import tagged_hash
-from embit.descriptor.checksum import add_checksum
-from embit.liquid.descriptor import LDescriptor
-from embit.liquid.pset import PSET, PSBTError
+from embit.liquid import finalizer, slip77
 from embit.liquid.addresses import addr_decode
 from embit.liquid.addresses import address as liquid_address
+from embit.liquid.descriptor import LDescriptor
 from embit.liquid.networks import get_network
+from embit.liquid.pset import PSET, PSBTError
 from embit.liquid.transaction import LTransaction, unblind
-from embit.liquid import finalizer
-from embit.liquid import slip77
 from embit.psbt import read_string
-import copy
-from io import BytesIO
-from .util.pset import to_canonical_pset
 
-import logging
+from ..rpc import BitcoinRPC, RpcError
+from .util.pset import to_canonical_pset
 
 logger = logging.getLogger(__name__)
 

--- a/src/cryptoadvance/specter/managers/node_manager.py
+++ b/src/cryptoadvance/specter/managers/node_manager.py
@@ -62,7 +62,22 @@ class NodeManager:
                 default_fullpath=fullpath,
             )
         if not nodes:
+            if os.environ.get("ELM_RPC_USER"):
+                self.add_node(
+                    node_type="ELM",
+                    name="Blockstream Liquid",
+                    autodetect=True,
+                    datadir=get_default_datadir(node_type="ELM"),
+                    user="",
+                    password="",
+                    port=7041,
+                    host="localhost",
+                    protocol="http",
+                    external_node=True,
+                    default_alias=self.DEFAULT_ALIAS,
+                )
             self.add_node(
+                node_type="BTC",
                 name="Bitcoin Core",
                 autodetect=True,
                 datadir=get_default_datadir(),
@@ -118,6 +133,7 @@ class NodeManager:
 
     def add_node(
         self,
+        node_type,
         name,
         autodetect,
         datadir,
@@ -129,6 +145,10 @@ class NodeManager:
         external_node,
         default_alias=None,
     ):
+        """Adding a node. Params:
+        :param node_type: only valid for autodetect. Either BTC or ELM
+
+        """
         if not default_alias:
             node_alias = alias(name)
         else:
@@ -152,6 +172,7 @@ class NodeManager:
             protocol,
             external_node,
             fullpath,
+            node_type,
             self,
         )
         logger.info(f"persisting {node} in add_node")

--- a/src/cryptoadvance/specter/persistence.py
+++ b/src/cryptoadvance/specter/persistence.py
@@ -10,6 +10,7 @@ import os
 import shutil
 import threading
 
+
 from flask import current_app as app
 
 from .specter_error import SpecterError
@@ -90,20 +91,17 @@ def _write_json_file(content, path, lock=None):
 
 def write_json_file(content, path, lock=None):
     _write_json_file(content, path, lock)
-    storage_callback()
+    storage_callback(path=path)
 
 
 def delete_files(paths):
     """deletes multiple files and calls storage callback once"""
-    need_callback = False
     for path in paths:
         try:
             os.remove(path)
-            need_callback = True
+            storage_callback(mode="delete", path=path)
         except FileNotFoundError:
             pass
-    if need_callback:
-        storage_callback()
 
 
 def delete_file(path):
@@ -113,13 +111,11 @@ def delete_file(path):
 def write_devices(devices_json):
     """interpret a json as a list of devices and write them in the devices subfolder inside the specter-folder"""
     for device_json in devices_json:
-        _write_json_file(
-            device_json,
-            os.path.join(
-                app.specter.device_manager.data_folder, "%s.json" % device_json["alias"]
-            ),
+        path = os.path.join(
+            app.specter.device_manager.data_folder, "%s.json" % device_json["alias"]
         )
-    storage_callback()
+        _write_json_file(device_json, path)
+        storage_callback(path=path)
 
 
 def write_wallet(wallet_json):
@@ -130,28 +126,28 @@ def write_wallet(wallet_json):
         app.specter.wallet_manager.working_folder, "%s.json" % wallet_json["alias"]
     )
     _write_json_file(wallet_json, fpath)
-    storage_callback()
+    storage_callback(path=fpath)
 
 
 def write_device(device, fullpath):
     _write_json_file(device.json, fullpath)
-    storage_callback()
+    storage_callback(path=fullpath)
 
 
 def write_node(node, fullpath):
     _write_json_file(node.json, fullpath)
-    storage_callback()
+    storage_callback(path=fullpath)
 
 
 def delete_folder(path):
     _delete_folder(path)
-    storage_callback()
+    storage_callback(mode="delete", path=path)
 
 
 def delete_folders(paths):
     for path in paths:
         _delete_folder(path)
-    storage_callback()
+        storage_callback(mode="delete", path=path)
 
 
 def _write_csv(fname, objs, cls=dict):
@@ -172,7 +168,7 @@ def _write_csv(fname, objs, cls=dict):
 
 def write_csv(fname, objs, cls=dict):
     _write_csv(fname, objs, cls)
-    storage_callback()
+    storage_callback(path=fname)
 
 
 def read_csv(fname, cls=dict, *args):
@@ -182,16 +178,20 @@ def read_csv(fname, cls=dict, *args):
             return [cls(*args, **row) for row in csv_reader]
 
 
-def storage_callback():
+def storage_callback(mode="write", path=None):
+    # Might be usefull to figure out why the callback has been triggered:
+    # traceback.print_stack()
+    logger.info(f"Storage Callback called mode {mode} with path {path}")
     if os.getenv("SPECTER_PERSISTENCE_CALLBACK"):
-        result = run_shell(os.getenv("SPECTER_PERSISTENCE_CALLBACK").split(" "))
+        cmd_list = os.getenv("SPECTER_PERSISTENCE_CALLBACK").split(" ")
+        cmd_list.append(mode)
+        cmd_list.append(path)
+        logger.debug(f"Executing {cmd_list}")
+        result = run_shell(cmd_list)
         if result["code"] != 0:
-            logger.error("callback failed stdout: {}".format(result["out"]))
-            logger.error("stderr {}".format(result["err"]))
+            logger.error("callback failed ")
+            logger.error("stderr: {}".format(result["err"]))
+            logger.error("stdout: {}".format(result["out"]))
         else:
-            logger.info(
-                "Successfully executed {}".format(
-                    os.getenv("SPECTER_PERSISTENCE_CALLBACK")
-                )
-            )
+            logger.info("Successfully executed {}".format(" ".join(cmd_list)))
             logger.debug("result: {}".format(result))

--- a/src/cryptoadvance/specter/server_endpoints/nodes.py
+++ b/src/cryptoadvance/specter/server_endpoints/nodes.py
@@ -140,6 +140,7 @@ def node_settings(node_alias):
                 protocol,
                 node.external_node,
                 node.fullpath,
+                "BTC",
                 node.manager,
             )
             test = node.test_rpc()
@@ -170,6 +171,7 @@ def node_settings(node_alias):
                         rand=rand,
                     )
                 node = app.specter.node_manager.add_node(
+                    "BTC",
                     node.name,
                     autodetect,
                     datadir,

--- a/src/cryptoadvance/specter/specter.py
+++ b/src/cryptoadvance/specter/specter.py
@@ -35,8 +35,6 @@ from .process_controller.bitcoind_controller import BitcoindPlainController
 from .rpc import (
     BitcoinRPC,
     RpcError,
-    autodetect_rpc_confs,
-    detect_rpc_confs,
     get_default_datadir,
 )
 from .specter_error import ExtProcTimeoutException, SpecterError
@@ -726,6 +724,7 @@ class Specter:
                 old_rpc.get("protocol", "http"),
                 True,
                 os.path.join(os.path.join(self.data_folder, "nodes"), "default.json"),
+                "BTC",
                 self,
             )
             logger.info(f"persisting {node} in migrate_old_node_format")

--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -1352,6 +1352,9 @@ class Wallet:
     def get_address(self, index, change=False, check_keypool=True):
         if check_keypool:
             pool = self.change_keypool if change else self.keypool
+            logger.debug(
+                f"get_address index={index} pool={pool} gapLIMIT={self.GAP_LIMIT} change={change} will_keypoolrefill={pool < index + self.GAP_LIMIT}"
+            )
             if pool < index + self.GAP_LIMIT:
                 self.keypoolrefill(pool, index + self.GAP_LIMIT, change=change)
         return self.descriptor.derive(index, branch_index=int(change)).address(
@@ -1534,6 +1537,9 @@ class Wallet:
         if end is None:
             # end is ignored for descriptor wallets
             end = start + self.GAP_LIMIT
+        if end - start < self.GAP_LIMIT:
+            # avoid too many calls
+            end = start + self.GAP_LIMIT * 2
 
         desc = self.recv_descriptor if not change else self.change_descriptor
         args = [

--- a/tests/test_managers_node.py
+++ b/tests/test_managers_node.py
@@ -22,6 +22,7 @@ def test_NodeManager(
         print(f"data_folder={data_folder}")
         nm = NodeManager(data_folder=data_folder)
         nm.add_node(
+            "BTC",
             "bitcoin_regtest",
             False,
             "",
@@ -36,6 +37,7 @@ def test_NodeManager(
         nm.switch_node("bitcoin_regtest")
         assert nm.active_node.get_rpc().getblockchaininfo()["chain"] == "regtest"
         nm.add_node(
+            "ELM",
             "elements_elreg",
             False,
             "",

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -40,6 +40,7 @@ def test_Node_btc(bitcoin_regtest):
             "port": 18543,
             "host": "localhost",
             "protocol": "http",
+            "node_type": "BTC",
             "external_node": True,  # 'fullpath': ''
         }
 
@@ -99,6 +100,7 @@ def test_Node_elm(elements_elreg):
             "port": 18643,
             "host": "localhost",
             "protocol": "http",
+            "node_type": "BTC",
             "external_node": True,  # 'fullpath': ''
         }
 

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -29,12 +29,12 @@ def test_write_devices(app, monkeypatch, caplog):
     assert count_files_in(app.specter.device_manager.data_folder) == 2
     write_devices(devices_json)
     assert count_files_in(app.specter.device_manager.data_folder) == 5
-    assert not "callback failed stdout:" in caplog.text
+    assert not "callback failed" in caplog.text
     os.remove(os.path.join(app.specter.device_manager.data_folder, "fsedf.json"))
     monkeypatch.setenv("SPECTER_PERSISTENCE_CALLBACK", "ThisWillFail")
     write_devices(devices_json)
     assert count_files_in(app.specter.device_manager.data_folder) == 5
-    assert "callback failed stdout:" in caplog.text
+    assert "callback failed" in caplog.text
 
 
 def test_write_wallet(app, monkeypatch, caplog):
@@ -47,14 +47,14 @@ def test_write_wallet(app, monkeypatch, caplog):
     assert count_files_in(app.specter.wallet_manager.working_folder) == 0
     write_wallet(wallet_json)
     assert count_files_in(app.specter.wallet_manager.working_folder) == 1
-    assert not "callback failed stdout:" in caplog.text
+    assert not "callback failed" in caplog.text
     os.remove(
         os.path.join(app.specter.wallet_manager.working_folder, "myotherwallet.json")
     )
     monkeypatch.setenv("SPECTER_PERSISTENCE_CALLBACK", "ThisWillFail")
     write_wallet(wallet_json)
     assert count_files_in(app.specter.wallet_manager.working_folder) == 1
-    assert "callback failed stdout:" in caplog.text
+    assert "callback failed" in caplog.text
 
 
 def test_write_device(app):


### PR DESCRIPTION
When a wallet is created, the keypoolrefill-function get called for each address of probably 50 addresses wasting lots of time to write a csv-file dozens of times. This fixes this behaviour (in `wallet.py`).

It also adjusts the behaviour of the `SPECTER_PERSISTENCE_CALLBACK` (or `SPECTER_PERSISTENCE_CALLBACK_ASYNC` for a script which would run in a thread) to make it more flexible. This env-var takes an executable which will get called any time the persistence-layer is modifying a file.
Example:
* You have written a script called `/usr/local/bin/my_rsync_script.sh`
* You specify that script like `export SPECTER_PERSISTENCE_CALLBACK=/usr/local/bin/my_rsync_script.sh`
* In the past, that script simply get called
* Now if gets additional parameters:
  * the mode which is either `write` or `delete`
  * the filepath
* So an example-call would be `/usr/local/bin/my_rsync_script.sh write /home/someuser/.specter/config.json`
* You can also specify it in the `SPECTER_PERSISTENCE_CALLBACK_ASYNC` and it'll be called in a thread.
Those changes are in `persistence.py`.

Also this PR contains an autodetection-mechanism for Liquid-nodes. So in parallel to `BTC_RPC_USER, BTC_RPC_PASSWORD, BTC_RPC_HOST, BTC_RPC_PORT, ELM_RPC_PROTOCOL` we now also have `ELM_RPC_USER, ELM_RPC_PASSWORD, ELM_RPC_HOST, ELM_RPC_PORT ELM_RPC_PROTOCOL`.
This was a bit tricky as a node was, up to now, indifferent about the type (until it queried the RPC-interface). Now we need to specify the type of the node upfront in order to make the autodetection work if someone uses both autodetection-mechanisms at the same time.
Also, the `NodeManager` created an initial Node if there wasn't one. So we needed to adjust that and we create a second Liquid-Node if there isn't one (AND an env-var is existing). See the node_type as the first argument (which will then differ in which Env-vars to pick up):
```
            if os.environ.get("ELM_RPC_USER"):
                self.add_node(
                    node_type="ELM",
                    name="Blockstream Liquid",
                    autodetect=True,
                    datadir=get_default_datadir(node_type="ELM"),
                    user="",
                    password="",
                    port=7041,
                    host="localhost",
                    protocol="http",
                    external_node=True,
                    default_alias=self.DEFAULT_ALIAS,
                )
            self.add_node(
                node_type="BTC",
                name="Bitcoin Core",
                autodetect=True,
                datadir=get_default_datadir(),
                user="",
                password="",
                port=8332,
                host="localhost",
                protocol="http",
                external_node=True,
                default_alias=self.DEFAULT_ALIAS,
```