### PR TITLE
Fixes/wallet_rpc_fix

### DIFF
--- a/src/cryptoadvance/specter/devices/bitcoin_core.py
+++ b/src/cryptoadvance/specter/devices/bitcoin_core.py
@@ -308,4 +308,4 @@ class BitcoinCoreWatchOnly(BitcoinCore):
         # Change type (also triggers write to file)
         self.set_type(DeviceTypes.BITCOINCORE)
         # After update this device will be available as a BitcoinCore (hot) instance
-        self.manager.update()
+        self.manager.update(comment="via BitcoinCoreWatchOnly")

--- a/src/cryptoadvance/specter/managers/wallet_manager.py
+++ b/src/cryptoadvance/specter/managers/wallet_manager.py
@@ -63,12 +63,15 @@ class WalletManager:
         rpc: BitcoinRPC = None,
         chain: str = None,
         use_threading=True,
+        comment="",
     ):
         """Restructures the instance, specifically if chain/rpc changed
         The _update internal method will resync the internal status with Bitcoin Core
         use_threading : for the _update method which is heavily communicating with Bitcoin Core
         """
-        logger.debug("starting update of wallet_manager")
+        logger.debug(
+            f"starting update of wallet_manager (threading: {use_threading} , comment: {comment})"
+        )
         if self.is_loading:
             logger.debug("update in progress, aborting!")
             return

--- a/src/cryptoadvance/specter/server_endpoints/controller.py
+++ b/src/cryptoadvance/specter/server_endpoints/controller.py
@@ -88,7 +88,7 @@ def server_specter_error(se):
         return {"error": str(se)}
     flash(str(se), "error")
     try:
-        app.specter.wallet_manager.update()
+        app.specter.wallet_manager.update(comment="via server_specter_error")
     except SpecterError as se:
         flash(str(se), "error")
     if request.method == "POST":

--- a/src/cryptoadvance/specter/server_endpoints/wallets/wallets_api.py
+++ b/src/cryptoadvance/specter/server_endpoints/wallets/wallets_api.py
@@ -703,7 +703,7 @@ def utxo_csv(wallet_alias):
 )
 @login_required
 def is_address_mine(wallet_alias, address):
-    wallet = app.specter.wallet_manager.get_by_alias(wallet_alias)
+    wallet: Wallet = app.specter.wallet_manager.get_by_alias(wallet_alias)
 
     # filter out invalid input
     # and Segwit addresses are always between 14 and 74 characters long.

--- a/src/cryptoadvance/specter/user.py
+++ b/src/cryptoadvance/specter/user.py
@@ -306,7 +306,10 @@ class User(UserMixin):
             self._wallet_manager = wallet_manager
         else:
             wallet_manager.update(
-                wallets_folder, self.specter.rpc, chain=self.specter.chain
+                wallets_folder,
+                self.specter.rpc,
+                chain=self.specter.chain,
+                comment="via user",
             )
 
     def check_device_manager(self, user=None):

--- a/src/cryptoadvance/specter/wallet.py
+++ b/src/cryptoadvance/specter/wallet.py
@@ -130,9 +130,7 @@ class Wallet:
 
         self.device_manager = device_manager
         self.manager = manager
-        self.rpc = self.manager.rpc.wallet(
-            os.path.join(self.manager.rpc_path, self.alias)
-        )
+        self.manager_rpc = manager.rpc
         self._devices = devices
         # check that all of the devices exist
         if None in self.devices:
@@ -175,6 +173,22 @@ class Wallet:
             or "" in [address, change_address]
         ):
             self.save_to_file()
+
+    @property
+    def rpc(self):
+        """caches an rpc-instance as long as the rpc from the wallet_manager did not change
+        This instance is also used by a lot of objects created by the wallet TxList/TxItem/...
+        """
+        if hasattr(self, "_rpc"):
+            if (
+                self.manager.rpc is self.manager_rpc
+            ):  # did the manager not change its rpc-instance?
+                return self._rpc
+        self.manager_rpc = self.manager.rpc
+        self._rpc = self.manager_rpc.wallet(
+            os.path.join(self.manager.rpc_path, self.alias)
+        )
+        return self._rpc
 
     @property
     def recv_descriptor(self):


### PR DESCRIPTION
* We wnat to have a better grip on why wallet_manager.update() has been called. So there is a new option param which will get logged
* Also we might want to prepare for being able to have more than one node for a specific network. For that, a wallet need to readjust it's rpc-instance as soon as the wallet_manager changed its rpc-instance (and the rpc is used).