### PR TITLE
Bugfix: Show whitepaper option only for Bitcoin Core nodes

### DIFF
--- a/src/cryptoadvance/specter/templates/welcome/components/tick_checkboxes.jinja
+++ b/src/cryptoadvance/specter/templates/welcome/components/tick_checkboxes.jinja
@@ -86,7 +86,7 @@
                 <td style="text-align: left;">
                 </td>
             </tr>
-            {% if specter.chain == 'main' %}
+            {% if specter.chain == 'main' and specter.node.node_type == "BTC "%}
             <tr class="tr-hover">
                 <td>
                     <img src="{{ url_for('static', filename='img/ghost_3d.png')}}" width="30px">


### PR DESCRIPTION
If you try to get the whitepaper from the timechain with a Spectrum node, you get this:
`Bitcoin Core RpcError: ('Method not found (getrawtransaction)', -32601)`. 
This PR restricts the feature to Bitcoin Core nodes, which also fixes that this is not possible with Liquid nodes.
