### PR TITLE
UI: Margin under 'Device type' dropdown

### DIFF
--- a/src/cryptoadvance/specter/templates/device/device.jinja
+++ b/src/cryptoadvance/specter/templates/device/device.jinja
@@ -13,7 +13,7 @@
 	<h1 id="title">{{ device.name }}</h1>
 	{% from 'components/editable_title.jinja' import editable_title %}
 	{{ editable_title(device.name) }}
-	<form action="./" method="POST">
+	<form action="./" method="POST" style="margin-bottom: 15px;">
 		<input type="hidden" class="csrf-token" name="csrf_token" value="{{ csrf_token() }}"/>
 		<div class="row" style="text-align: center; line-height: 2;">
 			{% include "device/components/device_type.jinja" %}


### PR DESCRIPTION
closes #1615
Adding a margin under the 'Device type' dropdown in [device.jinja](https://github.com/cryptoadvance/specter-desktop/compare/master...cypherhoodlum:issue_%231615?expand=1#diff-691f38dedb90d1a59b2cf387c96dab702efdf376e10c56e9e354664db213c3ff).