### PR TITLE
Bugfix: Adding migrations to the hidden imports

### DIFF
--- a/src/cryptoadvance/specter/managers/service_manager/service_manager.py
+++ b/src/cryptoadvance/specter/managers/service_manager/service_manager.py
@@ -17,6 +17,8 @@ from flask import current_app as app
 from flask import url_for
 from flask.blueprints import Blueprint
 
+from cryptoadvance.specter.util.specter_migrator import SpecterMigration
+
 from ...services.service import Service
 from ...services import callbacks, ExtensionException
 from ...util.reflection import (
@@ -450,10 +452,11 @@ class ServiceManager:
 
     @classmethod
     def get_service_packages(cls):
-        """returns a list of strings containing the service-classes (+ controller +config-classes +devices)
+        """returns a list of strings containing the service-classes (+ controller +config-classes +devices +migrations)
         This is used for hiddenimports in pyinstaller
         """
         arr = get_subclasses_for_clazz(Service)
+        arr.extend(get_subclasses_for_clazz(SpecterMigration))
         logger.info(f"initial arr: {arr}")
         arr.extend(
             get_classlist_of_type_clazz_from_modulelist(
@@ -509,6 +512,7 @@ class ServiceManager:
                 arr.append(config_package)
             except ModuleNotFoundError as e:
                 pass
+        arr = list(dict.fromkeys(arr))
         return arr
 
     @classmethod

--- a/tests/test_managers_service.py
+++ b/tests/test_managers_service.py
@@ -75,6 +75,13 @@ def test_ServiceManager_get_service_packages(caplog):
     assert "cryptoadvance.specterext.swan.service" in packages
     assert "cryptoadvance.specterext.electrum.service" in packages
     assert "cryptoadvance.specterext.electrum.devices.electrum" in packages
+    assert "cryptoadvance.specterext.devhelp.service" in packages
+    assert "cryptoadvance.specterext.liquidissuer.service" in packages
+
+    assert "cryptoadvance.specter.util.migrations.migration_0000" in packages
+    assert "cryptoadvance.specter.util.migrations.migration_0001" in packages
+    assert "cryptoadvance.specter.util.migrations.migration_0002" in packages
+    assert len(packages) == 25
 
 
 def test_ServiceManager_make_path_relative(caplog):


### PR DESCRIPTION
It seems that the migrations never got packaged into the specterd. That didn't caused so much trouble up to now. However, now `migration_0002` is a critical one. Not shipping it caused #2006

This PR is fixing that:
```
2022-12-07T17:22:39.304Z [info] : stderr-SPECTERD: INFO in specter_migrator: Initiated MigDataManager(~/.specter_mainchain/migration_data.json events:0 execs:0 )
SPECTERD: INFO in specter_migrator: A new version has been started compared to last time: v1.14.1-pre1

2022-12-07T17:22:39.305Z [info] : stderr-SPECTERD: INFO in specter_migrator: Collecting possible migrations ...

2022-12-07T17:22:39.305Z [info] : stderr-SPECTERD: INFO in specter_migrator: Collecting possible migrations ...

2022-12-07T17:22:39.305Z [info] : stderr-SPECTERD: INFO in specter_migrator: Collecting possible migrations ...

2022-12-07T17:22:39.306Z [info] : stderr-SPECTERD: INFO in specter_migrator:   --> Starting Migration SpecterMigration_0002
SPECTERD: INFO in specter_migrator: Node-class migration:
            We introduced the Spectrum Node on an extension. With that, we made the choice of 
            the Node to be instantiated much more flexible. The node.json gets an attribute called
            python_class which is the fully qualified package name of the class the NodeManager
            should instantiate.
            This migrates all the node.json files to the new format.
            Effectively it will:
            * Iterate over all nodes in ~/.specter/nodes/*.json
            * load each node.json and adds the correct python_class 
            * stores it again
            In order to reverse this migration, you do need to reverse the addition of the 
            python_class like this:
            
            sudo apt-get install moreutils jq
            cd ~/.specter/nodes
            # remove python_class key
            for file in `ls *.json`; do jq 'del(.python_class)' $file | sponge $file ; done
            cd ..
            jq 'del(.migration_executions[] | select(.migration_id == 2))' migration_data.json | sponge migration_data.json

        

2022-12-07T17:22:39.306Z [info] : stderr-SPECTERD: INFO in migration_0002: No node_folder found in {self.data_folder}. Nothing to do
SPECTERD: INFO in specter_migrator:   --> Completed Migration SpecterMigration_0002

2022-12-07T17:22:39.306Z [info] : stderr-SPECTERD: INFO in specter_migrator:   --> Starting Migration SpecterMigration_0001
SPECTERD: INFO in specter_migrator: Single-Node migration:
            In v1.3.1 Single Node implementation has been implemented
            Later we had multiple nodes. This migrates the single installation to one of many.
            Effectively it will:
            * Check whether an internal node was existing in ~/.specter/.bitcoin
            * Check whether a new internal default node (bitcoin/main) is NOT existing
            * Move the ~/.specter/.bitcoin to ~/.specter/nodes/specter_bitcoin/.bitcoin-main
            * Creates a json-definition in ~/.specter/nodes/specter_bitcoin.json
        

2022-12-07T17:22:39.306Z [info] : stderr-SPECTERD: INFO in migration_0001: No .bitcoin directory found in {self.data_folder}. Nothing to do

2022-12-07T17:22:39.306Z [info] : stderr-SPECTERD: INFO in specter_migrator:   --> Completed Migration SpecterMigration_0001

2022-12-07T17:22:39.306Z [info] : stderr-SPECTERD: INFO in specter_migrator:   --> Starting Migration SpecterMigration_0000
SPECTERD: INFO in specter_migrator: A dummy migration:
            * It will do nothing
            * It's just here to explain how SpecterMigration works
            * It will be shown in the logs when it's executed (just like the other real migrations but doing nothing)
        

2022-12-07T17:22:39.307Z [info] : stderr-SPECTERD: INFO in specter_migrator:   --> Completed Migration SpecterMigration_0000

2022-12-07T17:22:39.307Z [info] : stderr-SPECTERD: INFO in server: Initializing LoginManager


```