### PR TITLE
Chore: Bump electron from 11.5.0 to 13.6.9 /pyinstaller/electron

### DIFF
--- a/pyinstaller/electron/error_logs.html
+++ b/pyinstaller/electron/error_logs.html
@@ -1,7 +1,7 @@
 <html>
     <link rel="stylesheet" type="text/css" href="./styles.css">
     <body style="overflow: auto; height: 100%;">
-	<div class="card" style="width:90%; max-width: 1000px;">
+	<div class="card" style="width:90%">
 		This window shows you the last 700 lines Logs of the specterApp. This also includes 
         the Logs of specterd which are marked as such. It might give you hints on why specter is not coming up properly.
         The best approach is to scroll to the bottom and then search upwards for errors.
@@ -16,11 +16,7 @@
         const helpers = require('./helpers')
         helpers.getSpecterAppLogs( (lines) => {
             document.getElementById('specterapp-logs').innerText = lines
-        })
-        
-
-
-        
+        }) 
 
     </script>
     </body>

--- a/pyinstaller/electron/main.js
+++ b/pyinstaller/electron/main.js
@@ -481,13 +481,16 @@ function setMainMenu() {
 }
 
 
-function openNewWindow(htmlContentFile) {
+function openNewWindow(htmlContentFile, width, height) {
+  if (! width) {width=700}
+  if (! height) {height=750}
   prefWindow = new BrowserWindow({
-    width: 700,
-    height: 750,
+    width: width,
+    height: height,
     autoHideMenuBar: true,
     webPreferences: {
       nodeIntegration: true,
+      contextIsolation: false, // acceptable as this is not the mainwindow. No remote content!
       enableRemoteModule: true,
       
     }
@@ -506,7 +509,9 @@ function openPreferences() {
 }
 
 function openErrorLog() {
-  openNewWindow("error_logs.html")
+  width = parseInt(dimensions.width * 0.7),
+  height = parseInt(dimensions.height * 0.7)
+  openNewWindow("error_logs.html", width, height)
 }
 
 function showError(error) {

--- a/pyinstaller/electron/package-lock.json
+++ b/pyinstaller/electron/package-lock.json
@@ -17,7 +17,7 @@
         "winston": "^3.3.3"
       },
       "devDependencies": {
-        "electron": "^11.5.0",
+        "electron": "^13.6.9",
         "electron-builder": "^22.9.1"
       }
     },
@@ -54,6 +54,8 @@
         "env-paths": "^2.2.0",
         "filenamify": "^4.1.0",
         "fs-extra": "^8.1.0",
+        "global-agent": "^2.0.2",
+        "global-tunnel-ng": "^2.7.1",
         "got": "^9.6.0",
         "progress": "^2.0.3",
         "semver": "^6.2.0",
@@ -113,9 +115,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "12.12.62",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.62.tgz",
-      "integrity": "sha512-qAfo81CsD7yQIM9mVyh6B/U47li5g7cfpVQEDMfQeF8pSZVwzbhwU3crc0qG4DmpsebpJPR49AKOExQyJ05Cpg==",
+      "version": "14.18.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.12.tgz",
+      "integrity": "sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A==",
       "devOptional": true
     },
     "node_modules/@types/yargs": {
@@ -1029,14 +1031,14 @@
       }
     },
     "node_modules/electron": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-11.5.0.tgz",
-      "integrity": "sha512-WjNDd6lGpxyiNjE3LhnFCAk/D9GIj1rU3GSDealVShhkkkPR3Vh4q8ErXGDl1OAO/faomVa10KoFPUN/pLbNxg==",
+      "version": "13.6.9",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-13.6.9.tgz",
+      "integrity": "sha512-Es/sBy85NIuqsO9MW41PUCpwIkeinlTQ7g0ainfnmRAM2rmog3GBxVCaoV5dzEjwTF7TKG1Yr/E7Z3qHmlfWAg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@electron/get": "^1.0.1",
-        "@types/node": "^12.0.12",
+        "@types/node": "^14.6.2",
         "extract-zip": "^1.0.3"
       },
       "bin": {
@@ -1336,6 +1338,7 @@
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dependencies": {
+        "@types/yauzl": "^2.9.1",
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
         "yauzl": "^2.10.0"
@@ -3433,9 +3436,9 @@
       }
     },
     "@types/node": {
-      "version": "12.12.62",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.62.tgz",
-      "integrity": "sha512-qAfo81CsD7yQIM9mVyh6B/U47li5g7cfpVQEDMfQeF8pSZVwzbhwU3crc0qG4DmpsebpJPR49AKOExQyJ05Cpg==",
+      "version": "14.18.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.12.tgz",
+      "integrity": "sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A==",
       "devOptional": true
     },
     "@types/yargs": {
@@ -4226,13 +4229,13 @@
       }
     },
     "electron": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-11.5.0.tgz",
-      "integrity": "sha512-WjNDd6lGpxyiNjE3LhnFCAk/D9GIj1rU3GSDealVShhkkkPR3Vh4q8ErXGDl1OAO/faomVa10KoFPUN/pLbNxg==",
+      "version": "13.6.9",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-13.6.9.tgz",
+      "integrity": "sha512-Es/sBy85NIuqsO9MW41PUCpwIkeinlTQ7g0ainfnmRAM2rmog3GBxVCaoV5dzEjwTF7TKG1Yr/E7Z3qHmlfWAg==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",
-        "@types/node": "^12.0.12",
+        "@types/node": "^14.6.2",
         "extract-zip": "^1.0.3"
       },
       "dependencies": {

--- a/pyinstaller/electron/package.json
+++ b/pyinstaller/electron/package.json
@@ -19,7 +19,7 @@
   "author": "Specter",
   "license": "MIT",
   "devDependencies": {
-    "electron": "^11.5.0",
+    "electron": "^13.6.9",
     "electron-builder": "^22.9.1"
   },
   "build": {


### PR DESCRIPTION
* update electron
* needs `contextIsolation: false` for the error_logs-window. Acceptable risk.
* error_log-window now bit bigger.