### PR TITLE
 fix typo in error_logs

### DIFF
--- a/pyinstaller/electron/error_logs.html
+++ b/pyinstaller/electron/error_logs.html
@@ -5,7 +5,7 @@
 		This window shows you the last 700 lines Logs of the specterApp. This also includes 
         the Logs of specterd which are marked as such. It might give you hints on why specter is not coming up properly.
         The best approach is to scroll to the bottom and then search upwards for errors.
-        You can find the logfile in [youHomedirectory]/.specter/specterApp.log.
+        You can find the logfile in [yourHomedirectory]/.specter/specterApp.log.
 		<pre><code id="specterapp-logs"></code></pre>
 		<br>
 	


### PR DESCRIPTION
Fixed a typo in the error_logs.html file regarding the path of the log file