### PR TITLE
UIUX: Individual HWI progess for Ledger devices

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,3 +1,24 @@
+# Release Notes
+
+## v1.12.0 August 26, 2022
+- Feature: add faucet and exfund extensions #1820 (Stepan Snigirev)
+- Feature: Dev tools - Adding full python access via javascript for developers #1842 (relativisticelectron)
+- UIUX: Complete overhaul of the tooltips used in Specter Desktop #1813 (Manolis Mandrapilias)
+- UIUX: Easier adding and deleting of recipients #1782 (relativisticelectron)
+- UIUX: Optimize tx-table for mobile screen #1804 (relativisticelectron)
+- Mobile: Some extra height in mobile browsers #1827 (relativisticelectron)
+- Bugfix: Allow mouse selection during address label editing for Firefox #1825 (relativisticelectron)
+- Bugfix: Another broken html part and b tag #1823 (relativisticelectron)
+- Bugfix: Fiat price in address table not visible #1836 (relativisticelectron)
+- Bugfix: remove print statement with buggy expression #1822 (k9ert)
+- Bugfix: fix explorer issue #1838 #1839 (relativisticelectron)
+- Chore: Detecting Liquid chain #1851 (Manolis Mandrapilias)
+- Chore: Fix psbt creator api to work with liquid assets when using json #1831 (Stepan Snigirev)
+- Chore: Upgrade pyinstaller from 4.9 to 5.2 #1807 (k9ert)
+- Docs: Add mobile access question to the FAQ #1829 (Manolis Mandrapilias)
+- Docs: some doc fixes, refactorings and ext clarification #1789 (k9ert)
+- Docs: Supported Python versions #1847 (Willie Wheeler)
+
 ## v1.10.5 Juli 21, 2022
 - Bugfix: startup issues for MacOS App 1815 #1816 (relativisticelectron)
 - Feature: generate app_config.py in extgen #1801 (k9ert)

--- a/src/cryptoadvance/specter/templates/device/device_blinding_key.jinja
+++ b/src/cryptoadvance/specter/templates/device/device_blinding_key.jinja
@@ -39,15 +39,8 @@
 {% block scripts %}
     <script type="text/javascript">
         document.getElementById('connect-hwi').addEventListener('click', async e => {
-            var devicesRadios = document.getElementsByName('devices');
-            let deviceType;
-            for (var i = 0, length = devicesRadios.length; i < length; i++) {
-                if (devicesRadios[i].checked) {
-                    deviceType = devicesRadios[i].value;
-                    break;
-                }
-            }
             // detect devices
+            let deviceType = `{{ device.device_type }}`;
             let devices = await enumerate(deviceType);
             if(devices == null){
                 return

--- a/src/cryptoadvance/specter/templates/device/new_device/new_device_keys.jinja
+++ b/src/cryptoadvance/specter/templates/device/new_device/new_device_keys.jinja
@@ -305,15 +305,8 @@
 
     <script type="text/javascript">
         document.getElementById('connect-hwi').addEventListener('click', async e => {
-            var devicesRadios = document.getElementsByName('devices');
-            let deviceType;
-            for (var i = 0, length = devicesRadios.length; i < length; i++) {
-                if (devicesRadios[i].checked) {
-                    deviceType = devicesRadios[i].value;
-                    break;
-                }
-            }
             // detect devices
+            let deviceType = `{{ device_class.device_type }}`;
             let devices = await enumerate(deviceType);
             if(devices == null){
                 return

--- a/src/cryptoadvance/specter/templates/device/new_device_manual.jinja
+++ b/src/cryptoadvance/specter/templates/device/new_device_manual.jinja
@@ -204,8 +204,8 @@ m/48h/{{ 0 if specter.info.chain == "main" else 1 }}h/0h/2h</textarea>
 			});
 		}
 	}
+	const deviceType = document.getElementById("device_type");
 	function checkType() {
-		var deviceType = document.getElementById("device_type");
 		if (!deviceType.value) {
 			type_reminder.style.display = 'block';
 		} else {
@@ -240,7 +240,6 @@ m/48h/{{ 0 if specter.info.chain == "main" else 1 }}h/0h/2h</textarea>
             {% endfor %}
 			
 		}
-		var deviceType = document.getElementById("device_type");
 		var typeReminder = document.getElementById("type_reminder");
 
 		if(deviceType!=null){
@@ -272,8 +271,12 @@ m/48h/{{ 0 if specter.info.chain == "main" else 1 }}h/0h/2h</textarea>
 	{% include "device/components/add_keys.js" %}
 
 	document.getElementById('askhwi').addEventListener('click', async e=>{
+		// Ensure that device type was selected
+		if (!checkType()) {
+			return
+		}
 		// detect devices
-		let devices = await enumerate();
+		let devices = await enumerate(deviceType.value);
 		if(devices == null){
 			return
 		}

--- a/src/cryptoadvance/specter/templates/includes/hwi/hwi.jinja
+++ b/src/cryptoadvance/specter/templates/includes/hwi/hwi.jinja
@@ -89,6 +89,9 @@
             showHWIProgress(`{{ _("Detecting...") }}`, `{{ _("Plug in your device") }}`);
             }   
         }
+        if (deviceTypes == 'ledger') {
+             showHWIProgress(`{{ _("Detecting...") }}`, `{{ _("Plug in your Ledger. Make sure you have activated the Bitcoin app on your Ledger otherwise Specter can't detect the device.") }}`);
+        }
         let result = [];
         let retryCounter = 0;
         try {

--- a/src/cryptoadvance/specter/templates/includes/hwi/hwi.jinja
+++ b/src/cryptoadvance/specter/templates/includes/hwi/hwi.jinja
@@ -89,9 +89,6 @@
             showHWIProgress(`{{ _("Detecting...") }}`, `{{ _("Plug in your device") }}`);
             }   
         }
-        if (deviceTypes == 'ledger') {
-             showHWIProgress(`{{ _("Detecting...") }}`, `{{ _("Plug in your Ledger. Make sure you have activated the Bitcoin app on your Ledger otherwise Specter can't detect the device.") }}`);
-        }
         let result = [];
         let retryCounter = 0;
         try {

--- a/src/cryptoadvance/specter/templates/includes/hwi/hwi.jinja
+++ b/src/cryptoadvance/specter/templates/includes/hwi/hwi.jinja
@@ -82,7 +82,12 @@
                 }
         // detect device
         if (devicePath == null) {
+            if (deviceTypes == 'ledger') {
+             showHWIProgress(`{{ _("Detecting...") }}`, `{{ _("Plug in your Ledger. Make sure you have activated the Bitcoin app on your Ledger otherwise Specter can't detect the device.") }}`);
+            }
+            else {
             showHWIProgress(`{{ _("Detecting...") }}`, `{{ _("Plug in your device") }}`);
+            }   
         }
         let result = [];
         let retryCounter = 0;

--- a/src/cryptoadvance/specter/templates/includes/hwi/hwi.jinja
+++ b/src/cryptoadvance/specter/templates/includes/hwi/hwi.jinja
@@ -83,7 +83,7 @@
         // detect device
         if (devicePath == null) {
             if (deviceTypes == 'ledger') {
-             showHWIProgress(`{{ _("Detecting...") }}`, `{{ _("Plug in your Ledger. Make sure you have activated the Bitcoin app on your Ledger otherwise Specter can't detect the device.") }}`);
+             showHWIProgress(`{{ _("Detecting...") }}`, `{{ _("Plug in your Ledger. Make sure you have opened the Bitcoin app on your Ledger otherwise Specter can't detect the device.") }}`);
             }
             else {
             showHWIProgress(`{{ _("Detecting...") }}`, `{{ _("Plug in your device") }}`);


### PR DESCRIPTION
### Background 
Apparently, Ledger devices can only be connected if the user has also activated the Bitcoin app on his ledger.
See #1863
### Contents
- Add specific HWI progress message for Ledger (hwi.jinja)
- Fixes to use device_types (other jinja files) - the last thing was actually kind of a bug: It was for example possible to select a Ledger as device, connect a different USB HWW like a Trezor and HWI still worked. 
### Visuals
<img width="342" alt="Screenshot 2022-08-29 at 11 50 59" src="https://user-images.githubusercontent.com/70536101/187294613-96992935-5203-47aa-aa4b-893bb3859c8a.png">
After a couple of unsuccessful attempts:

<img width="343" alt="Screenshot 2022-08-29 at 11 51 10" src="https://user-images.githubusercontent.com/70536101/187294625-c66ac475-d5d8-46fd-a1cd-af056b26d7d0.png">
