### PR TITLE
Spectrum specific hint on TX overview if there are no transactions

### DIFF
--- a/src/cryptoadvance/specter/node.py
+++ b/src/cryptoadvance/specter/node.py
@@ -683,6 +683,10 @@ class Node(AbstractNode):
             logger.debug(f"Could not find any wallet file at: {path}")
         return wallet_file_removed
 
+    def no_tx_hint(self):
+        """Returns the path to a template with some basic html and and a hint text to be used in the Transactions tab if there are no transactions"""
+        return "node/components/no_tx_hint.jinja"
+
     @property
     def is_running(self):
         if self._network_info["version"] == 999999:

--- a/src/cryptoadvance/specter/templates/includes/tx-table.html
+++ b/src/cryptoadvance/specter/templates/includes/tx-table.html
@@ -157,26 +157,11 @@
             display: flex;
             justify-content: center;
         }
-        .rescan-hint {
+        .no-tx-hint {
             display: flex;
             flex-direction: column;
             align-items: center;
             font-size: 1.1em;
-        }
-        .go-to-rescan-btn {
-            max-width: 175px;
-            margin: 0 0 5px 0;
-            border: 1px solid var(--cmap-border);
-            border-radius: 0.5em;
-            background-color: var(--cmap-border);
-            padding: 0.8em;
-            text-align: center;
-            font-weight: 250;
-        }
-        .go-to-rescan-btn:hover {
-            background-color: var(--cmap-border);
-            border: 1px solid var(--main-color);
-            text-decoration: none;
         }
         .empty-row {
             display: table-row;
@@ -308,10 +293,7 @@
             <thead id=""table-header>
                 <tr id="feedback-row" class="hidden">
                     <td id="feedback-row-content">
-                        <div id="rescan-hint" class="hidden">
-                            <p>{{_('Is this not a fresh wallet? Did you expect transactions here? Then click') }} &#128071; {{_('to find them') }}</p>
-                            <a id="go-to-rescan-btn" href="{{ url_for('wallets_endpoint.settings', wallet_alias=wallet_alias, rescan_blockchain=True) }}" class="go-to-rescan-btn btn">Go to blockchain rescan</a>
-                        </div>
+                        {% include specter.node.no_tx_hint() %}
                     </td>
                 </tr>
                 <tr id="empty-row" class="hidden">
@@ -372,7 +354,7 @@
             // Feedback row
             this.feedbackRow = clone.getElementById('feedback-row');
             this.feedbackRowContent = clone.getElementById('feedback-row-content')
-            this.rescanHint = clone.getElementById('rescan-hint')
+            this.noTxHint = clone.getElementById('no-tx-hint')
 
             // Empty row
             this.emptyRow = clone.getElementById('empty-row')
@@ -932,15 +914,15 @@
                     this.tableHeader.classList.add('hidden');
                     this.feedbackRow.classList.add('feedback-row');
                     this.feedbackRow.classList.remove('hidden');
-                    this.rescanHint.classList.remove('hidden')
-                    this.rescanHint.classList.add('rescan-hint')
+                    this.noTxHint.classList.remove('hidden')
+                    this.noTxHint.classList.add('no-tx-hint')
                     this.pageCount = 1;
                 } else {
                     this.tableHeader.classList.remove('hidden');
                     this.feedbackRow.classList.remove('feedback-row');
                     this.feedbackRow.classList.add('hidden');
-                    this.rescanHint.classList.remove('rescan-hint')
-                    this.rescanHint.classList.add('hidden');
+                    this.noTxHint.classList.remove('no-tx-hint')
+                    this.noTxHint.classList.add('hidden');
                 }
 
                 // If index is greater than the pages count fetch again for the last page

--- a/src/cryptoadvance/specter/templates/node/components/no_tx_hint.jinja
+++ b/src/cryptoadvance/specter/templates/node/components/no_tx_hint.jinja
@@ -1,0 +1,8 @@
+<div id="no-tx-hint" class="hidden">
+    {% if specter.info.get("initialblockdownload") %}
+      <p>{{_('Is this not a fresh wallet? Did you expect transactions here? Then click') }} &#128071; {{_('to find them') }}</p>
+        <a id="go-to-rescan-btn" href="{{ url_for('wallets_endpoint.settings', wallet_alias=wallet_alias, rescan_blockchain=True) }}" class="btn">Go to blockchain rescan</a>
+    {% else %}
+        {{_('No transactions yet') }}
+    {% endif %}
+</div>

--- a/src/cryptoadvance/specterext/spectrum/spectrum_node.py
+++ b/src/cryptoadvance/specterext/spectrum/spectrum_node.py
@@ -225,6 +225,10 @@ class SpectrumNode(AbstractNode):
     def node_connection_template(self):
         return "spectrum/components/spectrum_node_connection.jinja"
 
+    def no_tx_hint(self):
+        """Returns the path to a template with some basic html and and a hint text to be used in the Transactions tab if there are no transactions"""
+        return "spectrum/components/spectrum_no_tx_hint.jinja"
+
     @property
     def taproot_support(self):
         return False

--- a/src/cryptoadvance/specterext/spectrum/templates/spectrum/components/spectrum_no_tx_hint.jinja
+++ b/src/cryptoadvance/specterext/spectrum/templates/spectrum/components/spectrum_no_tx_hint.jinja
@@ -1,0 +1,8 @@
+<div id="no-tx-hint" class="hidden">
+    {% if specter.info.get("initialblockdownload") %}
+        {{_('Is this not a fresh wallet? Did you expect transactions here?') }} <br>
+        {{_('Wait for Spectrum to be fully synced. Check the progess by clicking on the connection.') }}
+    {% else %}
+        {{_('No transactions yet') }}
+    {% endif %}
+</div>


### PR DESCRIPTION
Looks now like this:

If Spectrum is still syncing:
![grafik](https://user-images.githubusercontent.com/70536101/220714061-2cadf1b6-e6fe-445a-a160-00148f7d0355.png)

If Spectrum is finished syncing:
![grafik](https://user-images.githubusercontent.com/70536101/220713991-5f09333a-aa0b-4c28-93d9-98c00881b9ae.png)

Text (now also in jinja file) for Bitcoin Core also adapted to distinguish between syncing state and non-syncing state. 