### PR TITLE
Add nix shell

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -7,6 +7,7 @@
     - [Install dependencies:](#install-dependencies)
       - [Ubuntu/Debian:](#ubuntudebian)
       - [macOS:](#macos)
+      - [Nix:](#nix)
       - [Arch:](#arch)
       - [Fedora/CentOS:](#fedoracentos)
       - [Windows](#windows)
@@ -50,6 +51,8 @@ sudo apt install libusb-1.0-0-dev libudev-dev libffi-dev libssl-dev build-essent
 ```
 brew install libusb
 ```
+#### Nix:
+The easiest way to get all necessary tools is to run `nix-shell` from the `utils` directory of this repository. You need to have [Nix](https://nixos.org/) installed.
 #### Arch: 
 ```
 sudo pacman -Syu && sudo pacman -S libusb

--- a/utils/shell.nix
+++ b/utils/shell.nix
@@ -1,0 +1,21 @@
+with import <nixpkgs> { };
+with pkgs.python38Packages;
+
+stdenv.mkDerivation {
+  name = "specter-desktop";
+  buildInputs = [
+    python38Full
+    python38Packages.virtualenv
+    python38Packages.pip
+    libusb1
+  ];
+  shellHook = ''
+    cd ..
+    pip3 install virtualenv
+    virtualenv --python=python3 .env
+    source .env/bin/activate
+    pip3 install -r requirements.txt --require-hashes
+    pip3 install -e .
+    python3 setup.py install
+  '';
+}


### PR DESCRIPTION
# Description

This PR makes it easier to develop and run specter desktop for nix users. Install the dependencies by running `nix-shell` from the project's root directory and then run the server with `python3 -m cryptoadvance.specter server --config DevelopmentConfig --debug`.
