### PR TITLE
Cleanup:(ui) Remove Specter Ghost from the background of the about page

### DIFF
--- a/src/cryptoadvance/specter/static/styles.css
+++ b/src/cryptoadvance/specter/static/styles.css
@@ -233,10 +233,6 @@ nav.side > a.item.active, nav.side > div > a.item.active{
     margin-bottom: 1em;
     border: 3px #263044 solid;
     border-radius: 1em;
-    background-image: url("img/ghost_3d_transparent.png");
-    background-size: 400px 400px;
-    background-repeat: no-repeat;
-    background-position: 100% 100%;
 }
 .main-description-box{
     max-width: 90%;


### PR DESCRIPTION
Simple PR to remove the css from the about page that sets the Specter ghost as the background image.