### PR TITLE
Added "Open Bitcoin app" verbiage to Ledger Upload Keys page

### DIFF
--- a/src/cryptoadvance/specter/templates/device/new_device/new_device_keys.jinja
+++ b/src/cryptoadvance/specter/templates/device/new_device/new_device_keys.jinja
@@ -91,7 +91,7 @@
                     </span>
                 </div>
                 <div id="hwi-only-instructions" {%if device_class.device_type in ['bitcoincore', 'bitcoincore_watchonly', 'cobo', 'coldcard', 'electrum', 'other', 'specter']%}class="hidden"{% endif %}>
-                    <p>{{ _("Connect your hardware device to the computer via USB.") }}<p>
+                    <p>{{ _("Connect your hardware device to the computer via USB.") }}</p>
                     {% if device_class.device_type == 'ledger' %}
                         <p>NOTE: You must open the Bitcoin app on the Ledger before you can upload your keys.</p>
                     {% endif %}

--- a/src/cryptoadvance/specter/templates/device/new_device/new_device_keys.jinja
+++ b/src/cryptoadvance/specter/templates/device/new_device/new_device_keys.jinja
@@ -91,7 +91,10 @@
                     </span>
                 </div>
                 <div id="hwi-only-instructions" {%if device_class.device_type in ['bitcoincore', 'bitcoincore_watchonly', 'cobo', 'coldcard', 'electrum', 'other', 'specter']%}class="hidden"{% endif %}>
-                    <p>{{ _("Connect your hardware device to the computer via USB.") }}</p>
+                    <p>{{ _("Connect your hardware device to the computer via USB.") }}<p>
+                    {% if device_class.device_type == 'ledger' %}
+                        <p>NOTE: You must open the Bitcoin app on the Ledger before you can upload your keys.</p>
+                    {% endif %}
                 </div>
                 <br>
                 <table>


### PR DESCRIPTION
Targets issue #1863, in addition to the PR that @moneymanolis
submitted.

The idea is to spare the user the annoyance of having to
cancel the upload because s/he didn't know to open the Bitcoin
app before pressing "Upload via USB".