### PR TITLE
Fix App Icon for Gnome Dock #1158

### DIFF
--- a/pyinstaller/electron/main.js
+++ b/pyinstaller/electron/main.js
@@ -192,6 +192,7 @@ function initMainWindow(specterURL) {
   mainWindow = new BrowserWindow({
     width: parseInt(dimensions.width * 0.8),
     height: parseInt(dimensions.height * 0.8),
+    icon: path.join(__dirname, '/assets/icon.png'),
     webPreferences
   })
   


### PR DESCRIPTION
Fixes missing app icon.

Kudos to this for the hint - https://github.com/electron-userland/electron-builder/issues/2269#issuecomment-342168989