### PR TITLE
Chore: upgrade cypress to 9.5.4 part2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -75,7 +75,9 @@ cypress_test_task:
     - virtualenv --version
   << : *PREP_STUFF_TEMPLATE
   npm_cache:
-    folder: ./node_modules
+    folders:
+      - ./node_modules
+      - /root/.cache/Cypress
     fingerprint_script: cat package-lock.json
     populate_script: npm ci
   cypress_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -64,7 +64,7 @@ test_task:
 
 cypress_test_task:
   container:
-    image: registry.gitlab.com/cryptoadvance/specter-desktop/cypress-python:latest
+    image: registry.gitlab.com/cryptoadvance/specter-desktop/cypress-python:v9.5.4
     cpu: 6
     memory: 6G
   pre_prep_script: 
@@ -75,9 +75,7 @@ cypress_test_task:
     - virtualenv --version
   << : *PREP_STUFF_TEMPLATE
   npm_cache:
-    folders:
-      - ./node_modules
-      - ../../root/.cache/Cypress # needs to be raltive 
+    folder: ./node_modules
     fingerprint_script: cat package-lock.json
     populate_script: npm ci
   cypress_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -77,7 +77,7 @@ cypress_test_task:
   npm_cache:
     folders:
       - ./node_modules
-      - /root/.cache/Cypress
+      - ../../root/.cache/Cypress # needs to be raltive 
     fingerprint_script: cat package-lock.json
     populate_script: npm ci
   cypress_script:

--- a/docker/cypress-python/Dockerfile
+++ b/docker/cypress-python/Dockerfile
@@ -10,5 +10,5 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get install  --no-install-recommends -y
 
 WORKDIR /test
 RUN rm -rf node_modules package-lock.json ~/.cache/Cypress
-RUN npm install --save-dev cypress@7.1.0
+RUN npm install --save-dev cypress@9.5.4
 RUN $(npm bin)/cypress verify


### PR DESCRIPTION
The version is preinstalled in a docker-image. It should get updated with every run anyway but in order to avoid that and speed up the build, let's update the docker-image as well.
Part 1 was in #1672 