### PR TITLE
BugFix: htmlsafebabel issue on python 3.9

### DIFF
--- a/src/cryptoadvance/specter/htmlsafebabel.py
+++ b/src/cryptoadvance/specter/htmlsafebabel.py
@@ -1,6 +1,6 @@
 from flask_babel import Babel, get_translations
 from jinja2.utils import markupsafe
-from html.parser import HTMLParser
+import html
 
 
 class HTMLSafeBabel(Babel):
@@ -30,4 +30,4 @@ class HTMLSafeBabel(Babel):
 
         Existing entities need to be decoded first to avoid double-encoding.
         """
-        return markupsafe.Markup.escape(HTMLParser().unescape(escaped_string))
+        return markupsafe.Markup.escape(html.unescape(escaped_string))


### PR DESCRIPTION
Could reproduce bug  https://github.com/cryptoadvance/specter-desktop/issues/1815 caused by https://github.com/cryptoadvance/specter-desktop/pull/1793 on master with linux, python 3.9.  This PR fixes it.

- Tested on linux , python 3.8, python 3.9

Needs testing on windows and mac