### PR TITLE
Update docs/reverse-proxy.md

### DIFF
--- a/docs/reverse-proxy.md
+++ b/docs/reverse-proxy.md
@@ -49,6 +49,30 @@ ssh -nN -R 25441:localhost:25441 user@specter.mydomain.com
 
 Check in your browser - when you navigate to `http://specter.mydomain.com` you should see Specter already.
 
+## Incorporate SSH tunnel into Specter.service file
+
+To launch specter automatically on system startup, see [daemon.md](./daemon.md). Whether you use the specter python package or the tar.gz release, you can incorporate an ssh port forward to your reverse proxy to start automatically with specter. 
+
+For the python approach, would use the following specter.service file:
+
+```
+[Unit]
+Description=Specter Desktop Service
+After=multi-user.target
+Conflicts=getty@tty1.service
+
+[Service]
+User=myusername
+Type=simple
+ExecStart=/usr/bin/python3 -m cryptoadvance.specter server & ssh -nN -R 25441:localhost:25441 user@specter.mydomain.com && fg
+StandardInput=tty-force
+
+[Install]
+WantedBy=multi-user.target
+```
+
+The approach for using the tarball is commented out in the example in [daemon.md](./daemon.md).
+
 ## Adding HTTPS
 
 HTTPS is very important, not only because it is secure, but also because without HTTPS we can't use camera to scan QR codes. We need to get secure connection.

--- a/src/cryptoadvance/specter/devices/hwi/jade.py
+++ b/src/cryptoadvance/specter/devices/hwi/jade.py
@@ -875,7 +875,7 @@ def enumerate(password: str = "") -> List[Dict[str, Any]]:
 
     except Exception as e:
         # If we get any sort of error do not add the simulator
-        logging.debug(f"Failed to connect to Jade simulator at {SIMULATOR_PATH}")
-        logging.debug(e)
+        logger.debug(f"Failed to connect to Jade simulator at {SIMULATOR_PATH}")
+        logger.debug(e)
 
     return results


### PR DESCRIPTION
Added instructions to incorporate automatic ssh tunneling into the specter.service file. This should streamline setup of a headless system that automatically port forwards to a reverse proxy. 