### PR TITLE
Fix electrum single-sig wallet import

### DIFF
--- a/src/cryptoadvance/specter/util/wallet_importer.py
+++ b/src/cryptoadvance/specter/util/wallet_importer.py
@@ -456,6 +456,13 @@ class WalletImporter:
                     "label": wallet_data["keystore"].get("label", "Electrum Wallet"),
                 }
             ]
+            if "seed" in wallet_data["keystore"]:
+                flash(
+                    _(
+                        "The Electrum wallet contains a seed. The seed will not be imported."
+                    ),
+                    "warning",
+                )
         # Current Specter backups
         else:
             # Newer exports are able to reinitialize device types but stay backwards

--- a/src/cryptoadvance/specter/util/wallet_importer.py
+++ b/src/cryptoadvance/specter/util/wallet_importer.py
@@ -443,7 +443,7 @@ class WalletImporter:
                 )
             recv_descriptor = "{}({})".format(
                 wallet_type,
-                "[{}]{}/0/*,".format(
+                "[{}]{}/0/*".format(
                     wallet_data["keystore"]["derivation"].replace(
                         "m", wallet_data["keystore"]["root_fingerprint"]
                     ),
@@ -456,7 +456,6 @@ class WalletImporter:
                     "label": wallet_data["keystore"].get("label", "Electrum Wallet"),
                 }
             ]
-
         # Current Specter backups
         else:
             # Newer exports are able to reinitialize device types but stay backwards

--- a/tests/test_util_wallet_importer.py
+++ b/tests/test_util_wallet_importer.py
@@ -11,6 +11,7 @@ from mock import MagicMock, call, patch
 
 
 @patch("cryptoadvance.specter.util.wallet_importer.flash", print)
+@patch("cryptoadvance.specter.util.wallet_importer._", lambda x: x)
 def test_WalletImporter_unit():
     specter_mock = MagicMock()
     specter_mock.chain = "regtest"


### PR DESCRIPTION
Similar to the multisig electrum wallet import (https://github.com/cryptoadvance/specter-desktop/pull/1543), the single-sig electrum wallet import also had a bug in the descriptor.  This PR is a fix.

I also added tests for the electrum wallet import.  (single sig and multisig)