### PR TITLE
Chore: Node manager refactoring

### DIFF
--- a/src/cryptoadvance/specter/server_endpoints/nodes.py
+++ b/src/cryptoadvance/specter/server_endpoints/nodes.py
@@ -166,7 +166,7 @@ def node_settings(node_alias):
                 flash(_("Test failed: {}").format(test["err"]), "error")
         elif action == "save":
             if not node_alias:
-                if node.name in app.specter.node_manager.nodes:
+                if node.name in app.specter.node_manager.nodes_names:
                     flash(
                         _(
                             "Node with this name already exists, please choose a different name."
@@ -271,7 +271,7 @@ def internal_node_settings(node_alias):
                 node.rename(node_name)
         elif action == "forget":
             if not node_alias:
-                flash(_("Failed to deleted node. Node isn't saved"), "error")
+                flash(_("Failed to delete node. Node isn't saved"), "error")
             elif len(app.specter.node_manager.nodes) > 1:
                 node.stop()
                 app.specter.node_manager.delete_node(node, app.specter)

--- a/src/cryptoadvance/specter/server_endpoints/setup.py
+++ b/src/cryptoadvance/specter/server_endpoints/setup.py
@@ -161,7 +161,7 @@ def setup_bitcoind_datadir():
     network = request.form.get("network", "main")
     node_name = "Specter Bitcoin" if network == "main" else f"Specter {network.title()}"
     i = 1
-    while node_name in app.specter.node_manager.nodes:
+    while node_name in app.specter.node_manager.nodes_names:
         i += 1
         node_name = (
             f"Specter Bitcoin {i}"

--- a/src/cryptoadvance/specter/templates/includes/sidebar/components/node_select_popup.jinja
+++ b/src/cryptoadvance/specter/templates/includes/sidebar/components/node_select_popup.jinja
@@ -25,7 +25,7 @@
 <div id="node_select_popup" class="hidden" style="text-align: left;">
     <h1>{{ _("Node configuration") }}</h1>
     {% for node_name in specter.node_manager.nodes_names %}
-        {% set node = specter.node_manager.nodes[node_name] %}
+        {% set node = specter.node_manager.get_by_name(node_name) %}
         <form action="{{url_for('nodes_endpoint.switch_node')}}" id="{{node.alias}}-select-node-form" method="POST">
 		    <input type="hidden" class="csrf-token" name="csrf_token" value="{{ csrf_token() }}"/>
 		    <input type="hidden" name="node_alias" value="{{ node.alias }}"/>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -218,18 +218,39 @@ def node(empty_data_folder, bitcoin_regtest):
     nodes_folder = empty_data_folder + "/nodes"
     if not os.path.isdir(nodes_folder):
         os.makedirs(nodes_folder)
-    node = Node.from_json(
-        {
-            "autodetect": False,
-            "datadir": bitcoin_regtest.datadir,
-            "user": bitcoin_regtest.rpcconn.rpcuser,
-            "password": bitcoin_regtest.rpcconn.rpcpassword,
-            "port": bitcoin_regtest.rpcconn.rpcport,
-            "host": bitcoin_regtest.rpcconn.ipaddress,
-            "protocol": "http",
-        },
-        manager=NodeManager(data_folder=nodes_folder),
-        default_fullpath=os.path.join(nodes_folder, "standard_node.json"),
+    nm = NodeManager(data_folder=nodes_folder)
+    node = nm.add_external_node(
+        "BTC",
+        "Standard node",
+        False,
+        bitcoin_regtest.datadir,
+        bitcoin_regtest.rpcconn.rpcuser,
+        bitcoin_regtest.rpcconn.rpcpassword,
+        bitcoin_regtest.rpcconn.rpcport,
+        bitcoin_regtest.rpcconn._ipaddress,
+        "http",
+        "standard_node",
+    )
+    return node
+
+
+@pytest.fixture
+def node_with_different_port(empty_data_folder, bitcoin_regtest):
+    nodes_folder = empty_data_folder + "/nodes"
+    if not os.path.isdir(nodes_folder):
+        os.makedirs(nodes_folder)
+    nm = NodeManager(data_folder=nodes_folder)
+    node = nm.add_external_node(
+        "BTC",
+        "Node with a different port",
+        False,
+        "",
+        bitcoin_regtest.rpcconn.rpcuser,
+        bitcoin_regtest.rpcconn.rpcpassword,
+        18333,
+        bitcoin_regtest.rpcconn._ipaddress,
+        "http",
+        "satoshis_node",
     )
     return node
 

--- a/tests/test_managers_node.py
+++ b/tests/test_managers_node.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from cryptoadvance.specter.managers.node_manager import NodeManager
+from cryptoadvance.specter.specter_error import SpecterError
 from cryptoadvance.specter.process_controller.bitcoind_controller import (
     BitcoindPlainController,
 )
@@ -15,8 +16,62 @@ from cryptoadvance.specter.process_controller.elementsd_controller import (
 )
 
 
+def test_node_manager_basics(
+    empty_data_folder, node, node_with_different_port, specter_regtest_configured
+):
+    nodes_folder = empty_data_folder + "/nodes"
+    nm = specter_regtest_configured.node_manager
+    # # Load from disk to get the other two nodes
+    assert sorted(list(nm.nodes.keys())) == [
+        "default",
+        "satoshis_node",
+        "standard_node",
+    ]
+    assert nm.nodes_names == [
+        "Standard node",
+        "Node with a different port",
+        "Bitcoin Core",
+    ]
+    nm.load_from_disk(nodes_folder)
+    assert nm.nodes_names == [
+        "Standard node",
+        "Node with a different port",
+        "Bitcoin Core",
+    ]
+    # Checking some standard methods and properties
+    assert nm.get_by_alias("satoshis_node") == nm.get_by_name(
+        "Node with a different port"
+    )
+    default_node = nm.get_by_alias("default")
+    satoshis_node = nm.get_by_alias("satoshis_node")
+    assert nm.default_node() == default_node
+    assert nm.active_node == default_node
+    assert specter_regtest_configured.config["active_node_alias"] == "default"
+    # Switching the node via the node manager does not change the active_node_alias in the config, only specter.update_active_node() does
+    nm.switch_node("satoshis_node")
+    assert nm.active_node == satoshis_node
+    assert specter_regtest_configured.config["active_node_alias"] == "default"
+    specter_regtest_configured.update_active_node("satoshis_node")
+    assert specter_regtest_configured.config["active_node_alias"] == "satoshis_node"
+    assert nm.active_node == satoshis_node
+    # Deleting a node
+    nm.delete_node(satoshis_node, specter_regtest_configured)
+    assert nm.nodes_names == ["Standard node", "Bitcoin Core"]
+    # Check that with the deletion of the active node the switch to the next node work, the first node in the list, here the Standard node, is switched to
+    assert specter_regtest_configured.config["active_node_alias"] == "standard_node"
+    assert nm._active_node == "standard_node"
+    # Check the error handling
+    with pytest.raises(
+        SpecterError,
+        match="Node with a different port not found, node could not be deleted.",
+    ):
+        nm.delete_node(satoshis_node, specter_regtest_configured)
+    with pytest.raises(SpecterError, match="Node alias satoshis_node does not exist!"):
+        nm.switch_node("satoshis_node")
+
+
 @pytest.mark.elm
-def test_NodeManager(
+def test_switch_nodes_across_chains(
     bitcoin_regtest: BitcoindPlainController, elements_elreg: ElementsPlainController
 ):
     with tempfile.TemporaryDirectory(
@@ -34,9 +89,10 @@ def test_NodeManager(
             bitcoin_regtest.rpcconn.rpcport,
             bitcoin_regtest.rpcconn._ipaddress,
             "http",
+            "bitcoin_regtest_alias",
         )
         assert nm.nodes_names == ["Bitcoin Core", "bitcoin_regtest"]
-        nm.switch_node("bitcoin_regtest")
+        nm.switch_node("bitcoin_regtest_alias")
         assert nm.active_node.rpc.getblockchaininfo()["chain"] == "regtest"
         nm.add_external_node(
             "ELM",
@@ -52,48 +108,3 @@ def test_NodeManager(
         assert nm.nodes_names == ["Bitcoin Core", "bitcoin_regtest", "elements_elreg"]
         nm.switch_node("elements_elreg")
         assert nm.active_node.rpc.getblockchaininfo()["chain"] == "elreg"
-        nm.delete_node(nm.nodes["Bitcoin Core"], MagicMock())
-
-
-""" For some reason this breaks other tests"""
-
-
-@pytest.mark.skip()
-def test_NodeManager_import(bitcoind_path):
-    with tempfile.TemporaryDirectory("_some_datafolder_tmp") as data_folder:
-        print(f"data_folder={data_folder}")
-        nm = NodeManager(data_folder=data_folder, bitcoind_path=bitcoind_path)
-        print(os.getcwd())
-        # This .bitcoin folder doesn't have a config-file
-        btc_tar = tarfile.open(
-            "./tests/helpers_testdata/bitcoin_minimum_mainnet_datadir.tgz", "r:gz"
-        )
-        btc_tar.extractall(os.path.join(data_folder, "somename", ".bitcoin-main"))
-        #         # ... so let's create one
-        #         with open(
-        #             os.path.join(data_folder,"somename",".bitcoin-main","bitcoin.conf"),
-        #             "w+",
-        #         ) as file:
-        #             file.write('''
-        # rpcauth=bitcoin:044931c1d498b7c27080d8b981331a65$6ee7929513401c39ca1f7e376e55553c52dcb36a14e8410ac5f514fbf18bedbb
-        # server=1
-        # listen=1
-        # proxy=127.0.0.1:9050
-        # bind=127.0.0.1
-        # torcontrol=127.0.0.1:9051
-        # torpassword=gVzREfuHso6U2OfRRvqT3w
-        # fallbackfee=0.0002
-        # prune=1000
-        #             '''
-        #             )
-
-        node = nm.add_internal_node("somename", port=8339)
-        try:
-            node.start()
-            time.sleep(5)
-            # assert node.rpc.password == None
-            nm.switch_node("somename")
-            time.sleep(5)
-            assert nm.active_node.rpc.getblockchaininfo()["chain"] == "main"
-        finally:
-            node.stop()


### PR DESCRIPTION
- This PR changes the keys in the `node_manager.nodes `dictionary to the node aliases instead of the node names to avoid bugs like we had in https://github.com/cryptoadvance/specter-desktop/issues/1968. This PR fixes https://github.com/cryptoadvance/specter-desktop/issues/1968
- Bugfix where the default node was created all the time not only when it was not available anymore
- Node manager test coverage improved