### PR TITLE
Bug fix: stuck fee slider in minimum fee environment

### DIFF
--- a/src/cryptoadvance/specter/templates/includes/fee-selection.html
+++ b/src/cryptoadvance/specter/templates/includes/fee-selection.html
@@ -238,7 +238,8 @@
         // Gets executed after fee initialisation
         initWithFees() {
             // this.feesSlider.min is set above via min_fee
-            this.feesSlider.max = Math.floor(this.fees["fastestFee"] * 1.4)
+            this.feesSlider.max = Math.ceil(this.fees["fastestFee"] * 1.4)
+            this.feesSlider.step = Math.min(1, (this.feesSlider.max - this.feesSlider.min)/10); 
             let sliderMin = this.fees["minimumFee"]
             let sliderMax = this.fees["fastestFee"]
             let average = Math.floor((sliderMin + sliderMax) / 2)


### PR DESCRIPTION
See: https://github.com/cryptoadvance/specter-desktop/issues/1865

The fix is to round up the fastest rate, resulting in 2 sat/vbyte in a maximum feerate in a minimum feerate environment.  
Now it looks like:
![Screenshot_20220904_162939](https://user-images.githubusercontent.com/60378539/188318761-73736f28-7ed5-4f44-b43c-eeb2a5792921.png)
