### PR TITLE
Bugfix: Hover effect in balance display

### DIFF
--- a/src/cryptoadvance/specter/static/styles.css
+++ b/src/cryptoadvance/specter/static/styles.css
@@ -749,10 +749,6 @@ th{
     font-weight: inherit;
     border-bottom: 3px solid var(--cmap-bg-lightest);
 }
-tbody tr:not(.nohover):hover{
-    background: rgba(255,255,255,0.03);
-    color: #fff;
-}
 .xpub{
     max-width: 300px;
 }


### PR DESCRIPTION
There was a background effect when hovering over the balance display:

![grafik](https://user-images.githubusercontent.com/70536101/192337938-78258505-0424-47f9-b465-dfa36a257d65.png)

Solved by removing unnecessary hover style.