### PR TITLE
Bugfix: Allow string response in send_request-helper function

### DIFF
--- a/src/cryptoadvance/specter/static/helpers.js
+++ b/src/cryptoadvance/specter/static/helpers.js
@@ -201,8 +201,8 @@ async function send_request(url, method_str, csrf_token, formData) {
 		if (typeof(jsonResponse) === 'boolean') {
 			return {}
 		}
-		else if (jsonResponse !== null && 'error' in jsonResponse) {
-			showError(`${jsonResponse["error"]}`)
+		else if (jsonResponse !== null && jsonResponse.error) {
+			showError(`${jsonResponse.error}`)
 			return jsonResponse
 		}
 		return jsonResponse


### PR DESCRIPTION
Checking for an error in a string as response resulted in such errors:

![grafik](https://user-images.githubusercontent.com/70536101/212749804-c0d07d46-86cb-44b0-9f31-d54fd63beb22.png)
