### PR TITLE
fix i18n issue

### DIFF
--- a/src/cryptoadvance/specter/server_endpoints/wallets_api.py
+++ b/src/cryptoadvance/specter/server_endpoints/wallets_api.py
@@ -804,7 +804,7 @@ def txlist_to_csv(wallet: Wallet, _txlist, includePricesHistory=False):
         lazy_gettext("Value ({})").format(symbol),
         lazy_gettext("Rate (BTC/{})").format(symbol)
         if app.specter.unit != "sat"
-        else _("Rate ({}/SAT)").format(symbol),
+        else lazy_gettext("Rate ({}/SAT)").format(symbol),
         lazy_gettext("TxID"),
         lazy_gettext("Address"),
         lazy_gettext("Block Height"),
@@ -887,11 +887,12 @@ def addresses_list_to_csv(wallet: Wallet):
     w = csv.writer(data)
     # write header
     row = (
-        _("Address"),
-        _("Label"),
-        _("Index"),
-        _("Used"),
-        _("Current balance"),
+        # For some reason (probably app-context_specific) the _ apprev of lazy_gettext does not work
+        lazy_gettext("Address"),
+        lazy_gettext("Label"),
+        lazy_gettext("Index"),
+        lazy_gettext("Used"),
+        lazy_gettext("Current balance"),
     )
     w.writerow(row)
     yield data.getvalue()
@@ -938,13 +939,14 @@ def wallet_addresses_list_to_csv(addresses_list):
     w = csv.writer(data)
     # write header
     row = (
-        _("Index"),
-        _("Address"),
-        _("Type"),
-        _("Label"),
-        _("Used"),
-        _("UTXO"),
-        _("Amount (BTC)"),
+        # For some reason (probably app-context_specific) the _ apprev of lazy_gettext does not work
+        lazy_gettext("Index"),
+        lazy_gettext("Address"),
+        lazy_gettext("Type"),
+        lazy_gettext("Label"),
+        lazy_gettext("Used"),
+        lazy_gettext("UTXO"),
+        lazy_gettext("Amount (BTC)"),
     )
     w.writerow(row)
     yield data.getvalue()


### PR DESCRIPTION
In some cases, we still have a weird bug ` local variable '_' referenced before assignment`

This seem to happen when using MacOS apps with newer MacOS and then exporting Txs or addresses with historic prices.

```
2022-04-07T16:23:27.162Z [info] : stderr-SPECTERD: INFO in _internal: 127.0.0.1 - - [07/Apr/2022 18:23:27] "GET /wallets/wallet/storage_arbeit_2/transactions.csv?exportPrices=true&search=&sortby=time&sortdir=desc HTTP/1.1" 500 -

2022-04-07T16:23:27.163Z [info] : stderr-SPECTERD: ERROR in _internal: Error on request:
Traceback (most recent call last):
  File "/var/folders/cr/wr00rr_d77q9xh0ht13tcjrc0000gn/T/_MEImMmNnf/werkzeug/serving.py", line 323, in run_wsgi
    
  File "/var/folders/cr/wr00rr_d77q9xh0ht13tcjrc0000gn/T/_MEImMmNnf/werkzeug/serving.py", line 314, in execute
    
  File "/var/folders/cr/wr00rr_d77q9xh0ht13tcjrc0000gn/T/_MEImMmNnf/werkzeug/wsgi.py", line 506, in __next__
    
  File "/var/folders/cr/wr00rr_d77q9xh0ht13tcjrc0000gn/T/_MEImMmNnf/werkzeug/wrappers/base_response.py", line 45, in _iter_encoded
    
  File "/var/folders/cr/wr00rr_d77q9xh0ht13tcjrc0000gn/T/_MEImMmNnf/flask/helpers.py", line 162, in generator
    
  File "/var/folders/cr/wr00rr_d77q9xh0ht13tcjrc0000gn/T/_MEImMmNnf/cryptoadvance/specter/server_endpoints/wallets_api.py", line 799, in txlist_to_csv
    
UnboundLocalError: local variable '_' referenced before assignment
```