### PR TITLE
Bugfix: versionChecker and downloadloc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ pyinstaller/release-linux
 pyinstaller/release-win
 pyinstaller/version.txt
 pyinstaller/electron/version-data.json
+pyinstaller/electron/downloadloc.js
 pyinstaller/electron/node_modules
 pyinstaller/electron/dist
 .DS_Store

--- a/pyinstaller/electron/downloadloc.js
+++ b/pyinstaller/electron/downloadloc.js
@@ -1,6 +1,6 @@
 
 function getDownloadLocation(version, platformname) {
-    return `http://specterext.bitcoinops.de/user/k9ert/dice/releases/download/${version}/diced-${version}-${platformname}.zip`
+    return `https://github.com/cryptoadvance/specter-desktop/releases/download/${version}/specterd-${version}-${platformname}.zip`
 }
 
 function appName() {

--- a/src/cryptoadvance/specter/util/version.py
+++ b/src/cryptoadvance/specter/util/version.py
@@ -78,7 +78,7 @@ class VersionChecker:
             logger.warning(
                 "We're checking here for a different binary than specter-desktop. We're hopefully in a pytest"
             )
-        latest = VersionChecker._get_latest_version_from_github(self.specter)
+        latest = VersionChecker._get_latest_version_from_github()
         return current, latest
 
     def _get_pip_version(self):
@@ -136,19 +136,19 @@ class VersionChecker:
             self.stop()
         return current, latest, False
 
-    @classmethod
-    def _get_latest_version_from_github(cls, specter):
+    def _get_latest_version_from_github(self):
         try:
-            if specter:
-                requests_session = specter.requests_session(force_tor=False)
+            if self.specter:
+                requests_session = self.specter.requests_session(force_tor=False)
             else:
                 requests_session = requests.Session()
-
+            print(requests_session.get().json())
             releases = (
                 requests_session.get(f"https://pypi.org/pypi/{self.name}/json")
                 .json()["releases"]
                 .keys()
             )
+
             latest = list(releases)[-1]
         except Exception as e:
             logger.exception(e)


### PR DESCRIPTION
fixes:
```
2022-03-21T23:01:38.097Z [info] : stderr-SPECTERD: ERROR in version: name 'self' is not defined
Traceback (most recent call last):
  File "cryptoadvance\specter\util\version.py", line 148, in _get_latest_version_from_github
NameError: name 'self' is not defined
SPECTERD: INFO in version: version checked. upgrade: False
```
and also fixed downloadlocation.