### PR TITLE
Add suggestion to quit other wallet software when connecting HWW

### DIFF
--- a/src/cryptoadvance/specter/templates/includes/hwi/hwi.jinja
+++ b/src/cryptoadvance/specter/templates/includes/hwi/hwi.jinja
@@ -16,7 +16,7 @@
     <p id="bitbox02-pairing-code" style="margin: auto;"></p>
     <img src="{{ url_for('static', filename='img/loader_boxes.svg') }}">
     <div class="flex-center hidden" id="hwi_progress_note" style="cursor: pointer;">
-        {{ _("If your device does not show up, ensure the Specter USB settings are correctly configured.") }}<br><br>
+        {{ _("If your device does not show up, close any other wallet software that may be connected to your device and ensure the Specter USB settings are correctly configured.") }}<br><br>
         <a href="{{ url_for('settings_endpoint.hwi') }}" style="color: #fff; text-decoration: underline; cursor: pointer;">
             {{ _("View USB settings") }}
         </a>


### PR DESCRIPTION
Referencing https://github.com/cryptoadvance/specter-desktop/issues/1480. Tested this with a Blockstream Jade and BitBox 02. If resp. Blockstream Green or the BitBox app is open, Specter Desktop cannot detect the HWW connected over USB as I assume the other wallet software 'monopolises' the connection (there is undoubtedly a good tech term for it that I don't know). When the other wallet software is closed, Specter Desktop can again find the HWW and extract its keys.

I would therefore propose to suggest trying this to the user as well in the message that shows up if the device is not found immediately.