### PR TITLE
Mobile: Optimisation of tx-table

### DIFF
--- a/src/cryptoadvance/specter/templates/includes/tx-row.html
+++ b/src/cryptoadvance/specter/templates/includes/tx-row.html
@@ -105,7 +105,7 @@
             <span class="amount"></span> 
             <span class="amount-price note hidden">()</span>
         </td>
-        <td id="column-time" class="time"></td>
+        <td id="column-time" class="time optional"></td>
         <td id="column-confirmations">
             <span class="confirmations"></span>
         </td>

--- a/src/cryptoadvance/specter/templates/includes/tx-table.html
+++ b/src/cryptoadvance/specter/templates/includes/tx-table.html
@@ -200,7 +200,6 @@
             width: 100%;
             margin-bottom: 10px;
             border: 1.5px solid var(--cmap-border);
-            overflow-x: auto;
         }
         .scrollbar {
             overflow-y: auto;
@@ -365,7 +364,7 @@
                     <th value="txid"     class="column-txid optional txid-header">TxID<div class="txid-arrow"></div></th>
                     <th value="label"    class="column-label optional label-header">{{ _("Label") }}<div class="label-arrow"></div></th>
                     <th value="amount"   class="column-amount amount-header">{{ _("Amount") }}<div class="amount-arrow"></div></th>
-                    <th value="time"     class="column-time time-header">{{ _("Time") }}<div class="time-arrow up-arrow"></div></th>
+                    <th value="time"     class="column-time time-header optional">{{ _("Time") }}<div class="time-arrow up-arrow"></div></th>
                     <th value="confirmations" class="column-confirmations confirmations-header">{{ _("Confirmations") }}<div class="confirmations-arrow"></div></th>
                     <th value="blockhash" class="column-blockhash optional hidden blockhash-header">
                         <div style="display: flex">


### PR DESCRIPTION
This drops the time column for mobile. Would look like that:

![grafik](https://user-images.githubusercontent.com/70536101/186665965-fdfda830-b637-4aca-afe0-fc6ba6dce900.png)
