### PR TITLE
Bugfix: Jinja error when 'ext_wallettabs' is empty

### DIFF
--- a/src/cryptoadvance/specter/templates/wallet/components/wallet_menu.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/components/wallet_menu.jinja
@@ -14,6 +14,9 @@
 		{{ wallet_menu_item('addresses', _('Addresses'), wallet_alias, active_menuitem) }}
 		{{ wallet_menu_item('receive', _('Receive'), wallet_alias, active_menuitem, id='btn_receive') }}
 		{{ wallet_menu_item('send', _('Send'), wallet_alias, active_menuitem, id='btn_send') }}
+		{% if not ext_wallettabs %}
+			{% set ext_wallettabs = {} %}
+		{% endif %}
 		{% for ext_id, wallettabs in ext_wallettabs.items() %}
 			{% for wallettab in wallettabs %}
 				{{ wallet_menu_item(wallettab["endpoint"], _(wallettab["title"]), wallet_alias, active_menuitem, isRight=false, blueprint=ext_id+"_endpoint") }}


### PR DESCRIPTION
`ext_wallettabs` should not have to be set. 
For example, just using the exfund plugin is not contributing anything towards this dictionary.