### PR TITLE
Corrected readme

### DIFF
--- a/pyinstaller/README.md
+++ b/pyinstaller/README.md
@@ -9,9 +9,12 @@ This will update the file hash and version name the Specter Desktop app expects 
 
 # Pyinstaller build
 
-`cd` into this directory (`specter-desktop/pyinstaller`) and install requirements:
+Install requirements:
 
 ```bash
+$ virtualenv --python=python3 .buildenv
+$ source .buildenv/bin/activate 
+$ cd pyinstaller
 $ pip3 install -r requirements.txt --require-hashes
 ```
 

--- a/src/cryptoadvance/specter/managers/service_manager.py
+++ b/src/cryptoadvance/specter/managers/service_manager.py
@@ -308,13 +308,15 @@ class ServiceManager:
         # Those pathes are absolute. Let's make them relative:
         arr = [Path(*path.parts[-6:]) for path in arr]
 
+        virtuelenv_path = os.path.relpath(os.environ["VIRTUAL_ENV"], ".")
+
         if os.name == "nt":
-            virtualenv_search_path = Path("..", ".buildenv", "Lib")
+            virtualenv_search_path = Path(virtuelenv_path, "Lib")
         else:
             # let's calcultate so that we get something like:
             # virtualenv_search_path = Path("..", ".buildenv", "lib", "python3.8")
             site_package = [path for path in sys.path if "site-packages" in path][0]
-            site_package = Path("..", ".buildenv", *(Path(site_package).parts[-3:-1]))
+            site_package = Path(virtuelenv_path, *(Path(site_package).parts[-3:-1]))
             virtualenv_search_path = site_package
 
         # ... and as the classes are in the .buildenv (see build-unix.sh) let's add ..


### PR DESCRIPTION
The build only works for virtuelenv and a specfic env name (see https://github.com/cryptoadvance/specter-desktop/issues/1710#issuecomment-1140179748 ). 

- Updated the docs to give correct instructions.
- Made that the build env can have any name

