### PR TITLE
Bugfix: support extracting xpub of master xkey derivation

### DIFF
--- a/src/cryptoadvance/specter/hwi_rpc.py
+++ b/src/cryptoadvance/specter/hwi_rpc.py
@@ -262,6 +262,8 @@ class HWIBridge(JSONRPC):
                     derivation, default="xpub", network=network
                 )
                 xpub = convert_xpub_prefix(xpub, slip132_prefix)
+                if derivation == "m":
+                    return "[{}]{}\n".format(master_fpr, xpub)
                 return "[{}/{}]{}\n".format(master_fpr, derivation.split("m/")[1], xpub)
             except Exception as e:
                 logger.warning(


### PR DESCRIPTION
# Description

I tried importing an extended key from my hardware wallet (via hwi) with derivation = 'm'; this resulted in an exception due to a python3 `List index out of range` error. The cause of the error is clear from the code, which tries to access the key path after splitting the derivation on "m/". For this particular edge case, there is no index=1 so the process fails.