### PR TITLE
fix starting server with hardware wallet plugged in

### DIFF
--- a/src/cryptoadvance/specter/hwi_rpc.py
+++ b/src/cryptoadvance/specter/hwi_rpc.py
@@ -75,11 +75,6 @@ class HWIBridge(JSONRPC):
             "extract_master_blinding_key": self.extract_master_blinding_key,
             "bitbox02_pairing": self.bitbox02_pairing,
         }
-        # Running enumerate after beginning an interaction with a specific device
-        # crashes python or make HWI misbehave. For now we just get all connected
-        # devices once per session and save them.
-        print("Initializing HWI...")  # to explain user why it takes so long
-        self.enumerate()
 
     @locked(hwilock)
     def enumerate(self, passphrase="", chain=""):


### PR DESCRIPTION
fix issue where the server stalls on startup waiting for a hardware wallet pin to be entered if such a hardware wallet is plugged in when starting the server

there is no feedback to the user that the startup process is waiting for the hardware wallet pin to be entered (or unplugged) so it is confusing for the user why specter desktop has stalled

I havent experienced the issue documented in the removed code comment below.. perhaps it is not an issue with current HWI version? I guess it will need some more testing to verify:
```
        # Running enumerate after beginning an interaction with a specific device
        # crashes python or make HWI misbehave. For now we just get all connected
        # devices once per session and save them.
```
