### PR TITLE
Chore: Use Python 3.9 for black in pre-commit-config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,4 @@ repos:
     rev: 22.3.0
     hooks:
     - id: black
-      language_version: python3.10
+      language_version: python3.9


### PR DESCRIPTION
Using Python 3.10 for black is problematic / premature since not all requirements.txt-dependencies are yet compatible with Python 3.10 - thus running a virtual env with Python 3.10 (which would satisfy the pre-commit-config) can create issues.