### PR TITLE
fix style detection

### DIFF
--- a/src/cryptoadvance/specter/util/reflection.py
+++ b/src/cryptoadvance/specter/util/reflection.py
@@ -131,9 +131,14 @@ def get_subclasses_for_clazz_in_cwd(clazz, cwd=".") -> List[type]:
 
     # if not testing but in a folder which looks like specter-desktop/src --> No dynamic extensions
     if "PYTEST_CURRENT_TEST" not in os.environ:
-        # Hmm, need a better way to detect a specter-desktop-sourcedir
+        # Hmm, a bit hackish but if the pyproject.toml specifies cryptoadvance.specter as a name and
+        # we don't need to depend on toml-parsing libs, that should be ok.
         try:
-            if grep("./setup.py", 'name="cryptoadvance.specter",'):
+            found, line = grep("./pyproject.toml", 'name = "cryptoadvance.specter"')
+            if not found:
+                return []
+            line = line.replace(" ", "").replace("'", "").replace('"', "")
+            if line != "name=cryptoadvance.specter":
                 return []
         except FileNotFoundError:
             pass
@@ -141,6 +146,7 @@ def get_subclasses_for_clazz_in_cwd(clazz, cwd=".") -> List[type]:
     # Depending on the style we either add "." or "./src" to the searchpath
 
     extension_style = detect_extension_style_in_cwd()
+    # raise Exception(extension_style)
     if extension_style == "adhoc":
         package_dirs.append(Path("."))
     elif extension_style == "publish-ready":
@@ -151,7 +157,13 @@ def get_subclasses_for_clazz_in_cwd(clazz, cwd=".") -> List[type]:
             logger.info("We're in testing mode. Adding CWD to searchpath")
             package_dirs.append(Path("./src"))
         else:
-            raise Exception(f"This should not happen")
+            raise Exception(
+                f"""
+                We checked before that we're not in the specter-desktop home 
+                directory but now the extension-style is 'specter-desktop' ?!
+                This should not happen!
+            """
+            )
     logger.info(f"Detected Extension-style: {extension_style}")
     logger.info(f"We'll search in those package_dirs {package_dirs}")
     return get_subclasses_for_clazz(clazz, package_dirs)

--- a/src/cryptoadvance/specter/util/shell.py
+++ b/src/cryptoadvance/specter/util/shell.py
@@ -69,5 +69,5 @@ def grep(file_location, search_line):
     with open(file_location, "r") as the_file:
         for line in the_file.readlines():
             if line.strip().__contains__(search_line):
-                return True
-    return False
+                return True, line
+    return False, None


### PR DESCRIPTION
```
[2023-02-16 15:09:27,916] INFO in service_manager: ----> starting service discovery dynamic
Traceback (most recent call last):
  File "/home/kim/.pyenv/versions/3.10.4/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/kim/.pyenv/versions/3.10.4/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/kim/src/specter-desktop/src/cryptoadvance/specter/__main__.py", line 7, in <module>
    entry_point()
  File "/home/kim/src/specter-desktop/.env/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/kim/src/specter-desktop/.env/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/kim/src/specter-desktop/.env/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/kim/src/specter-desktop/.env/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/kim/src/specter-desktop/.env/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/kim/src/specter-desktop/src/cryptoadvance/specter/cli/cli_server.py", line 152, in server
    init_app(app, hwibridge=hwibridge)
  File "/home/kim/src/specter-desktop/src/cryptoadvance/specter/server.py", line 166, in init_app
    specter.service_manager = ExtensionManager(
  File "/home/kim/src/specter-desktop/src/cryptoadvance/specter/managers/service_manager/service_manager.py", line 62, in __init__
    class_list.extend(get_subclasses_for_clazz_in_cwd(Service))
  File "/home/kim/src/specter-desktop/src/cryptoadvance/specter/util/reflection.py", line 155, in get_subclasses_for_clazz_in_cwd
    raise Exception(f"This should not happen")
Exception: This should not happen
```