### PR TITLE
Bugfix: unloaded wallets at start

### DIFF
--- a/src/cryptoadvance/specter/managers/wallet_manager.py
+++ b/src/cryptoadvance/specter/managers/wallet_manager.py
@@ -96,7 +96,9 @@ class WalletManager:
 
         if self.working_folder is not None:
             wallets_files = load_jsons(self.working_folder, key="name")
-            logger.info(f"Iterating over {len(wallets_files.values())} wallet files")
+            logger.info(
+                f"Iterating over {len(wallets_files.values())} wallet files in {self.working_folder}"
+            )
             for wallet in wallets_files:
                 wallet_name = wallets_files[wallet]["name"]
                 wallets_update_list[wallet_name] = wallets_files[wallet]

--- a/src/cryptoadvance/specter/util/checker.py
+++ b/src/cryptoadvance/specter/util/checker.py
@@ -38,6 +38,12 @@ class Checker:
     def stop(self):
         self.running = False
 
+    def run_now(self):
+        """causes an almost immediate run for this checker
+        maximum 1 second delay
+        """
+        self.last_check = 0
+
     def loop(self):
         self.error_counter = 0
         self._execute(first_execution=True)
@@ -56,14 +62,14 @@ class Checker:
             dt = time.time() - t0
             if first_execution:
                 logger.info(
-                    "Checker executed within %.3f seconds. This message won't show again until stopped and started."
+                    f"Checker {self.desc} executed within %.3f seconds. This message won't show again until stopped and started."
                     % dt
                 )
         except Exception as e:
             self.error_counter += 1
             if self.error_counter <= 5:
                 logger.exception(
-                    f"Checker thread {self.desc} threw {e} for the {self.error_counter}th time"
+                    f"Checker {self.desc} threw {e} for the {self.error_counter}th time"
                 )
             if self.error_counter == 5:
                 logger.error(f"The above Error-Message is from now on suppressed!")

--- a/src/cryptoadvance/specterext/spectrum/service.py
+++ b/src/cryptoadvance/specterext/spectrum/service.py
@@ -79,6 +79,7 @@ class SpectrumService(Service):
                 self.spectrum_node.start_spectrum(app, self.data_folder)
             except BrokenCoreConnectionException as e:
                 logger.error(e)
+        self.specter.checker.run_now()
 
     # TODO: Refactor this or the next function to only have one
     def enable_default_spectrum(self):

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -26,7 +26,7 @@ def test_checker(caplog):
     checker.stop()
     assert "someException" in caplog.text
     # should output 5 times
-    assert caplog.text.count("[   ERROR] Checker thread") == 5
+    assert caplog.text.count("[   ERROR] Checker ") == 5
     # But should also show stacktrace 5 times
     assert caplog.text.count("Exception: someException") == 5
     assert caplog.text.count("The above Error-Message is from now on suppressed!") == 1


### PR DESCRIPTION
Currently, the wallets are not showing up on startup if you use Spectrum. So you have to wait 10-20 seconds or so, that they are loaded.

This PR fixes this.