### PR TITLE
Restore ability to import address labels of unlabeled addresses

### DIFF
--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -590,7 +590,7 @@ class Wallet:
         arr = [
             {"address": address, "label": label}
             for address, label in labeled_addresses.items()
-            if address in self._addresses  
+            if address in self._addresses
         ]
         logger.info(f"Array for set_labels is: {arr}")
         self._addresses.set_labels(arr)

--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -580,13 +580,16 @@ class Wallet:
                 reader = csv.DictReader(f, delimiter=dialect.delimiter)
                 reader.fieldnames = [name.lower() for name in reader.fieldnames]
                 for row in reader:
-                    labeled_addresses[row["address"]] = row["label"]
+                    if not row["label"].startswith(
+                        "Address #"
+                    ):  # Avoids importing addresses with standard "Address #X" description
+                        labeled_addresses[row["address"]] = row["label"]
                 logger.info(f"Specter label CSV was converted to {labeled_addresses}.")
             except (Error, KeyError) as e:
                 raise SpecterError(
                     f"Labels import failed. Check the import info box for the expected formats. Error: {e}"
                 )
-        # convert labeled_addresses to arr (for AddressList.set_labels), only allow existing addresses for which a label had been set
+        # Convert labeled_addresses to arr (for AddressList.set_labels)
         arr = [
             {"address": address, "label": label}
             for address, label in labeled_addresses.items()

--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -590,7 +590,7 @@ class Wallet:
         arr = [
             {"address": address, "label": label}
             for address, label in labeled_addresses.items()
-            if address in self._addresses and self._addresses[address].is_labeled
+            if address in self._addresses  
         ]
         logger.info(f"Array for set_labels is: {arr}")
         self._addresses.set_labels(arr)

--- a/tests/test_labels_import.py
+++ b/tests/test_labels_import.py
@@ -119,10 +119,6 @@ def test_import_address_labels(
         assert wallet._addresses[test_address]["label"] is None
         assert len(wallet._addresses) == number_of_addresses
 
-        # Test it with a txid label
-        wallet._addresses[test_address].set_label(
-            "some_label"
-        )  # some label has to be set before
         wallet.import_address_labels(json.dumps({txid: "txid label"}))
         assert wallet._addresses[test_address]["label"] == "txid label"
 

--- a/tests/test_labels_import.py
+++ b/tests/test_labels_import.py
@@ -119,6 +119,7 @@ def test_import_address_labels(
         assert wallet._addresses[test_address]["label"] is None
         assert len(wallet._addresses) == number_of_addresses
 
+        # Test it with a txid label
         wallet.import_address_labels(json.dumps({txid: "txid label"}))
         assert wallet._addresses[test_address]["label"] == "txid label"
 


### PR DESCRIPTION
As described in https://github.com/cryptoadvance/specter-desktop/pull/1470#pullrequestreview-823070898  the PR https://github.com/cryptoadvance/specter-desktop/pull/1470 broke the ability to import electrum address labels (for which most of the cases no prior address label was defined).

This PR implements recommended changes of https://github.com/cryptoadvance/specter-desktop/pull/1470#pullrequestreview-823070898 .   
@moneymanolis :  If these changes are not desired for the use-case of Specter CSV  and Specter JSOn import, please comment.
