### PR TITLE
Bugfix: internal node needs to be saved

### DIFF
--- a/src/cryptoadvance/specter/managers/node_manager.py
+++ b/src/cryptoadvance/specter/managers/node_manager.py
@@ -297,6 +297,7 @@ class NodeManager:
             self.internal_bitcoind_version,
         )
         self.nodes[node_alias] = node
+        self.save_node(node)
         return node
 
     def delete_node(self, node, specter):


### PR DESCRIPTION
Currently the spinup of an internal node is broken because the node does not get saved after creation.