### PR TITLE
Bugfix: Longer Timeout for run_the_numbers

### DIFF
--- a/src/cryptoadvance/specter/server_endpoints/wallets_api.py
+++ b/src/cryptoadvance/specter/server_endpoints/wallets_api.py
@@ -67,7 +67,7 @@ def generatemnemonic():
 @login_required
 @app.csrf.exempt
 def txout_set_info():
-    res = app.specter.rpc.gettxoutsetinfo()
+    res = app.specter.rpc.gettxoutsetinfo(timeout=3600)
     return res
 
 


### PR DESCRIPTION
Run the numbers might take several minutes. It needs a bigger timeout.