### PR TITLE
Bugfix: Spectrum connection can't be deleted after restart of Specter

### DIFF
--- a/src/cryptoadvance/specterext/spectrum/spectrum_node.py
+++ b/src/cryptoadvance/specterext/spectrum/spectrum_node.py
@@ -24,6 +24,7 @@ class SpectrumNode(AbstractNode):
         host=None,
         port=None,
         ssl=None,
+        fullpath=None,
     ):
         self._spectrum = spectrum
         self.bridge = bridge
@@ -32,6 +33,8 @@ class SpectrumNode(AbstractNode):
         self._host = host
         self._port = port
         self._ssl = ssl
+        if fullpath != None:
+            self.fullpath = fullpath
 
         # ToDo: Should not be necessary
         self._rpc = None
@@ -89,8 +92,9 @@ class SpectrumNode(AbstractNode):
         host = node_dict.get("host", None)
         port = node_dict.get("port", None)
         ssl = node_dict.get("ssl", None)
+        fullpath = node_dict.get("fullpath", None)
 
-        return cls(name, alias, host=host, port=port, ssl=ssl)
+        return cls(name, alias, host=host, port=port, ssl=ssl, fullpath=fullpath)
 
     @property
     def json(self):


### PR DESCRIPTION
#2047 introduced the feature to delete a Spectrum connection. However, it didn't persist the fullpath attribute, so deleting was only possible until the next start of Specter. This PR tackles this by adding a fullpath attribute to the Spectrum node class which will be set once the node is initialised from disk / the json file. If we set it always, we will encounter an error when the node manager is saving the node for the first time since the fullpath would be None then. Open to other ways to implement this, but not sure how to do this without having the node manager in the Spectrum node (for its data folder) which is not ideal either. 