### PR TITLE
Import wallet screen improvement

### DIFF
--- a/src/cryptoadvance/specter/templates/wallet/new_wallet/import_wallet.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/new_wallet/import_wallet.jinja
@@ -53,6 +53,6 @@
 			</div>
 		{% endif %}
 		<input type="hidden" name="createwallet" value="true">
-		<button type="submit" name="action" value="importwallet" class="btn centered">Import Wallet</button>
+		<button type="submit" name="action" value="importwallet" class="button">Import Wallet</button>
 	</form>
 {% endblock %}


### PR DESCRIPTION
Addresses #2123. 
I've started out by replacing the tailwind button with classic button as it goes more with the theme. Before moving further ahead I think it'll be better to discuss what we want first.
Import wallet screen after this commit:
![Screenshot from 2023-02-02 00-24-25](https://user-images.githubusercontent.com/86092410/216136999-aaab9825-cb24-4e6c-ab6d-301ae3cfe123.png)

Send screen:
![Screenshot from 2023-02-02 00-25-09](https://user-images.githubusercontent.com/86092410/216137036-11785023-1b53-49df-a388-9e1ad7e01313.png)

cc: @moneymanolis @otkstdio 
On comparing both the screens what changes would you like to be made to the import wallet screen?