### PR TITLE
UI: Added scrollbar for transaction list

### DIFF
--- a/src/cryptoadvance/specter/static/styles.css
+++ b/src/cryptoadvance/specter/static/styles.css
@@ -668,6 +668,7 @@ table{
 .table-holder{
     padding: 0 30px;
     width: 100%;
+    overflow-y: scroll;
     /*overflow-x: scroll;*/
 }
 .full-width{


### PR DESCRIPTION
Implemented based on suggestion in https://github.com/cryptoadvance/specter-desktop/issues/673

It's a very quick-and-easy fix.  The scrollbar is not ideal, but better than no scrollbar at all.  Best would be to scroll only the transactions (without the header).  

(scrolling example)
![image](https://user-images.githubusercontent.com/60378539/154840351-8b8703c0-e604-4239-b88d-a07401d48100.png)
![image](https://user-images.githubusercontent.com/60378539/154840373-40baf123-fcce-4c7a-9499-0bfcc75c0a02.png)
