### PR TITLE
Fix nix shell by generating hashes with pip-compile

### DIFF
--- a/utils/shell.nix
+++ b/utils/shell.nix
@@ -7,10 +7,12 @@ stdenv.mkDerivation {
     python38Full
     python38Packages.virtualenv
     python38Packages.pip
+    python38Packages.pip-tools
     libusb1
   ];
   shellHook = ''
     cd ..
+    pip-compile --generate-hashes requirements.in > requirements.txt
     pip3 install virtualenv
     virtualenv --python=python3 .env
     source .env/bin/activate


### PR DESCRIPTION
I noticed that my local dev environment using `nix-shell` was broken because the nix shell is still using python 3.8 whereas there is an ongoing migration of specter-desktop to python 3.10. Specifically, I ran into a requirement-hashes-not-found error because the `backports.zoneinfo` dependency is required for python < 3.10 ([source](https://github.com/cryptoadvance/specter-desktop/blob/2f27befb39c27da9867ae97029a09c03054f4dd3/requirements.in#L27)), but it's no longer included in [requirements.txt](https://github.com/cryptoadvance/specter-desktop/blob/master/requirements.txt). The long-term solution is to upgrade nix-shell to rely on python 3.10, but the short-term fix is to simply generate requirements.txt as part of the nix-shell shellHook. 