### PR TITLE
Corrected install_noded.sh help text

### DIFF
--- a/tests/install_noded.sh
+++ b/tests/install_noded.sh
@@ -153,9 +153,9 @@ function build_node_impl {
 function sub_help {
     echo "This script will result in having bitcoind or elementsd binaries, either by binary download or via compilation"
     echo "Do one of these:"
-    echo "$ ./install_node.sh --bitcoin compile"
-    echo "$ ./install_node.sh --elements compile"
-    echo "$ ./install_node.sh binary # only works for bitcoind currently, no binaries for elements"
+    echo "$ ./install_noded.sh --bitcoin compile"
+    echo "$ ./install_noded.sh --elements compile"
+    echo "$ ./install_noded.sh --bitcoin binary # only works for bitcoind currently, no binaries for elements"
     echo "For more context, see https://github.com/cryptoadvance/specter-desktop/blob/master/docs/development.md#how-to-run-the-tests"
 }
 


### PR DESCRIPTION
I corrected install_noded.sh help text.    No logic change.


The missing --bitcoin in the help text can be confusing (it doesn't work without --bitcoin).