### PR TITLE
Bugfix: failover for nonexistent nodes

### DIFF
--- a/src/cryptoadvance/specter/managers/node_manager.py
+++ b/src/cryptoadvance/specter/managers/node_manager.py
@@ -8,7 +8,7 @@ from ..rpc import get_default_datadir, RPC_PORTS
 from ..specter_error import SpecterError, SpecterInternalException
 from ..persistence import PersistentObject, write_node, delete_file
 from ..helpers import alias, calc_fullpath, load_jsons
-from ..node import BrokenNode, Node
+from ..node import Node
 from ..internal_node import InternalNode
 from ..services import callbacks
 from ..managers.service_manager import ServiceManager

--- a/src/cryptoadvance/specter/managers/service_manager/service_manager.py
+++ b/src/cryptoadvance/specter/managers/service_manager/service_manager.py
@@ -315,6 +315,17 @@ class ServiceManager:
         )
         return [self._services[s] for s in service_names]
 
+    def is_class_from_loaded_extension(self, claz):
+        """Returns Ture if that class is from a module which belongs to an extension
+        which is loaded, False otherwise
+        """
+        print("")
+        ext_module = ".".join(claz.__module__.split(".")[0:3])
+        for ext in self.services_sorted:
+            if ext.__class__.__module__.startswith(ext_module):
+                return True
+        return False
+
     def user_has_encrypted_storage(self, user: User) -> bool:
         """Looks for any data for any service in the User's ServiceEncryptedStorage.
         This check works even if the user doesn't have their plaintext_user_secret

--- a/src/cryptoadvance/specter/specter.py
+++ b/src/cryptoadvance/specter/specter.py
@@ -121,9 +121,19 @@ class Specter:
             internal_bitcoind_version=self._internal_bitcoind_version,
             data_folder=os.path.join(self.data_folder, "nodes"),
         )
-        logger.debug(
-            f"This is the active node in the node manager: {self.node_manager.active_node}"
-        )
+        try:
+            logger.debug(
+                f"This is the active node in the node manager: {self.node_manager.active_node}"
+            )
+        except SpecterError as e:
+            if str(e).endswith("does not exist!"):
+                logger.warning(
+                    f"Node {self.node_manager.active_node} doesn't exist. Switching over to node {self.node_manager.DEFAULT_ALIAS}."
+                )
+                self.update_active_node(self.node_manager.DEFAULT_ALIAS)
+            else:
+                raise e
+
         self.torbrowser_path = os.path.join(
             self.data_folder, f"tor-binaries/tor{get_tor_daemon_suffix()}"
         )

--- a/src/cryptoadvance/specter/specter.py
+++ b/src/cryptoadvance/specter/specter.py
@@ -120,6 +120,9 @@ class Specter:
             bitcoind_path=self.bitcoind_path,
             internal_bitcoind_version=self._internal_bitcoind_version,
             data_folder=os.path.join(self.data_folder, "nodes"),
+            service_manager=self.service_manager
+            if hasattr(self, "service_manager")
+            else None,
         )
         try:
             logger.debug(
@@ -128,7 +131,7 @@ class Specter:
         except SpecterError as e:
             if str(e).endswith("does not exist!"):
                 logger.warning(
-                    f"Node {self.node_manager.active_node} doesn't exist. Switching over to node {self.node_manager.DEFAULT_ALIAS}."
+                    f"Current Node doesn't exist. Switching over to node {self.node_manager.DEFAULT_ALIAS}."
                 )
                 self.update_active_node(self.node_manager.DEFAULT_ALIAS)
             else:

--- a/src/cryptoadvance/specter/util/checker.py
+++ b/src/cryptoadvance/specter/util/checker.py
@@ -28,17 +28,18 @@ class Checker:
     def start(self):
         if not self.running:
             self.running = True
-            self.error_counter = 0
             self.thread = FlaskThread(target=self.loop)
             self.thread.daemon = True
             self.thread.start()
-        logger.info(f"Checker {self.desc} started with period {self.period}")
+            logger.info(f"Checker {self.desc} started with period {self.period}")
+        else:
+            logger.warning(f"Checker {self.desc} started but ran already")
 
     def stop(self):
-        logger.info(f"Checker {self.desc} stopped.")
         self.running = False
 
     def loop(self):
+        self.error_counter = 0
         self._execute(first_execution=True)
         while self.running:
             # check if it's time to update
@@ -46,6 +47,7 @@ class Checker:
                 self._execute()
             # wait 1 second
             self._sleep()
+        logger.info(f"Checker {self.desc} stopped.")
 
     def _execute(self, first_execution=False):
         try:
@@ -58,11 +60,13 @@ class Checker:
                     % dt
                 )
         except Exception as e:
-            if self.error_counter < 5:
-                logger.exception(e)
-                self.error_counter = self.error_counter + 1
-            if self.error_counter == 4:
-                logger.error("The above Error-Message is now suppressed!")
+            self.error_counter += 1
+            if self.error_counter <= 5:
+                logger.exception(
+                    f"Checker thread {self.desc} threw {e} for the {self.error_counter}th time"
+                )
+            if self.error_counter == 5:
+                logger.error(f"The above Error-Message is from now on suppressed!")
         finally:
             self.last_check = time.time()
 

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -16,6 +16,7 @@ def test_checker(caplog):
     assert "Checker test started" in caplog.text
     assert "This message won't show again until stopped and started." in caplog.text
     checker.stop()
+    time.sleep(0.01)
     assert "Checker test stopped" in caplog.text
     callback_mock.side_effect = Exception("someException")
     checker.start()
@@ -25,8 +26,7 @@ def test_checker(caplog):
     checker.stop()
     assert "someException" in caplog.text
     # should output 5 times
-    assert caplog.text.count("[   ERROR] someException") == 5
+    assert caplog.text.count("[   ERROR] Checker thread") == 5
     # But should also show stacktrace 5 times
     assert caplog.text.count("Exception: someException") == 5
-    assert "The above Error-Message is now suppressed" in caplog.text
-    assert caplog.text.count("The above Error-Message is now suppressed") == 1
+    assert caplog.text.count("The above Error-Message is from now on suppressed!") == 1

--- a/tests/test_managers_service.py
+++ b/tests/test_managers_service.py
@@ -8,6 +8,10 @@ from flask import Flask
 from cryptoadvance.specter.managers.service_manager import ServiceManager
 from cryptoadvance.specter.services.callbacks import after_serverpy_init_app
 
+from cryptoadvance.specterext.swan.service import SwanService
+from cryptoadvance.specterext.swan.service import SwanClient
+from cryptoadvance.specterext.devhelp.service import DevhelpService
+
 
 def test_ServiceManager2(mock_specter, mock_flaskapp, caplog):
     ctx = mock_flaskapp.app_context()
@@ -20,6 +24,15 @@ def test_ServiceManager2(mock_specter, mock_flaskapp, caplog):
     assert sm.services["swan"] != None
 
     sm.execute_ext_callbacks(after_serverpy_init_app, scheduler=None)
+
+
+def test_is_class_from_loaded_extension(mock_specter, mock_flaskapp):
+    with mock_flaskapp.app_context():
+        sm = ServiceManager(mock_specter, "alpha")
+        assert type(sm.services_sorted[0]) == SwanService
+        assert sm.is_class_from_loaded_extension(SwanClient)
+        assert sm.is_class_from_loaded_extension(SwanService)
+        assert not sm.is_class_from_loaded_extension(DevhelpService)
 
 
 @pytest.mark.skip(reason="The .buildenv directoy does not exist on the CI-Infra")


### PR DESCRIPTION
Currently, the only way to remove a spectrum node is to delete the `spectrum_node.json`  which currently results in a failure of booting up.
So this PR makes that more failsafe.