### PR TITLE
Chore: fix broken cirrus build cache for bitcoind

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -50,7 +50,6 @@ prep_stuff_template: &PREP_STUFF_TEMPLATE
     - source ./.env/bin/activate
     - pip3 install -r requirements.txt --require-hashes && pip3 install -r test_requirements.txt
   install_script: 
-    - ls -l ./tests/elements/src/ 
     - source ./.env/bin/activate
     - pip3 install -e .
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -22,7 +22,7 @@ prep_stuff_template: &PREP_STUFF_TEMPLATE
       - cat tests/elements_gitrev_pinned 2> /dev/null || true
       - cat /etc/os-release | grep VERSION
       - cat ./tests/install_noded.sh
-      - echo "binary" # if the next line is --binary, otherwise compile. Not doing that correctly will break a proper caching switching between both
+      - echo "binary" # if the next line is --elements binary, otherwise use echo "compile" - this ensures different caching keys.
     populate_script: ./tests/install_noded.sh --debug --elements binary
   verify_script: 
     - echo "  --> Version of python, virtualenv and pip3"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,7 +13,7 @@ prep_stuff_template: &PREP_STUFF_TEMPLATE
       - cat tests/bitcoin_gitrev_pinned 2> /dev/null || true
       - cat /etc/os-release | grep VERSION
       - cat ./tests/install_noded.sh
-      - echo "binary" # if the next line is --binary, otherwise compile. Not doing that correctly will break a proper caching switching between both
+      - echo "binary" # if the next line is --bitcoin binary, otherwise use echo "compile" - this ensures different caching keys.
     populate_script: ./tests/install_noded.sh --debug --bitcoin binary
   elementsd_installation_cache:
     folder: ./tests/elements

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -28,7 +28,9 @@ prep_stuff_template: &PREP_STUFF_TEMPLATE
     - echo "  --> Version of python, virtualenv and pip3"
     - python3 --version && virtualenv --version && pip3 --version
     - echo "  --> Executables in tests/elements/src"
-    - find tests/elements/src -maxdepth 1 -type f -executable -exec ls -ld {} \;
+    - find tests/elements/src -maxdepth 1 -type f -executable -exec ls -ld {} \; || true
+    - echo "  --> Executables in tests/elements/bin"
+    - find tests/elements/bin -maxdepth 1 -type f -executable -exec ls -ld {} \; || true
     - echo "  --> Executables in tests/bitcoin/src"
     - find tests/bitcoin/src -maxdepth 1 -type f -executable -exec ls -ld {} \; || true
     - echo "  --> Executables in tests/bitcoin/bin"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,6 +12,8 @@ prep_stuff_template: &PREP_STUFF_TEMPLATE
       - cat pytest.ini | grep "addopts = " | cut -d'=' -f2 |  sed 's/--/+/g' | tr '+' '\n' | grep bitcoin |  cut -d' ' -f2 
       - cat tests/bitcoin_gitrev_pinned 2> /dev/null || true
       - cat /etc/os-release | grep VERSION
+      - cat ./tests/install_noded.sh
+      - echo "binary" # if the next line is --binary, otherwise compile. Not doing that correctly will break a proper caching switching between both
     populate_script: ./tests/install_noded.sh --debug --bitcoin binary
   elementsd_installation_cache:
     folder: ./tests/elements
@@ -19,6 +21,8 @@ prep_stuff_template: &PREP_STUFF_TEMPLATE
       - cat pytest.ini | grep "addopts = " | cut -d'=' -f2 |  sed 's/--/+/g' | tr '+' '\n' | grep elements |  cut -d' ' -f2 
       - cat tests/elements_gitrev_pinned 2> /dev/null || true
       - cat /etc/os-release | grep VERSION
+      - cat ./tests/install_noded.sh
+      - echo "binary" # if the next line is --binary, otherwise compile. Not doing that correctly will break a proper caching switching between both
     populate_script: ./tests/install_noded.sh --debug --elements binary
   verify_script: 
     - echo "  --> Version of python, virtualenv and pip3"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -39,7 +39,8 @@ prep_stuff_template: &PREP_STUFF_TEMPLATE
     - tests/bitcoin/src/bitcoind -version | head -1 || true
     - tests/bitcoin/bin/bitcoind -version | head -1 || true
     - echo "  --> elements version"
-    - tests/elements/src/elementsd -version | head -1
+    - tests/elements/src/elementsd -version | head -1 || true
+    - tests/elements/bin/elementsd -version | head -1 || true
 
   pip_script:
     #folder: /tmp/cirrus-ci-build/.env

--- a/tests/install_noded.sh
+++ b/tests/install_noded.sh
@@ -259,7 +259,7 @@ function sub_binary {
         find ./"$node_impl"/bin -maxdepth 1 -type f -executable -exec ls -ld {} \;
     fi
     echo "    --> checking for ${node_impl}d"
-    test -x ./bitcoin/bin/${node_impl}d || exit 2
+    test -x ./${node_impl}/bin/${node_impl}d || exit 2
     echo "    --> Finished installing ${node_impl}d binary"
     END=$(date +%s)
     DIFF=$(echo "$END - $START" | bc)


### PR DESCRIPTION
The fingerprint_script is not dependent on what exactly the populate_script is or how it is executed. Both is a problem:
in #1780 i've created a new task where i used `--compile` instead of `--binary`.  As a result, it seems that the cache got overridden by a compiled version which affects all branches.
This:
```
./tests/install_noded.sh --debug --bitcoin binary
```
is very different from this:
```
./tests/install_noded.sh --debug --bitcoin compile
```

This should be reflected in the cache key, especially if you want to use both modes at the same time (as in #1780 )

Also there were some issues with the new `--binary` mode of the elementsd version of the install_noded.sh script.