### PR TITLE
Update the daemon.md instructions to include the tarball release

### DIFF
--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -26,6 +26,50 @@ WantedBy=multi-user.target
 
 To stop run `sudo systemctl stop specter.service`, to restart `sudo systemctl restart specter.service`
 
+### Specter as a Service using the linux tarball (tar.gz) release
+
+Users may want to run the linux tarball release as a system service. This has the added benefits over the python release of being easily verifiable using the release signing keys.
+Unfortunately, there are some legacy locale issues that make running the tarball service difficult, so we will need to set local variables in a startup script that will then be called by the systemd service file.
+
+1. Create a file where you normally add manually installed apps and scripts: e.g. `/usr/local/bin/start_specterd`
+2. Add the following to the file:
+```
+#!/bin/bash
+
+#script to set correct system local before starting specterd
+
+export LC_ALL=C.UTF-8
+export LANG=C.UTF-8
+
+/usr/bin/specterd server --host localhost --port 25441 \
+# & ssh -nN -R 25441:localhost:25441 user@specter.mydomain.com \
+# && fg
+
+```
+3. Make the script executable `sudo chmod +x /ust/local/bin/start_specterd`
+4. Incorporate the script into your `specter.service` file:
+
+```
+[Unit]
+Description=Specter Desktop Service
+After=multi-user.target
+Conflicts=getty@tty1.service
+
+[Service]
+User=myusername
+Type=simple
+ExecStart=/usr/local/bin/start_specterd
+StandardInput=tty-force
+
+[Install]
+WantedBy=multi-user.target
+```
+5. To start the specter service run `sudo systemctl daemon-reload && sudo systemctl enable --now specter.service`
+
+You can check the status of specter.service by running `systemctl status specter.service` or for debugging, you can get more information by running `sudo journalctl -fu specter.service`
+
+The commented section of the service file above refers to an optional reverse proxy setup which is covered in the [reverse_proxy.md](reverse_proxy.md) document.
+
 ## bitcoind as a Service
 
 You can do the same for `bitcoind` if you want to, then both Specter and bitcoind will start on system boot.


### PR DESCRIPTION
The linux tarball release of specter-desktop has some locale issues that have not yet been fixed. To get around this, a short script is added to the systemd service file that sets the correct locale then launches the app.