### PR TITLE
Uiux/features/tiny_telemetry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 ARG USER=specter
 ARG DIR=/data/
 
-FROM python:3.9-slim-bullseye AS builder
+FROM python:3.10-slim-bullseye AS builder
 
 ARG VERSION
 ARG REPO
@@ -27,7 +27,7 @@ RUN pip3 install babel cryptography
 RUN pip3 install .
 
 
-FROM python:3.9-slim-bullseye as final
+FROM python:3.10-slim-bullseye as final
 
 ARG USER
 ARG DIR
@@ -48,7 +48,7 @@ RUN mkdir -p "$DIR/.specter/"
 
 
 # Copy over python stuff
-COPY --from=builder /usr/local/lib/python3.9 /usr/local/lib/python3.9
+COPY --from=builder /usr/local/lib/python3.10 /usr/local/lib/python3.10
 COPY --from=builder /usr/local/bin /usr/local/bin
 
 

--- a/src/cryptoadvance/specter/config.py
+++ b/src/cryptoadvance/specter/config.py
@@ -72,8 +72,9 @@ class BaseConfig(object):
     )
 
     # The Werkzeug Logs which are documenting each request are quite annoying with Cypress
-    # but by default, it's ok
-    ENABLE_WERZEUG_REQUEST_LOGGING = True
+    # but by default, we have a good replacement
+    ENABLE_WERZEUG_REQUEST_LOGGING = False
+    ENABLE_OWN_REQUEST_LOGGING = _get_bool_env_var("ENABLE_OWN_REQUEST_LOGGING", "True")
 
     # CERT and KEY is for running self-signed-ssl-certs. Check cli_server for details
     CERT = os.getenv("CERT", None)

--- a/src/cryptoadvance/specter/config.py
+++ b/src/cryptoadvance/specter/config.py
@@ -73,7 +73,9 @@ class BaseConfig(object):
 
     # The Werkzeug Logs which are documenting each request are quite annoying with Cypress
     # but by default, we have a good replacement
-    ENABLE_WERZEUG_REQUEST_LOGGING = False
+    ENABLE_WERZEUG_REQUEST_LOGGING = _get_bool_env_var(
+        "ENABLE_WERZEUG_REQUEST_LOGGING", "False"
+    )
     ENABLE_OWN_REQUEST_LOGGING = _get_bool_env_var("ENABLE_OWN_REQUEST_LOGGING", "True")
 
     # CERT and KEY is for running self-signed-ssl-certs. Check cli_server for details

--- a/src/cryptoadvance/specter/managers/wallet_manager.py
+++ b/src/cryptoadvance/specter/managers/wallet_manager.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime
 import os
 import sys
 import pathlib
@@ -159,6 +160,7 @@ class WalletManager:
         logger.info(
             f"Started updating wallets with {len(wallets_update_list.values())} wallets"
         )
+        timestamp = datetime.now()
         # list of wallets in the dict
         existing_names = list(self.wallets.keys())
         # list of wallet to keep
@@ -262,7 +264,10 @@ class WalletManager:
             logger.error(f"Failed updating wallet manager. RPC error: {e}")
         finally:
             self.is_loading = False
-            logger.info("Updating wallet manager done. Result:")
+            timediff_ms = int((datetime.now() - timestamp).total_seconds() * 1000)
+            logger.info(
+                "Updating wallet manager done in {: >5}ms. Result:".format(timediff_ms)
+            )
             logger.info(f"  * loaded_wallets: {len(self.wallets)}")
             logger.info(f"  * failed_load_wallets: {len(self._failed_load_wallets)}")
             for wallet in self._failed_load_wallets:


### PR DESCRIPTION
Replacing annoying Werkzeug Logger and adding millisenconds to each request by default:
```
[2023-02-10 14:49:53,082] INFO in controller: GET /svc/notifications/websocket             (200) took  411 ms
[2023-02-10 14:49:53,138] INFO in controller: GET /services/choose                         (200) took   25 ms
[2023-02-10 14:49:53,336] INFO in controller: GET /svc/notifications/get_websockets_info/  (200) took    0 ms
```

Also the WalletManager tells us now how long the update took:
```
[2023-02-10 14:49:47,687] INFO in wallet_manager: Updating wallet manager done in   543ms. Result:
[2023-02-10 14:49:47,687] INFO in wallet_manager:   * loaded_wallets: 6
[2023-02-10 14:49:47,687] INFO in wallet_manager:   * failed_load_wallets: 1
[2023-02-10 14:49:47,687] INFO in wallet_manager:     * MyTaprootTest : Working outside of request context.
```