### PR TITLE
Add Jade multisig support

### DIFF
--- a/src/cryptoadvance/specter/devices/hwi/jadepy/README.md
+++ b/src/cryptoadvance/specter/devices/hwi/jadepy/README.md
@@ -1,9 +1,0 @@
-# Python Jade Library
-
-This is a slightly stripped down version of the official [Jade](https://github.com/Blockstream/Jade) python library.
-
-This stripped down version was made at commit [dfdfc7e1d8b91227f4ea7555457640506b8c8aed](https://github.com/Blockstream/Jade/commit/dfdfc7e1d8b91227f4ea7555457640506b8c8aed).
-
-## Changes
-
-- Removed BLE module, reducing transitive dependencies

--- a/src/cryptoadvance/specter/devices/jade.py
+++ b/src/cryptoadvance/specter/devices/jade.py
@@ -11,7 +11,7 @@ class Jade(HWIDevice):
     icon = "jade_icon.svg"
 
     supports_hwi_toggle_passphrase = False
-    supports_hwi_multisig_display_address = False
+    supports_hwi_multisig_display_address = True
     liquid_support = True
 
     @classmethod


### PR DESCRIPTION
This PR adds support for multisig address display and tx signing with Jade.
If requested multisig is not registered on the device it will try to register it, and then continue with addr display or signing.

Requires latest firmware version of Jade - `0.1.32`.