### PR TITLE
Bugfix: Import electrum multisig wallet (with available seed)

### DIFF
--- a/src/cryptoadvance/specter/util/wallet_importer.py
+++ b/src/cryptoadvance/specter/util/wallet_importer.py
@@ -266,7 +266,10 @@ class WalletImporter:
                 xpubs += "[{}]{}/0/*,".format(
                     d["derivation"].replace("m", d["root_fingerprint"]), d["xpub"]
                 )
-                cosigners_types.append({"type": d["hw_type"], "label": d["label"]})
+                if "hw_type" in d:
+                    cosigners_types.append({"type": d["hw_type"], "label": d["label"]})
+                else:  # this can occcur if no hardware wallet was used, but the seed is available
+                    cosigners_types.append({"type": "electrum", "label": f'electrum multisig {i}'})
                 i += 1
             xpubs = xpubs.rstrip(",")
 
@@ -278,7 +281,7 @@ class WalletImporter:
                 raise Exception('"xpub" not found in "x1/" in Electrum backup json')
 
             required_sigs = int(wallet_data.get("wallet_type").split("of")[0])
-            recv_descriptor = "{}(sortedmulti({}, {}))".format(
+            recv_descriptor = "{}(sortedmulti({},{}))".format(
                 wallet_type, required_sigs, xpubs
             )
             wallet_name = "Electrum {} of {}".format(required_sigs, i - 1)

--- a/src/cryptoadvance/specter/util/wallet_importer.py
+++ b/src/cryptoadvance/specter/util/wallet_importer.py
@@ -269,7 +269,9 @@ class WalletImporter:
                 if "hw_type" in d:
                     cosigners_types.append({"type": d["hw_type"], "label": d["label"]})
                 else:  # this can occcur if no hardware wallet was used, but the seed is available
-                    cosigners_types.append({"type": "electrum", "label": f'electrum multisig {i}'})
+                    cosigners_types.append(
+                        {"type": "electrum", "label": f"electrum multisig {i}"}
+                    )
                 i += 1
             xpubs = xpubs.rstrip(",")
 

--- a/src/cryptoadvance/specter/util/wallet_importer.py
+++ b/src/cryptoadvance/specter/util/wallet_importer.py
@@ -272,6 +272,10 @@ class WalletImporter:
                     cosigners_types.append(
                         {"type": "electrum", "label": f"Electrum Multisig {i}"}
                     )
+                    if "seed" in d:
+                        logger.warning(
+                            "The Electrum wallet contains a seed. The seed will not be imported."
+                        )
                 i += 1
             xpubs = xpubs.rstrip(",")
 

--- a/src/cryptoadvance/specter/util/wallet_importer.py
+++ b/src/cryptoadvance/specter/util/wallet_importer.py
@@ -270,7 +270,7 @@ class WalletImporter:
                     cosigners_types.append({"type": d["hw_type"], "label": d["label"]})
                 else:  # this can occcur if no hardware wallet was used, but the seed is available
                     cosigners_types.append(
-                        {"type": "electrum", "label": f"electrum multisig {i}"}
+                        {"type": "electrum", "label": f"Electrum Multisig {i}"}
                     )
                 i += 1
             xpubs = xpubs.rstrip(",")

--- a/src/cryptoadvance/specter/util/wallet_importer.py
+++ b/src/cryptoadvance/specter/util/wallet_importer.py
@@ -10,6 +10,8 @@ from embit.descriptor import Key as DescriptorKey
 from embit.descriptor.arguments import AllowedDerivation
 from embit.liquid.descriptor import LDescriptor
 from cryptoadvance.specter.key import Key
+from flask import flash
+from flask_babel import lazy_gettext as _
 
 logger = logging.getLogger(__name__)
 
@@ -273,8 +275,11 @@ class WalletImporter:
                         {"type": "electrum", "label": f"Electrum Multisig {i}"}
                     )
                     if "seed" in d:
-                        logger.warning(
-                            "The Electrum wallet contains a seed. The seed will not be imported."
+                        flash(
+                            _(
+                                "The Electrum wallet contains a seed. The seed will not be imported."
+                            ),
+                            "warning",
                         )
                 i += 1
             xpubs = xpubs.rstrip(",")


### PR DESCRIPTION
1. A space was in recv_descriptor
2. hw_type key does not exist in the electrum wallet dict if the seed exists in the electrum wallet


How to reproduce the bug:  Create a 2/2 testnet electrum multisig wallet (with electrum seeds).  The file will look like:
```
{
    "addr_history": {

    },
    "addresses": {
        "change": [
        ],
        "receiving": [
        ]
    },
    "fiat_value": {},
    "frozen_coins": {},
    "invoices": {},
    "labels": {},
    "payment_requests": {},
    "prevouts_by_scripthash": {....},
    "seed_version": 41,
    "spent_outpoints": {......
    },
    "transactions": {.....    },
    "tx_fees": {.....    },
    "txi": {},
    "txo": {.....    },
    "use_encryption": false,
    "verified_tx3": {},
    "wallet_type": "2of2",
    "x1/": {
        "derivation": "m/1'",
        "pw_hash_version": 1,
        "root_fingerprint": "....",
        "seed": ".....",
        "seed_type": "segwit",
        "type": "bip32",
        "xprv": "...",
        "xpub": "..."
    },
    "x2/": {
        "derivation": "m/1'",
        "pw_hash_version": 1,
        "root_fingerprint": "...",
        "type": "bip32",
        "xprv": null,
        "xpub": "..."
    }
}
```