### PR TITLE
fix visual artifact in the electron settings dialog

### DIFF
--- a/pyinstaller/electron/settings.html
+++ b/pyinstaller/electron/settings.html
@@ -83,13 +83,13 @@
                 let advancedSettigns = document.getElementById('advanced_settings');
                 if (advancedSettigns.style.display === 'block') {
                     advancedSettigns.style.display = 'none';
-                    advancedButton.innerHTML = `{{ _("Advanced") }} &#9654;`;
+                    advancedButton.innerHTML = 'Advanced &#9654;';
                     if (isCoinSelectionActive()) {
                         toggleExpand();
                     }
                 } else {
                     advancedSettigns.style.display = 'block';
-                    advancedButton.innerHTML = `{{ _("Advanced") }} &#9660;`;
+                    advancedButton.innerHTML = 'Advanced &#9660;';
                 }
             }
 


### PR DESCRIPTION
there are some jinja template variables being used in a non jinja html file

currently after toggling the "Advanced" section you get this visual error:
![image](https://user-images.githubusercontent.com/42459/173058205-252ac8fb-3ded-4254-ba1b-e1aa60248df1.png)

at the moment it doesnt look like transation of the electron UI strings is implemented