### PR TITLE
Feature: QR support for Jade

### DIFF
--- a/src/cryptoadvance/specter/devices/jade.py
+++ b/src/cryptoadvance/specter/devices/jade.py
@@ -10,6 +10,9 @@ class Jade(HWIDevice):
     name = "Jade"
     icon = "img/devices/jade_icon.svg"
 
+    qr_code_support = True
+    supported_qr_code_format = "crypto-psbt"
+    sd_card_support = False
     supports_hwi_toggle_passphrase = False
     supports_hwi_multisig_display_address = True
     liquid_support = True
@@ -31,3 +34,10 @@ class Jade(HWIDevice):
         if wallet_type == "multisig" and is_liquid(network):
             return "Jade does not support multisig wallets on Liquid."
         return super().no_key_found_reason(wallet_type, network)
+
+    # For signing PSBTs via QR code on the Jade
+    def create_psbts(self, base64_psbt, wallet):
+        psbts = super().create_psbts(base64_psbt, wallet)
+        qr_psbt = wallet.fill_psbt(base64_psbt, non_witness=False, xpubs=False)
+        psbts["qrcode"] = f"{self.supported_qr_code_format}:{qr_psbt}"
+        return psbts


### PR DESCRIPTION
With the upcoming release, Jade will support signing PSBTs via QR codes as well as importing a xpub via QR codes. This PR is making the necessary changes on the Specter Desktop side. 

Manual tests were done with the firmware 0.1.40-beta1 from [this link](https://jadefw.blockstream.com/upgrade/fwupgrade.html). Import of xpub and signing of transaction were successful.