### PR TITLE
Doc: Added necessary command to build instructions

### DIFF
--- a/pyinstaller/README.md
+++ b/pyinstaller/README.md
@@ -14,6 +14,7 @@ Install requirements:
 ```bash
 virtualenv --python=python3 .buildenv
 source .buildenv/bin/activate 
+pip3 install -r requirements.txt --require-hashes
 cd pyinstaller
 pip3 install -r requirements.txt --require-hashes
 ```


### PR DESCRIPTION
Without the `requirements.txt` in the root folder, the build fails.