### PR TITLE
Fix: Button alignment issue 

### DIFF
--- a/src/cryptoadvance/specter/templates/includes/tx-row.html
+++ b/src/cryptoadvance/specter/templates/includes/tx-row.html
@@ -107,18 +107,18 @@
         </td>
         <td id="column-time" class="time"></td>
         <td id="column-confirmations">
-            <div style="display: flex; align-items: center;">
+            <div style="display: flex;">
                 <span class="confirmations"></span>
-                <div style="flex:1; display: flex; justify-content: center; align-items: center; flex-wrap: wrap;">
-                    <button class="rbf btn optional hidden" style="width: 130px; flex-grow: 0; margin: 5px;" type="button">{{ _("Speed up") }}</button>
-                    <button class="rbf-cancel danger btn optional hidden" style="width: 130px; flex-grow: 0; margin: 5px;" type="button">{{ _("Cancel transaction") }}</button>
-                </div>
             </div>
         </td>
         <td class="hidden optional blockhash"></td>
         <td id="column-action" class="highlight-box">
             <input class="select-tx-value" type="hidden" value="">
             <img style="vertical-align: middle;" class="select-tx-img" src="{{ url_for('static', filename='img/checkbox-untick.svg') }}" width="25px">
+            <div style="display: flex; justify-content: center; align-items: center; flex-wrap: wrap;">
+                <button class="rbf btn optional hidden" style="width: 130px; margin: 2px;" type="button">{{ _("Speed up") }}</button>
+                <button class="rbf-cancel danger btn optional hidden" style="width: 130px; margin: 2px;" type="button">{{ _("Cancel transaction") }}</button>
+            </div>
         </td>
     </tr>
 </template>

--- a/src/cryptoadvance/specter/templates/includes/tx-row.html
+++ b/src/cryptoadvance/specter/templates/includes/tx-row.html
@@ -106,10 +106,14 @@
             <span class="amount-price note hidden">()</span>
         </td>
         <td id="column-time" class="time"></td>
-        <td id="column-confirmations" >
-            <span class="confirmations"></span>
-            <button class="rbf btn optional hidden" style="width: 130px; float: right;" type="button">{{ _("Speed up") }}</button>
-            <button class="rbf-cancel danger btn optional hidden" style="width: 130px; float: right; margin-right: 10px;" type="button">{{ _("Cancel transaction") }}</button>
+        <td id="column-confirmations">
+            <div style="display: flex; align-items: center;">
+                <span class="confirmations"></span>
+                <div style="flex:1; display: flex; justify-content: center; align-items: center; flex-wrap: wrap;">
+                    <button class="rbf btn optional hidden" style="width: 130px; flex-grow: 0; margin: 5px;" type="button">{{ _("Speed up") }}</button>
+                    <button class="rbf-cancel danger btn optional hidden" style="width: 130px; flex-grow: 0; margin: 5px;" type="button">{{ _("Cancel transaction") }}</button>
+                </div>
+            </div>
         </td>
         <td class="hidden optional blockhash"></td>
         <td id="column-action" class="highlight-box">

--- a/src/cryptoadvance/specter/templates/includes/tx-row.html
+++ b/src/cryptoadvance/specter/templates/includes/tx-row.html
@@ -107,9 +107,7 @@
         </td>
         <td id="column-time" class="time"></td>
         <td id="column-confirmations">
-            <div style="display: flex;">
-                <span class="confirmations"></span>
-            </div>
+            <span class="confirmations"></span>
         </td>
         <td class="hidden optional blockhash"></td>
         <td id="column-action" class="highlight-box">

--- a/src/cryptoadvance/specter/templates/includes/tx-table.html
+++ b/src/cryptoadvance/specter/templates/includes/tx-table.html
@@ -939,7 +939,14 @@
                 } else {
                     pending_psbts = []
                 }
-                for (let txRow of this.shadowRoot.querySelectorAll('tx-row')) { 
+                for (let txRow of this.shadowRoot.querySelectorAll('tx-row')) {
+                    // This is currently not needed since the UTXO list API endpoint does not return "bip125-replaceable" and thus the rbf buttons are hidden in the tx-row web component
+                    if (this.utxoViewBtn.classList.contains("checked")) {
+                        if (txRow.tx["bip125-replaceable"] && txRow.tx["bip125-replaceable"] == "no") {
+                            txRow.rbf.classList.add('hidden');
+                            txRow.rbfCancel.classList.add('hidden');
+                        }
+                    }
                     // EventListener when hovering over checkboxes
                     txRow.selectTxImg.addEventListener("mouseover", () => {
                         this.actionTeaserDiv.style.color = 'orange';


### PR DESCRIPTION
# Description
- Remove float property used for aligning the buttons, which was causing this issue
- Switch to flexbox for responsive alignment
- Remove hard-coded right alignment, instead centered the buttons to achieve same results

# Visuals
![space-fix-specter](https://user-images.githubusercontent.com/31105595/165500856-6fbbccab-89a6-4737-a52d-fa7c773bfa04.gif)

# TODO
- [x] Should I handle the same case for mobile layout also? As of now, these buttons will disappear in the mobile window, since display will be set to "none" by optional class.