### PR TITLE
UIUX: Polishment of the about page

### DIFF
--- a/src/cryptoadvance/specter/static/styles.css
+++ b/src/cryptoadvance/specter/static/styles.css
@@ -235,7 +235,6 @@ nav.side > a.item.active, nav.side > div > a.item.active{
     max-width: 90%;
     padding-left: 1em;
     padding-right: 1em;
-    padding-top: .5em;
     margin-bottom: 1em;
     background-color: #263044;
     border: 1px solid #CCCCCC;

--- a/src/cryptoadvance/specter/templates/base.jinja
+++ b/src/cryptoadvance/specter/templates/base.jinja
@@ -127,8 +127,8 @@
 					{% endif %}
 					<div style="display: flex; justify-content: center; align-items: center;">
 						<div class="main-description-box">
-							<p style="font-size: 1.1em; margin-bottom: 2em; text-align: left;">{{ _("Specter Desktop is a convenient wallet interface to better use your Bitcoin Core node. It’s good for singlesig wallets, but comes with a special focus on multisignature setups for different hardware wallets and air-gapped signing devices.") }}
-								Learn <a style="color: #fff" href="https://specter-desktop-docs.netlify.app/multisig-guide/" target="_blank">🕮 {{ _("here") }}</a> more about multisig.
+							<p style="font-size: 1.1em; margin: 1em auto 1em auto; text-align: left;">{{ _("Specter Desktop is a convenient wallet interface to better use your Bitcoin Core node. It’s good for singlesig wallets, but comes with a special focus on multisignature setups for different hardware wallets and air-gapped signing devices.") }} <br><br>
+							&#128217; Learn <a style="color: #fff" href="https://specter-desktop-docs.netlify.app/multisig-guide/" target="_blank">{{ _("here") }}</a> more about multisig.
 							</p>
 						</div>
 					</div>
@@ -243,14 +243,14 @@
 						</table>
 						<br>
 					{% endif %}
-					<p style="position: relative; z-index: 1; line-height: 24px;">{{ _('Have a look at our <a href="https://specter-desktop-docs.netlify.app/" target="_blank" style="color: #fff; font-size: 1.05em; font-weight: bolder;">🕮 help</a> or <a href="https://specter-desktop-docs.netlify.app/faq/" target="_blank" style="color: #fff; font-size: 1.05em; font-weight: bolder;">FAQ</a>') }}</p><br><br>
-					<span style="position: relative; z-index: 1;">{{ _("Still having issues?") }}</span><br>
+					<p style="position: relative; z-index: 1; line-height: 24px; font-size: 1.1em">&#128064;{{ _(' Have a look at our <a href="https://specter-desktop-docs.netlify.app/" target="_blank" style="color: #fff; font-weight: bolder;">documentation</a> and the <a href="https://specter-desktop-docs.netlify.app/faq/" target="_blank" style="color: #fff; font-weight: bolder;">FAQ</a>') }}</p><br>
+					<span style="position: relative; z-index: 1;">&#128583;{{ _(" Still having issues?") }}</span><br>
 					<div style="display: flex; justify-content: center;">
 						<div style="max-width: 80%;">
-							<p style="position: relative; z-index: 1;">{{ _('Feel free to <a href="https://github.com/cryptoadvance/specter-desktop/issues/new" target="_blank" style="color: #fff;">open an issue on the GitHub</a> or ask in the <a href="https://t.me/spectersupport" target="_blank" style="color: #fff;">Specter Community telegram chat</a>') }}</p>
+							<p style="position: relative; z-index: 1;">{{ _('Feel free to <a href="https://github.com/cryptoadvance/specter-desktop/issues/new" target="_blank" style="color: #fff;">open an issue on GitHub</a> or ask in the <a href="https://t.me/spectersupport" target="_blank" style="color: #fff;">Specter Community telegram chat</a>') }}</p>
 						</div>
 					</div>
-					<br><br>
+					<br>
 					<a href="https://github.com/cryptoadvance/specter-desktop#help-wanted-do-you-like-specter" target="_blank" style="position: relative; z-index: 1; color: #fff; display: inline-block;"><h2 id="help-wanted-text" style="display: inline-block;">{{ _('Help wanted: Do you like Specter?') }}</h2><img src="{{ url_for('static', filename='img/love.png') }}" width="20px" style="vertical-align: sub; margin-left: 10px;"/></a>
 					<div class="footer">
 						<span style="position: relative; z-index: 1;">{{ _("Supported and maintained by") }}:</span><br>

--- a/src/cryptoadvance/specter/templates/wallet/new_wallet/new_wallet_type.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/new_wallet/new_wallet_type.jinja
@@ -56,7 +56,7 @@
 
 
 	<span style="font-size: 1.1em; margin: 10px; text-align: center;">
-		{{ _("New to multisig?") }}&#128217;{{ _(" Learn") }} <a style="color: #fff" href="https://specter-desktop-docs.netlify.app/multisig-guide/" target="_blank">here</a> {{ _("more about multisig") }}. 
+		{{ _("New to multisig? ") }}&#128217;{{ _(" Learn") }} <a style="color: #fff" href="https://specter-desktop-docs.netlify.app/multisig-guide/" target="_blank">here</a> {{ _("more about multisig") }}. 
 	</span>
 	<br>
 

--- a/src/cryptoadvance/specter/templates/wallet/new_wallet/new_wallet_type.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/new_wallet/new_wallet_type.jinja
@@ -55,8 +55,8 @@
 	{% include "wallet/new_wallet/components/import_wallet_account_map.jinja" %}
 
 
-	<span style="font-size: 1.2em; margin: 10px; text-align: center;">
-		New to Multisig? Read our <a style="color: #fff" href="https://specter-desktop-docs.netlify.app/multisig-guide/" target="_blank">🕮 {{ _("Multisig guide") }}</a>
+	<span style="font-size: 1.1em; margin: 10px; text-align: center;">
+		{{ _("New to multisig?") }}&#128217;{{ _(" Learn") }} <a style="color: #fff" href="https://specter-desktop-docs.netlify.app/multisig-guide/" target="_blank">here</a> {{ _("more about multisig") }}. 
 	</span>
 	<br>
 


### PR DESCRIPTION
### Description
- Fixed unknown html character codes (or whatever it was 😅) in links for multisig guide and documentation
- Bringing the link to the excellent new multisig guide more to the forefront.
- Some more front end polishment of the about page
### Visuals
Now:

<img width="763" alt="grafik" src="https://user-images.githubusercontent.com/70536101/171861527-30b2eee5-5a53-43ae-b76f-34ca78dc2b72.png">

Before:

<img width="763" alt="grafik" src="https://user-images.githubusercontent.com/70536101/171861775-773e442d-ae14-44cd-9d4f-137ce3937434.png">

