### PR TITLE
Chore: Refactor HWIBridge init

### DIFF
--- a/src/cryptoadvance/specter/hwi_server.py
+++ b/src/cryptoadvance/specter/hwi_server.py
@@ -18,7 +18,6 @@ from .helpers import deep_update, hwi_get_config, save_hwi_bridge_config
 hwi_server = Blueprint("hwi_server", __name__)
 CORS(hwi_server)
 rand = random.randint(0, 1e32)  # to force style refresh
-hwi = HWIBridge()
 
 
 @hwi_server.route("/", methods=["GET"])
@@ -103,7 +102,7 @@ def api():
         response = json.loads(forwarded_request.content)
         return jsonify(response)
 
-    return jsonify(hwi.jsonrpc(data))
+    return jsonify(app.specter.hwi.jsonrpc(data))
 
 
 @hwi_server.route("/settings/", methods=["GET", "POST"])

--- a/src/cryptoadvance/specter/server.py
+++ b/src/cryptoadvance/specter/server.py
@@ -2,6 +2,7 @@ import logging
 import os
 import sys
 from pathlib import Path
+from cryptoadvance.specter.hwi_rpc import HWIBridge
 
 from cryptoadvance.specter.liquid.rpc import LiquidRPC
 from cryptoadvance.specter.managers.service_manager import ServiceManager
@@ -138,6 +139,9 @@ def init_app(app: SpecterFlask, hwibridge=False, specter=None):
             config=app.config["DEFAULT_SPECTER_CONFIG"],
             internal_bitcoind_version=app.config["INTERNAL_BITCOIND_VERSION"],
         )
+
+    # HWI
+    specter.hwi = HWIBridge()
 
     # ServiceManager will instantiate and register blueprints for extensions
     specter.service_manager = ServiceManager(


### PR DESCRIPTION
HWIBridge is a relevant component which sometimes creates issues at startup. As all the other components, it should get instantiated within the init_app-mathod, not at import time.