### PR TITLE
Bugfix: netlify

### DIFF
--- a/utils/mkdocs-wrapper.sh
+++ b/utils/mkdocs-wrapper.sh
@@ -15,8 +15,9 @@
 # We're using mkdocs for creating the static pages
 # We don't pin this dependency as this is not relevant for either testing or
 # production. Therefore it's easier to simply let it upgrade automatically:
-pip3 install mkdocs mkdocs-video  mdx_truly_sane_lists
-# At the sime of this comment, we had: mkdocs==1.2.3
+pip3 install markdown==3.3.7 mkdocs mkdocs-video  mdx_truly_sane_lists
+# At the sime of this comment, we had: mkdocs==1.3.0
+# mdx_truly_sane_lists seems to be dependent on markdown==3.3.7
 
 
 

--- a/utils/mkdocs-wrapper.sh
+++ b/utils/mkdocs-wrapper.sh
@@ -15,9 +15,10 @@
 # We're using mkdocs for creating the static pages
 # We don't pin this dependency as this is not relevant for either testing or
 # production. Therefore it's easier to simply let it upgrade automatically:
-pip3 install markdown==3.3.7 mkdocs mkdocs-video  mdx_truly_sane_lists
+pip3 install mkdocs mkdocs-video  # mdx_truly_sane_lists
+# see #1814
+pip3 install git+https://github.com/relativisticelectron/mdx_truly_sane_lists
 # At the sime of this comment, we had: mkdocs==1.3.0
-# mdx_truly_sane_lists seems to be dependent on markdown==3.3.7
 
 
 


### PR DESCRIPTION
Currently we're suffering:
```
6:36:44 PM: Successfully installed Markdown-3.4.1 PyYAML-6.0 ghp-import-2.1.0 mdx_truly_sane_lists-1.2 mergedeep-1.3.4 mkdocs-1.3.0 mkdocs-video-1.3.0 packaging-21.3 pyparsing-3.0.9 pyyaml-env-tag-0.1 watchdog-2.1.9
6:36:45 PM: ERROR    -  Config value: 'markdown_extensions'. Error: Failed loading extension "mdx_truly_sane_lists".
6:36:45 PM: Aborted with 1 Configuration Errors!
6:36:45 PM: ​
6:36:45 PM: ────────────────────────────────────────────────────────────────
6:36:45 PM:   "build.command" failed                                        
6:36:45 PM: ────────────────────────────────────────────────────────────────
```

The successfull build looked like this:
```
10:05:10 AM: Successfully installed Markdown-3.3.7 PyYAML-6.0 ghp-import-2.1.0 mdx_truly_sane_lists-1.2 mergedeep-1.3.4 mkdocs-1.3.0 mkdocs-video-1.3.0 packaging-21.3 pyparsing-3.0.9 pyyaml-env-tag-0.1 watchdog-2.1.9
```

So let's pin markdown ...