### PR TITLE
UI: Better unconfirmed icons

### DIFF
--- a/src/cryptoadvance/specter/static/img/mixed-clock.svg
+++ b/src/cryptoadvance/specter/static/img/mixed-clock.svg
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="30"
+   height="30"
+   viewBox="0 0 30 30"
+   fill="none"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="mixed.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     id="namedview10"
+     pagecolor="#ffffff"
+     bordercolor="#999999"
+     borderopacity="1"
+     inkscape:pageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="21.466667"
+     inkscape:cx="14.976708"
+     inkscape:cy="15"
+     inkscape:window-width="1920"
+     inkscape:window-height="1007"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg8" />
+  <g
+     id="Page-1"
+     stroke="none"
+     stroke-width="1"
+     fill="none"
+     fill-rule="evenodd">
+    <g
+       id="receive"
+       transform="translate(7.000000, 7.000000)">
+      <path
+         d="M0,12.2436 L0,15.6872 C0,16.1098 0.3426,16.4524 0.76523,16.4524 L15.3045,16.4524 C15.7272,16.4524 16.0698,16.1098 16.0698,15.6872 L16.0698,12.2436"
+         id="Path"
+         stroke="#000000"
+         stroke-width="1.5"
+         stroke-linecap="round"
+         stroke-linejoin="round" />
+      <path
+         d="M5.8872,11.2435 C6.1801,11.5364 6.6549,11.5364 6.9478,11.2435 C7.09335115,11.0704319 7.16612673,10.8927177 7.16612673,10.7103574 C7.16612673,10.5279972 6.91658449,10.175378 6.4175,9.6525 L2.1749,5.4099 C1.882,5.117 1.4071,5.117 1.1142,5.4099 C0.8213,5.7028 0.8213,6.1776 1.1142,6.4705 L5.8872,11.2435 Z M5.6675,0 L5.6675,10.7132 L7.1675,10.7132 L7.1675,0 L5.6675,0 Z"
+         id="Shape"
+         fill="#000000"
+         fill-rule="nonzero" />
+      <path
+         d="M13.8872,11.2435 C14.1801,11.5364 14.6549,11.5364 14.9478,11.2435 C15.0933512,11.0704319 15.1661267,10.8927177 15.1661267,10.7103574 C15.1661267,10.5279972 14.9165845,10.175378 14.4175,9.6525 L10.1749,5.4099 C9.882,5.117 9.4071,5.117 9.1142,5.4099 C8.8213,5.7028 8.8213,6.1776 9.1142,6.4705 L13.8872,11.2435 Z M13.6675,0 L13.6675,10.7132 L15.1675,10.7132 L15.1675,0 L13.6675,0 Z"
+         id="path4"
+         fill="#000000"
+         fill-rule="nonzero"
+         transform="translate(12.031013, 5.731587) scale(-1, -1) translate(-12.031013, -5.731587) " />
+    </g>
+  </g>
+  <g
+     id="g879"
+     transform="translate(-0.03518357,-0.08682249)">
+    <g
+       style="fill:none"
+       id="g838"
+       transform="matrix(0.56923188,0,0,0.56923188,16.217516,-3.2345402)">
+      <path
+         fill-rule="evenodd"
+         clip-rule="evenodd"
+         d="m 24,15 c 0,4.9706 -4.0294,9 -9,9 -4.9706,0 -9,-4.0294 -9,-9 0,-4.9706 4.0294,-9 9,-9 4.9706,0 9,4.0294 9,9 z m -9.4998,-0.0149 c -0.004,0.1329 0.0448,0.267 0.1462,0.3684 l 2.8284,2.8284 c 0.1953,0.1953 0.5119,0.1953 0.7071,0 0.1953,-0.1952 0.1953,-0.5118 0,-0.7071 l -2.682,-2.6819 V 9.96997 c 0,-0.27614 -0.2238,-0.5 -0.5,-0.5 -0.2761,0 -0.5,0.22386 -0.5,0.5 V 14.97 c 0,0.005 10e-5,0.0101 3e-4,0.0151 z"
+         fill="#000000"
+         id="path829" />
+    </g>
+  </g>
+</svg>

--- a/src/cryptoadvance/specter/static/img/receive-clock.svg
+++ b/src/cryptoadvance/specter/static/img/receive-clock.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="30"
+   height="30"
+   viewBox="0 0 30 30"
+   fill="none"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="receive.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#ffffff"
+     bordercolor="#999999"
+     borderopacity="1"
+     inkscape:pageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="21.466667"
+     inkscape:cx="14.976708"
+     inkscape:cy="15"
+     inkscape:window-width="1920"
+     inkscape:window-height="1007"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <path
+     d="M7 19.2436V22.6872C7 23.1098 7.3426 23.4524 7.76523 23.4524H22.3045C22.7272 23.4524 23.0698 23.1098 23.0698 22.6872V19.2436"
+     stroke="black"
+     stroke-width="1.5"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="path2" />
+  <path
+     d="M14.8872 18.2435C15.1801 18.5364 15.6549 18.5364 15.9478 18.2435L20.7208 13.4705C21.0137 13.1776 21.0137 12.7028 20.7208 12.4099C20.4279 12.117 19.953 12.117 19.6601 12.4099L15.4175 16.6525L11.1749 12.4099C10.882 12.117 10.4071 12.117 10.1142 12.4099C9.8213 12.7028 9.8213 13.1776 10.1142 13.4705L14.8872 18.2435ZM14.6675 7L14.6675 17.7132L16.1675 17.7132L16.1675 7L14.6675 7Z"
+     fill="black"
+     id="path4" />
+  <g
+     style="fill:none"
+     id="g838"
+     transform="matrix(0.56923188,0,0,0.56923188,16.160471,-3.2634006)">
+    <path
+       fill-rule="evenodd"
+       clip-rule="evenodd"
+       d="m 24,15 c 0,4.9706 -4.0294,9 -9,9 -4.9706,0 -9,-4.0294 -9,-9 0,-4.9706 4.0294,-9 9,-9 4.9706,0 9,4.0294 9,9 z m -9.4998,-0.0149 c -0.004,0.1329 0.0448,0.267 0.1462,0.3684 l 2.8284,2.8284 c 0.1953,0.1953 0.5119,0.1953 0.7071,0 0.1953,-0.1952 0.1953,-0.5118 0,-0.7071 l -2.682,-2.6819 V 9.96997 c 0,-0.27614 -0.2238,-0.5 -0.5,-0.5 -0.2761,0 -0.5,0.22386 -0.5,0.5 V 14.97 c 0,0.005 10e-5,0.0101 3e-4,0.0151 z"
+       fill="#000000"
+       id="path829" />
+  </g>
+</svg>

--- a/src/cryptoadvance/specter/static/img/send-clock.svg
+++ b/src/cryptoadvance/specter/static/img/send-clock.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="30"
+   height="30"
+   viewBox="0 0 30 30"
+   fill="none"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="send.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#ffffff"
+     bordercolor="#999999"
+     borderopacity="1"
+     inkscape:pageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="21.466667"
+     inkscape:cx="14.976708"
+     inkscape:cy="15"
+     inkscape:window-width="1920"
+     inkscape:window-height="1007"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <path
+     d="M7 19.2791V22.7326C7 23.1564 7.3436 23.5 7.76744 23.5H22.3488C22.7727 23.5 23.1163 23.1564 23.1163 22.7326V19.2791"
+     stroke="black"
+     stroke-width="1.5"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="path2" />
+  <path
+     d="M14.9115 6.46967C15.2044 6.17678 15.6793 6.17678 15.9722 6.46967L20.7452 11.2426C21.0381 11.5355 21.0381 12.0104 20.7452 12.3033C20.4523 12.5962 19.9774 12.5962 19.6845 12.3033L15.4419 8.06066L11.1992 12.3033C10.9063 12.5962 10.4315 12.5962 10.1386 12.3033C9.84567 12.0104 9.84567 11.5355 10.1386 11.2426L14.9115 6.46967ZM14.6919 17.7442L14.6919 7L16.1919 7L16.1919 17.7442L14.6919 17.7442Z"
+     fill="black"
+     id="path4" />
+  <g
+     style="fill:none"
+     id="g838"
+     transform="matrix(0.56923188,0,0,0.56923188,16.219625,-3.2894429)">
+    <path
+       fill-rule="evenodd"
+       clip-rule="evenodd"
+       d="m 24,15 c 0,4.9706 -4.0294,9 -9,9 -4.9706,0 -9,-4.0294 -9,-9 0,-4.9706 4.0294,-9 9,-9 4.9706,0 9,4.0294 9,9 z m -9.4998,-0.0149 c -0.004,0.1329 0.0448,0.267 0.1462,0.3684 l 2.8284,2.8284 c 0.1953,0.1953 0.5119,0.1953 0.7071,0 0.1953,-0.1952 0.1953,-0.5118 0,-0.7071 l -2.682,-2.6819 V 9.96997 c 0,-0.27614 -0.2238,-0.5 -0.5,-0.5 -0.2761,0 -0.5,0.22386 -0.5,0.5 V 14.97 c 0,0.005 10e-5,0.0101 3e-4,0.0151 z"
+       fill="#000000"
+       id="path829" />
+  </g>
+</svg>

--- a/src/cryptoadvance/specter/static/img/transfer-clock.svg
+++ b/src/cryptoadvance/specter/static/img/transfer-clock.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="30"
+   height="30"
+   viewBox="0 0 30 30"
+   fill="none"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="transfer-clock.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     id="namedview10"
+     pagecolor="#ffffff"
+     bordercolor="#999999"
+     borderopacity="1"
+     inkscape:pageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="15.179225"
+     inkscape:cx="16.898096"
+     inkscape:cy="13.867638"
+     inkscape:window-width="1194"
+     inkscape:window-height="790"
+     inkscape:window-x="726"
+     inkscape:window-y="217"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg8">
+    <sodipodi:guide
+       position="6.1024845,21.195652"
+       orientation="1,0"
+       id="guide840" />
+    <sodipodi:guide
+       position="21.475155,24.037267"
+       orientation="0,-1"
+       id="guide842" />
+    <sodipodi:guide
+       position="27.531056,6.0093168"
+       orientation="0,-1"
+       id="guide844" />
+  </sodipodi:namedview>
+  <path
+     d="M6.9303 19.0306V22.4891C6.9303 22.9135 7.27439 23.2576 7.69885 23.2576H22.3013C22.7257 23.2576 23.0698 22.9135 23.0698 22.4891V19.0306"
+     stroke="black"
+     stroke-width="1.5"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="path2" />
+  <path
+     d="M23.0698 13.8902L19.9956 16.9644L16.9214 13.8902"
+     stroke="black"
+     stroke-width="1.5"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="path4" />
+  <path
+     d="M10.0045 16.3144V11.7379C10.0045 8.97896 12.2411 6.74237 15.0001 6.74237V6.74237C17.759 6.74237 19.9956 8.97896 19.9956 11.7379V16.3144"
+     stroke="black"
+     stroke-width="1.5"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="path6" />
+  <g
+     style="fill:none"
+     id="g838"
+     transform="matrix(0.56923188,0,0,0.56923188,16.217516,-3.2345402)">
+    <path
+       fill-rule="evenodd"
+       clip-rule="evenodd"
+       d="m 24,15 c 0,4.9706 -4.0294,9 -9,9 -4.9706,0 -9,-4.0294 -9,-9 0,-4.9706 4.0294,-9 9,-9 4.9706,0 9,4.0294 9,9 z m -9.4998,-0.0149 c -0.004,0.1329 0.0448,0.267 0.1462,0.3684 l 2.8284,2.8284 c 0.1953,0.1953 0.5119,0.1953 0.7071,0 0.1953,-0.1952 0.1953,-0.5118 0,-0.7071 l -2.682,-2.6819 V 9.96997 c 0,-0.27614 -0.2238,-0.5 -0.5,-0.5 -0.2761,0 -0.5,0.22386 -0.5,0.5 V 14.97 c 0,0.005 10e-5,0.0101 3e-4,0.0151 z"
+       fill="#000000"
+       id="path829" />
+  </g>
+</svg>

--- a/src/cryptoadvance/specter/templates/includes/tx-row.html
+++ b/src/cryptoadvance/specter/templates/includes/tx-row.html
@@ -435,21 +435,20 @@
         }
 
         getCategoryImg(category, isConfirmed) {
-            if (!isConfirmed) {
-                return `{{ url_for('static', filename='img') }}/clock.svg`;
-            }
+            var clock_string = isConfirmed ? '' : '-clock';
+
             switch (category) {
                 case "send":
-                    return `{{ url_for('static', filename='img') }}/send.svg`;
+                    return `{{ url_for('static', filename='img') }}/send${clock_string}.svg`;
                 case "receive":
-                    return `{{ url_for('static', filename='img') }}/receive.svg`;
+                    return `{{ url_for('static', filename='img') }}/receive${clock_string}.svg`;
                 case "immature":
                 case "generate":
                     return `{{ url_for('static', filename='img') }}/gear.svg`;
                 case "selftransfer":
-                    return `{{ url_for('static', filename='img') }}/transfer.svg`;
+                    return `{{ url_for('static', filename='img') }}/transfer${clock_string}.svg`;
                 case "mixed":
-                    return `{{ url_for('static', filename='img') }}/mixed.svg`;
+                    return `{{ url_for('static', filename='img') }}/mixed${clock_string}.svg`;
             }
         }
     }

--- a/src/cryptoadvance/specter/templates/includes/tx-row.html
+++ b/src/cryptoadvance/specter/templates/includes/tx-row.html
@@ -435,20 +435,20 @@
         }
 
         getCategoryImg(category, isConfirmed) {
-            var clock_string = isConfirmed ? '' : '-clock';
+            var clockString = isConfirmed ? '' : '-clock';
 
             switch (category) {
                 case "send":
-                    return `{{ url_for('static', filename='img') }}/send${clock_string}.svg`;
+                    return `{{ url_for('static', filename='img') }}/send${clockString}.svg`;
                 case "receive":
-                    return `{{ url_for('static', filename='img') }}/receive${clock_string}.svg`;
+                    return `{{ url_for('static', filename='img') }}/receive${clockString}.svg`;
                 case "immature":
                 case "generate":
                     return `{{ url_for('static', filename='img') }}/gear.svg`;
                 case "selftransfer":
-                    return `{{ url_for('static', filename='img') }}/transfer${clock_string}.svg`;
+                    return `{{ url_for('static', filename='img') }}/transfer${clockString}.svg`;
                 case "mixed":
-                    return `{{ url_for('static', filename='img') }}/mixed${clock_string}.svg`;
+                    return `{{ url_for('static', filename='img') }}/mixed${clockString}.svg`;
             }
         }
     }


### PR DESCRIPTION
This addresses the unconfirmed icon part of https://github.com/cryptoadvance/specter-desktop/issues/1861

Before:
![image](https://user-images.githubusercontent.com/60378539/192090249-ba3d4e40-c24b-4060-b29d-74cc8009c9d8.png)

After:
![image](https://user-images.githubusercontent.com/60378539/192090231-a740961b-58ec-45fd-afd5-45b2ff4a40d5.png)
