### PR TITLE
Chore: Detecting Liquid chain

### DIFF
--- a/src/cryptoadvance/specter/commands/psbt_creator.py
+++ b/src/cryptoadvance/specter/commands/psbt_creator.py
@@ -251,7 +251,7 @@ class PsbtCreator:
                                 )
                         else:
                             raise SpecterError(
-                                f"Non-compliant json: Unknown unit {recipient['unit']}"
+                                f"Non-compliant json: Unknown unit {recipient['unit']}. This could be caused by using a special name for your Elements regtest."
                             )
                 except ValueError as e:
                     raise SpecterError(

--- a/src/cryptoadvance/specter/helpers.py
+++ b/src/cryptoadvance/specter/helpers.py
@@ -65,7 +65,7 @@ def is_testnet(chain):
 
 
 def is_liquid(chain):
-    return chain not in ["main", "regtest", "test", "signet", "None", "none", None, ""]
+    return chain in ["liquidv1", "liquidtestnet", "elementsregtest", "elreg"]
 
 
 def normalize_address(addr: str) -> str:

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -3,6 +3,7 @@ import pytest
 import tempfile
 
 from cryptoadvance.specter.node import Node
+from cryptoadvance.specter.helpers import is_liquid
 from mock import MagicMock, call, patch
 
 
@@ -55,7 +56,9 @@ def test_Node_btc(bitcoin_regtest):
         print(f"info = {node.info}")
         # something like:
         # {'chain': 'regtest', 'blocks': 100, 'headers': 100, 'bestblockhash': '5277c27b3b5e8aad8e079a928e4675931ea1638a28c7a33bae4ef26425402259', 'difficulty': 4.656542373906925e-10, 'mediantime': 1622635607, 'verificationprogress': 1, 'initialblockdownload': False, 'chainwork': '00000000000000000000000000000000000000000000000000000000000000ca', 'size_on_disk': 30477, 'pruned': False, 'softforks': {'bip34': {'type': 'buried', 'active': False, 'height': 500}, 'bip66': {'type': 'buried', 'active': False, 'height': 1251}, 'bip65': {'type': 'buried', 'active': False, 'height': 1351}, 'csv': {'type': 'buried', 'active': False, 'height': 432}, 'segwit': {'type': 'buried', 'active': True, 'height': 0}, 'testdummy': {'type': 'bip9', 'bip9': {'status': 'defined', 'start_time': 0, 'timeout': 9223372036854775807, 'since': 0}, 'active': False}}, 'warnings': '', 'mempool_info': {'loaded': True, 'size': 0, 'bytes': 0, 'usage': 0, 'maxmempool': 300000000, 'mempoolminfee': 1e-05, 'minrelaytxfee': 1e-05}, 'uptime': 480, 'blockfilterindex': False, 'utxorescan': None}
-        assert node.info["chain"] == "regtest"
+        chain = node.info["chain"]
+        assert chain == "regtest"
+        assert is_liquid(chain) == False
 
         print(f"network_info = {node.network_info}")
         # something like:
@@ -115,7 +118,9 @@ def test_Node_elm(elements_elreg):
         print(f"info = {node.info}")
         # something like:
         # {'chain': 'regtest', 'blocks': 100, 'headers': 100, 'bestblockhash': '5277c27b3b5e8aad8e079a928e4675931ea1638a28c7a33bae4ef26425402259', 'difficulty': 4.656542373906925e-10, 'mediantime': 1622635607, 'verificationprogress': 1, 'initialblockdownload': False, 'chainwork': '00000000000000000000000000000000000000000000000000000000000000ca', 'size_on_disk': 30477, 'pruned': False, 'softforks': {'bip34': {'type': 'buried', 'active': False, 'height': 500}, 'bip66': {'type': 'buried', 'active': False, 'height': 1251}, 'bip65': {'type': 'buried', 'active': False, 'height': 1351}, 'csv': {'type': 'buried', 'active': False, 'height': 432}, 'segwit': {'type': 'buried', 'active': True, 'height': 0}, 'testdummy': {'type': 'bip9', 'bip9': {'status': 'defined', 'start_time': 0, 'timeout': 9223372036854775807, 'since': 0}, 'active': False}}, 'warnings': '', 'mempool_info': {'loaded': True, 'size': 0, 'bytes': 0, 'usage': 0, 'maxmempool': 300000000, 'mempoolminfee': 1e-05, 'minrelaytxfee': 1e-05}, 'uptime': 480, 'blockfilterindex': False, 'utxorescan': None}
-        assert node.info["chain"] == "elreg"
+        chain = node.info["chain"]
+        assert chain == "elreg"
+        assert is_liquid(chain) == True
 
         print(f"network_info = {node.network_info}")
         # something like:


### PR DESCRIPTION
- Make `is_liquid()` more explicit
- Hint that "Unknown unit" could result from a special name for an Elements regtest (names can be arbitrary)
- Tests for `is_liquid()`

Fixes https://github.com/stepansnigirev/specterext-exfund/issues/5