### PR TITLE
Bugfix: NoneType has not attribute get in certain circumstances

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -88,6 +88,10 @@ cypress_test_task:
     - source ./.env/bin/activate
     #- pip3 install -e .
     - ./utils/test-cypress.sh --debug run
+  junit_artifacts:
+    path: "cypresstest-output.xml"
+    type: text/xml
+    format: junit
   always:
     cypress_screenshots_artifacts:
       path: "./cypress/screenshots/**"

--- a/cypress.json
+++ b/cypress.json
@@ -18,5 +18,11 @@
     "env": {
       "broadcast_timeout":"8000"
     },
-    "includeShadowDom": false 
+    "includeShadowDom": false,
+    "reporter": "junit",
+    "reporterOptions": {
+      "mochaFile": "cypresstest-output.xml",
+      "toConsole": true
+    }
+
 }

--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -463,7 +463,8 @@ class Wallet:
                     for address in [
                         tx["details"][0].get("address")
                         for tx in txs.values()
-                        if tx.get("details")
+                        if tx
+                        and tx.get("details")
                         and (
                             tx.get("details")[0].get("category") != "send"
                             and tx["details"][0].get("address") not in self._addresses


### PR DESCRIPTION
```
specter-zero
[2022-07-14 13:55:01,646] WARNING in wallet_manager: Failed to load wallet kimhot2: 'NoneType' object has no attribute 'get'
specter-zero
[2022-07-14 13:55:01,648] WARNING in wallet_manager: Traceback (most recent call last):
specter-zero
File "/usr/local/lib/python3.8/site-packages/cryptoadvance/specter/managers/wallet_manager.py", line 201, in _update
specter-zero
loaded_wallet = self.WalletClass.from_json(
specter-zero
File "/usr/local/lib/python3.8/site-packages/cryptoadvance/specter/wallet.py", line 774, in from_json
specter-zero
return cls(
specter-zero
File "/usr/local/lib/python3.8/site-packages/cryptoadvance/specter/wallet.py", line 170, in __init__
specter-zero
self.update()
specter-zero
File "/usr/local/lib/python3.8/site-packages/cryptoadvance/specter/wallet.py", line 625, in update
specter-zero
self.getdata()
specter-zero
File "/usr/local/lib/python3.8/site-packages/cryptoadvance/specter/wallet.py", line 836, in getdata
specter-zero
self.fetch_transactions()
specter-zero
File "/usr/local/lib/python3.8/site-packages/cryptoadvance/specter/wallet.py", line 463, in fetch_transactions
specter-zero
for address in [
specter-zero
File "/usr/local/lib/python3.8/site-packages/cryptoadvance/specter/wallet.py", line 466, in <listcomp>
specter-zero
if tx.get("details")
specter-zero
AttributeError: 'NoneType' object has no attribute 'get'
specter-zero
[2022-07-14 13:55:01,723] WARNING in wallet_manager: Failed to load wallet kimhot2-3: 'NoneType' object has no attribute 'get'
specter-zero
[2022-07-14 13:55:01,725] WARNING in wallet_manager: Traceback (most recent call last):
```