### PR TITLE
Fix logging error, caused by passing 2 arguments

### DIFF
--- a/src/cryptoadvance/specter/managers/wallet_manager.py
+++ b/src/cryptoadvance/specter/managers/wallet_manager.py
@@ -147,12 +147,7 @@ class WalletManager:
                             if len(loaded_wallet.pending_psbts) > 0:
                                 for psbt in loaded_wallet.pending_psbts:
                                     logger.info(
-                                        "lock {} {}".format(
-                                            wallet_alias,
-                                            loaded_wallet.pending_psbts[
-                                                psbt
-                                            ].utxo_dict(),
-                                        )
+                                        f"lock {wallet_alias} {loaded_wallet.pending_psbts[psbt].utxo_dict()}"
                                     )
                                     loaded_wallet.rpc.lockunspent(
                                         False,

--- a/src/cryptoadvance/specter/managers/wallet_manager.py
+++ b/src/cryptoadvance/specter/managers/wallet_manager.py
@@ -147,8 +147,12 @@ class WalletManager:
                             if len(loaded_wallet.pending_psbts) > 0:
                                 for psbt in loaded_wallet.pending_psbts:
                                     logger.info(
-                                        "lock %s " % wallet_alias,
-                                        loaded_wallet.pending_psbts[psbt].utxo_dict(),
+                                        "lock {} {}".format(
+                                            wallet_alias,
+                                            loaded_wallet.pending_psbts[
+                                                psbt
+                                            ].utxo_dict(),
+                                        )
                                     )
                                     loaded_wallet.rpc.lockunspent(
                                         False,


### PR DESCRIPTION
Fixed logging error, which was caused by passing 2 arguments to logger.info()