### PR TITLE
Bugfix: Release procedure fix

### DIFF
--- a/src/cryptoadvance/specter/managers/service_manager/service_manager.py
+++ b/src/cryptoadvance/specter/managers/service_manager/service_manager.py
@@ -502,10 +502,10 @@ class ServiceManager:
 
     @classmethod
     def _make_path_relative(cls, path: Path) -> Path:
-        ''' make out of something like '# /home/kim/src/specter-desktop/.buildenv/lib/python3.8/site-packages/cryptoadvance/specter/services/swan/templates
-            somethink like:                                                                                   cryptoadvance/specter/services/swan/templates
-            The first part might be completely random. The marker is something like .*env
-        '''
+        """make out of something like '# /home/kim/src/specter-desktop/.buildenv/lib/python3.8/site-packages/cryptoadvance/specter/services/swan/templates
+        somethink like:                                                                                   cryptoadvance/specter/services/swan/templates
+        The first part might be completely random. The marker is something like .*env
+        """
         index = 0
         sep_index = 0
         for part in path.parts:
@@ -513,6 +513,8 @@ class ServiceManager:
                 sep_index = index
             index += 1
         if sep_index == 0:
-            raise SpecterInternalException(f"Path {path} does not contain an environment directory!")
+            raise SpecterInternalException(
+                f"Path {path} does not contain an environment directory!"
+            )
 
         return Path(*path.parts[sep_index:index])

--- a/src/cryptoadvance/specter/util/reflection.py
+++ b/src/cryptoadvance/specter/util/reflection.py
@@ -186,16 +186,16 @@ def get_subclasses_for_clazz(clazz, package_dirs: List[str] = None):
                 continue
             try:
                 module = import_module(f"{module_name}.service")
-                logger.debug(f"  Imported {module_name}.service")
+                logger.info(f"  Imported {module_name}.service")
             except ModuleNotFoundError as e:
                 try:
                     # Another style is orgname.specterext.extensionid, for that we have to guess the orgname:
                     orgname = str(importer).split(os.path.sep)[-2]
-                    logger.debug(f"guessing orgname: {orgname}")
+                    logger.info(f"guessing orgname: {orgname}")
                     module = import_module(
                         f"{orgname}.specterext.{module_name}.service"
                     )
-                    logger.debug(
+                    logger.info(
                         f"  Imported {orgname}.specterext.{module_name}.service"
                     )
                 except ModuleNotFoundError as e:

--- a/src/cryptoadvance/specter/util/reflection.py
+++ b/src/cryptoadvance/specter/util/reflection.py
@@ -175,7 +175,7 @@ def get_subclasses_for_clazz(clazz, package_dirs: List[str] = None):
         # skip known redherrings
         if module_name in ["callbacks"]:
             continue
-        logger.debug(
+        logger.info(
             f"Iterating on importer={importer} , module_name={module_name} is_pkg={is_pkg}"
         )
         if clazz.__name__ == "Service":

--- a/src/cryptoadvance/specter/util/reflection.py
+++ b/src/cryptoadvance/specter/util/reflection.py
@@ -190,7 +190,7 @@ def get_subclasses_for_clazz(clazz, package_dirs: List[str] = None):
             except ModuleNotFoundError as e:
                 try:
                     # Another style is orgname.specterext.extensionid, for that we have to guess the orgname:
-                    orgname = str(importer).split(os.path.sep)[-2]
+                    orgname = importer.path.split(os.path.sep)[-2]
                     logger.info(f"guessing orgname: {orgname}")
                     module = import_module(
                         f"{orgname}.specterext.{module_name}.service"

--- a/tests/test_managers_service.py
+++ b/tests/test_managers_service.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 import pytest
+from pathlib import PosixPath, Path
 import os
 from unittest.mock import MagicMock
 from flask import Flask
@@ -36,22 +37,19 @@ def test_ServiceManager_get_service_x_dirs(caplog):
         )
         # however, in the real build, you get something like:
         # ../.buildenv/lib/python3.8/site-packages/cryptoadvance/specter/services/swan/templates
-        assert f"{expected_folder}/cryptoadvance/specter/services/swan/templates" in [
+        assert f"{expected_folder}/cryptoadvance/specterext/swan/templates" in [
             str(dir) for dir in dirs
         ]
         for path in dirs:
             assert str(path).endswith("templates")
 
         dirs = ServiceManager.get_service_x_dirs("static")
-        assert f"{expected_folder}/cryptoadvance/specter/services/swan/static" in [
+        assert f"{expected_folder}/cryptoadvance/specterext/swan/static" in [
             str(dir) for dir in dirs
         ]
-        assert (
-            f"{expected_folder}/cryptoadvance/specter/services/bitcoinreserve/static"
-            in [str(dir) for dir in dirs]
-        )
         print(dirs)
-        assert len(dirs) >= 2
+        assert len(dirs) >= 2000
+        assert False
     finally:
         os.chdir("../")
 
@@ -62,6 +60,16 @@ def test_ServiceManager_get_service_packages(caplog):
     assert "cryptoadvance.specterext.swan.service" in packages
     assert "cryptoadvance.specterext.electrum.service" in packages
     assert "cryptoadvance.specterext.electrum.devices.electrum" in packages
+
+def test_ServiceManager_make_path_relative(caplog):
+    caplog.set_level(logging.DEBUG)
+    arr = [ 
+        Path("/home/kim/src/specter-desktop/.buildenv/lib/python3.8/site-packages/cryptoadvance/specter/services/swan/templates"),
+        Path("wurstbrot/something/.env/site-packages/the_rest")
+    ]
+    arr = [ ServiceManager._make_path_relative(path) for path in arr ]
+    assert arr[0] == PosixPath("site-packages/cryptoadvance/specter/services/swan/templates")
+    assert arr[1] == PosixPath("site-packages/the_rest")
 
 
 @pytest.fixture

--- a/tests/test_managers_service.py
+++ b/tests/test_managers_service.py
@@ -61,14 +61,19 @@ def test_ServiceManager_get_service_packages(caplog):
     assert "cryptoadvance.specterext.electrum.service" in packages
     assert "cryptoadvance.specterext.electrum.devices.electrum" in packages
 
+
 def test_ServiceManager_make_path_relative(caplog):
     caplog.set_level(logging.DEBUG)
-    arr = [ 
-        Path("/home/kim/src/specter-desktop/.buildenv/lib/python3.8/site-packages/cryptoadvance/specter/services/swan/templates"),
-        Path("wurstbrot/something/.env/site-packages/the_rest")
+    arr = [
+        Path(
+            "/home/kim/src/specter-desktop/.buildenv/lib/python3.8/site-packages/cryptoadvance/specter/services/swan/templates"
+        ),
+        Path("wurstbrot/something/.env/site-packages/the_rest"),
     ]
-    arr = [ ServiceManager._make_path_relative(path) for path in arr ]
-    assert arr[0] == PosixPath("site-packages/cryptoadvance/specter/services/swan/templates")
+    arr = [ServiceManager._make_path_relative(path) for path in arr]
+    assert arr[0] == PosixPath(
+        "site-packages/cryptoadvance/specter/services/swan/templates"
+    )
     assert arr[1] == PosixPath("site-packages/the_rest")
 
 


### PR DESCRIPTION
There are currently issues with the creation of the pyinstaller package (see below logs). This PR fixes that:
* `importer.path` instead of `str(importer)`
* Some refactorings to make things a bit more modular and easier to test

```
31837 INFO: Processing pre-find module path hook site from 'C:\\gitlab-runner\\builds\\xPkLDUk2\\0\\k9ert\\specter-desktop\\.buildenv\\lib\\site-packages\\PyInstaller\\hooks\\pre_find_module_path\\hook-site.py'.
31845 INFO: site: retargeting to fake-dir 'C:\\gitlab-runner\\builds\\xPkLDUk2\\0\\k9ert\\specter-desktop\\.buildenv\\lib\\site-packages\\PyInstaller\\fake-modules'
40736 INFO: Processing pre-safe import module hook six.moves from 'C:\\gitlab-runner\\builds\\xPkLDUk2\\0\\k9ert\\specter-desktop\\.buildenv\\lib\\site-packages\\PyInstaller\\hooks\\pre_safe_import_module\\hook-six.moves.py'.
55479 INFO: Analyzing hidden import 'pkg_resources.py2_warn'
55489 ERROR: Hidden import 'pkg_resources.py2_warn' not found
55489 INFO: Analyzing hidden import 'tzdata'
55569 INFO: Processing module hooks...
55571 INFO: Loading module hook 'hook-cryptoadvance.specter.services.py' from 'C:\\gitlab-runner\\builds\\xPkLDUk2\\0\\k9ert\\specter-desktop\\pyinstaller\\hooks'...
63399 INFO: Collecting subclasses of Service in C:\gitlab-runner\builds\xPkLDUk2\0\k9ert\specter-desktop\.buildenv\Lib\site-packages\cryptoadvance\specterext...
Traceback (most recent call last):
  File "C:\gitlab-runner\builds\xPkLDUk2\0\k9ert\specter-desktop\.buildenv\lib\site-packages\cryptoadvance\specter\util\reflection.py", line 188, in get_subclasses_for_clazz
    module = import_module(f"{module_name}.service")
  File "c:\python38\lib\importlib\__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 961, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 973, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'devhelp'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "c:\python38\lib\runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "c:\python38\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\gitlab-runner\builds\xPkLDUk2\0\k9ert\specter-desktop\.buildenv\Scripts\pyinstaller.exe\__main__.py", line 7, in <module>
  File "C:\gitlab-runner\builds\xPkLDUk2\0\k9ert\specter-desktop\.buildenv\lib\site-packages\PyInstaller\__main__.py", line 178, in run
    run_build(pyi_config, spec_file, **vars(args))
  File "C:\gitlab-runner\builds\xPkLDUk2\0\k9ert\specter-desktop\.buildenv\lib\site-packages\PyInstaller\__main__.py", line 59, in run_build
    PyInstaller.building.build_main.main(pyi_config, spec_file, **kwargs)
  File "C:\gitlab-runner\builds\xPkLDUk2\0\k9ert\specter-desktop\.buildenv\lib\site-packages\PyInstaller\building\build_main.py", line 842, in main
    build(specfile, distpath, workpath, clean_build)
  File "C:\gitlab-runner\builds\xPkLDUk2\0\k9ert\specter-desktop\.buildenv\lib\site-packages\PyInstaller\building\build_main.py", line 764, in build
    exec(code, spec_namespace)
  File "specterd.spec", line 47, in <module>
    a = Analysis(['specterd.py'],
  File "C:\gitlab-runner\builds\xPkLDUk2\0\k9ert\specter-desktop\.buildenv\lib\site-packages\PyInstaller\building\build_main.py", line 319, in __init__
    self.__postinit__()
  File "C:\gitlab-runner\builds\xPkLDUk2\0\k9ert\specter-desktop\.buildenv\lib\site-packages\PyInstaller\building\datastruct.py", line 173, in __postinit__
    self.assemble()
  File "C:\gitlab-runner\builds\xPkLDUk2\0\k9ert\specter-desktop\.buildenv\lib\site-packages\PyInstaller\building\build_main.py", line 487, in assemble
    self.graph.process_post_graph_hooks(self)
  File "C:\gitlab-runner\builds\xPkLDUk2\0\k9ert\specter-desktop\.buildenv\lib\site-packages\PyInstaller\depend\analysis.py", line 326, in process_post_graph_hooks
    module_hook.post_graph(analysis)
  File "C:\gitlab-runner\builds\xPkLDUk2\0\k9ert\specter-desktop\.buildenv\lib\site-packages\PyInstaller\depend\imphook.py", line 404, in post_graph
    self._load_hook_module()
  File "C:\gitlab-runner\builds\xPkLDUk2\0\k9ert\specter-desktop\.buildenv\lib\site-packages\PyInstaller\depend\imphook.py", line 367, in _load_hook_module
    self._hook_module = importlib_load_source(self.hook_module_name, self.hook_filename)
  File "C:\gitlab-runner\builds\xPkLDUk2\0\k9ert\specter-desktop\.buildenv\lib\site-packages\PyInstaller\compat.py", line 620, in importlib_load_source
    return mod_loader.load_module()
  File "<frozen importlib._bootstrap_external>", line 462, in _check_name_wrapper
  File "<frozen importlib._bootstrap_external>", line 962, in load_module
  File "<frozen importlib._bootstrap_external>", line 787, in load_module
  File "<frozen importlib._bootstrap>", line 265, in _load_module_shim
  File "<frozen importlib._bootstrap>", line 702, in _load
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "C:\gitlab-runner\builds\xPkLDUk2\0\k9ert\specter-desktop\pyinstaller\hooks\hook-cryptoadvance.specter.services.py", line 9, in <module>
    for service_dir in ServiceManager.get_service_x_dirs("templates")
  File "C:\gitlab-runner\builds\xPkLDUk2\0\k9ert\specter-desktop\.buildenv\lib\site-packages\cryptoadvance\specter\managers\service_manager\service_manager.py", line 394, in get_service_x_dirs
    for clazz in get_subclasses_for_clazz(Service)
  File "C:\gitlab-runner\builds\xPkLDUk2\0\k9ert\specter-desktop\.buildenv\lib\site-packages\cryptoadvance\specter\util\reflection.py", line 195, in get_subclasses_for_clazz
    module = import_module(
  File "c:\python38\lib\importlib\__init__.py", line 122, in import_module
    raise TypeError(msg.format(name))
TypeError: the 'package' argument is required to perform a relative import for '.specterext.devhelp.service'
Compress-Archive : The path 'dist\specterd.exe' either does not exist or is not a valid file system path.
At line:1 char:1
+ Compress-Archive -Path dist\specterd.exe release\specterd-v1.13.2-pre ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (dist\specterd.exe:String) [Compress-Archive], InvalidOperationExceptio 
   n
    + FullyQualifiedErrorId : ArchiveCmdletPathNotFound,Compress-Archive
```

WIP, still.