### PR TITLE
BugFix: Assume flashed messages and errors are safe

### DIFF
--- a/src/cryptoadvance/specter/templates/base.jinja
+++ b/src/cryptoadvance/specter/templates/base.jinja
@@ -91,12 +91,12 @@
 			{% with messages = get_flashed_messages(with_categories=True) %}
 				{% if messages %}
 					{% for category, message in messages | unique %}
-						<message-box type="{{ category }}">{{ message }}</message-box>
+						<message-box type="{{ category }}">{{ message | safe }}</message-box>
 					{% endfor %}
 				{% endif %}
 			{% endwith %}
 			{% if error %}
-				<message-box type="error">{{ _("ERROR:") }} {{error}}</message-box>
+				<message-box type="error">{{ _("ERROR:") }} {{error | safe }}</message-box>
 			{% endif %}
 			</div>
 


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/60378539/190597516-83be6ef9-5da7-43c6-a6e5-68d8e03dd060.png)

After
![image](https://user-images.githubusercontent.com/60378539/190597317-81171a68-a3a6-4aad-ad29-36f43cab29fa.png)
