### PR TITLE
Add non-witness-utxos and xpubs when using hwi with ledger

### DIFF
--- a/src/cryptoadvance/specter/devices/ledger.py
+++ b/src/cryptoadvance/specter/devices/ledger.py
@@ -8,4 +8,4 @@ class Ledger(HWIDevice):
     icon = "ledger_icon.svg"
 
     def create_psbts(self, base64_psbt, wallet):
-        return {"hwi": wallet.fill_psbt(base64_psbt, non_witness=False)}
+        return {"hwi": wallet.fill_psbt(base64_psbt, non_witness=True, xpubs=True)}


### PR DESCRIPTION
Currently, Specter Desktop doesn't add the global xpubs to the psbt when signing transactions with ledger devices. Since [HWI uses them](https://github.com/bitcoin-core/HWI/blob/e731395bde13362950e9f13e01689c475545e4dc/hwilib/devices/ledger.py#L288-L295) to figure out the right parameters for the hardware wallet, HWI falls back to the legacy protocol.

The next release of the Ledger bitcoin app (version 2.1.0) will remove compatiblity with the legacy protocol (before version 2.0.0 of the app), so it will not be able to sign with HWI psbts without the global xpubs.

This instructs Specter to add the xpubs.
Moreover, it also adds the non-witness-utxos, since a warning would be shown if the non-witness-utxo is missing on segwitv0 transactions.

Closes: #1886