### PR TITLE
Fix redirect after removing device

### DIFF
--- a/src/cryptoadvance/specter/server_endpoints/devices.py
+++ b/src/cryptoadvance/specter/server_endpoints/devices.py
@@ -440,7 +440,7 @@ def device(device_alias):
                     bitcoin_datadir=app.specter.bitcoin_datadir,
                     chain=app.specter.chain,
                 )
-                return redirect("")
+                return redirect(url_for("welcome_endpoint.index"))
         elif action == "delete_key":
             key = Key.from_json({"original": request.form["key"]})
             wallets_with_key = [w for w in wallets if key in w.keys]


### PR DESCRIPTION
Fixes #https://github.com/cryptoadvance/specter-desktop/issues/2154

The "" string probably works in Flask but not with Electron, that is why the tests haven't picked up the bug.