### PR TITLE
Fix: Change specter compatibility to ">=3.7,<3.10" due to dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         "Operating System :: OS Independent",
         "Framework :: Flask",
     ],
-    python_requires=">=3.6,<3.10",
+    python_requires=">=3.7,<3.10",
     cmdclass={
         "install": InstallWithBabelCompile,
         # The rest is convenience but not strictly necessary for the automation:


### PR DESCRIPTION
The specter requirements include
https://github.com/cryptoadvance/specter-desktop/blob/8e6c374c110aca9639aa4b6cc3f3e2d5b0605a6e/requirements.in#L3
which has the requirement  https://pypi.org/project/click/8.1.1/
![image](https://user-images.githubusercontent.com/60378539/167142261-3dba8da5-5ce1-457d-8915-4ff9b1d6fee0.png)

This then requires for specter also to have python>= 3.7