### PR TITLE
Bugfix: logging-system screwup

### DIFF
--- a/src/cryptoadvance/specter/devices/hwi/jade.py
+++ b/src/cryptoadvance/specter/devices/hwi/jade.py
@@ -875,7 +875,7 @@ def enumerate(password: str = "") -> List[Dict[str, Any]]:
 
     except Exception as e:
         # If we get any sort of error do not add the simulator
-        logging.debug(f"Failed to connect to Jade simulator at {SIMULATOR_PATH}")
-        logging.debug(e)
+        logger.debug(f"Failed to connect to Jade simulator at {SIMULATOR_PATH}")
+        logger.debug(e)
 
     return results


### PR DESCRIPTION
Since this commit: https://github.com/cryptoadvance/specter-desktop/commit/57091ff2b8d0f94f4ff47bdd00c485799b1eb165 we're having some sort of logging screwup in testing-mode.

THis should fix it.