### PR TITLE
BugFix in RBF flow

### DIFF
--- a/src/cryptoadvance/specter/server_endpoints/wallets.py
+++ b/src/cryptoadvance/specter/server_endpoints/wallets.py
@@ -545,6 +545,7 @@ def send_new(wallet_alias):
                 fee_rate = float(request.form["rbf_fee_rate"])
                 fee_options = "manual"
                 rbf = True
+                fillform = True
             except Exception as e:
                 handle_exception(e)
                 flash(_("Failed to perform RBF. Error: {}").format(e), "error")

--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -1076,6 +1076,7 @@ class Wallet:
                     rpc_tx = self.rpc.gettransaction(tx["txid"])
                     tx["fee"] = rpc_tx.get("fee", 1)
                     tx["confirmations"] = rpc_tx.get("confirmations", 0)
+                    tx["vsize"] = decoderawtransaction(rpc_tx["hex"]).get("vsize")
 
                 if isinstance(tx["address"], str):
                     tx["label"] = self.getlabel(tx["address"])
@@ -1828,8 +1829,6 @@ class Wallet:
                 "txid": utxo["txid"],
                 "vout": utxo["vout"],
                 "amount": utxo["details"]["value"],
-                "address": get_address_from_dict(utxo["details"]),
-                "label": self.getlabel(get_address_from_dict(utxo["details"])),
             }
             for utxo in rbf_utxo
         ]


### PR DESCRIPTION
The missing fee rate in https://github.com/cryptoadvance/specter-desktop/issues/1467#issuecomment-1040562857  let me to discover that `this.tx.vsize` in https://github.com/cryptoadvance/specter-desktop/blob/352355e8d711be8ec5ee9372c92dbabbd6435359/src/cryptoadvance/specter/templates/includes/tx-row.html#L318 was `None`.
This PR is a fix and now there is a suggested higher fee rate visible for RBF:
![image](https://user-images.githubusercontent.com/60378539/154135942-bdb200aa-82ab-4154-b24a-9a24ad76523f.png)


Additionally was the `fillform = True` not set, which led to that the "Create Transaction" form was not filled, after one clicked on 
![image](https://user-images.githubusercontent.com/60378539/154136716-f5f8fb39-2f1b-4612-a615-a9e0edbd727b.png)

