### PR TITLE
fix extension-test

### DIFF
--- a/src/cryptoadvance/specter/services/extension_gen.py
+++ b/src/cryptoadvance/specter/services/extension_gen.py
@@ -104,6 +104,7 @@ class ExtGen:
         self.render("README.md", version=self.version)
         self.render("requirements.txt", version=self.version)
         self.render(".gitignore")
+        self.render(f"pytest.ini")
         package_path = f"src/dummyorg/specterext/dummy"
         self.render(f"{package_path}/service.py")
         self.render(f"{package_path}/controller.py")
@@ -126,7 +127,6 @@ class ExtGen:
             self.render(f"{package_path}/templates/dummy/components/dummy_menu.jinja")
             self.render(f"{package_path}/templates/dummy/components/dummy_tab.jinja")
 
-        self.render(f"pytest.ini", env=self.sd_env)
         self.render(f"tests/conftest.py", env=self.sd_env)
         self.render(f"tests/conftest_visibility.py", env=self.sd_env)
         self.render(f"tests/fix_ghost_machine.py", env=self.sd_env)


### PR DESCRIPTION
The extension test is currently failing because we set the master branch to the uiux-revamp branch which no longer has a `pytest.ini` resulting in 

```
  File "/tmp/cirrus-ci-build/.env/lib/python3.10/site-packages/jinja2/environment.py", line 1010, in get_template
    return self._load_template(name, globals)
  File "/tmp/cirrus-ci-build/.env/lib/python3.10/site-packages/jinja2/environment.py", line 969, in _load_template
    template = self.loader.load(self, name, self.make_globals(globals))
  File "/tmp/cirrus-ci-build/.env/lib/python3.10/site-packages/jinja2/loaders.py", line 126, in load
    source, filename, uptodate = self.get_source(environment, name)
  File "/tmp/cirrus-ci-build/src/cryptoadvance/specter/services/extension_gen.py", line 237, in get_source
    raise TemplateNotFound(f"{url} results in {r.status_code}")
jinja2.exceptions.TemplateNotFound: https://raw.githubusercontent.com/cryptoadvance/specter-desktop//master/pytest.ini results in 404
```

However, the extgen process rely on specific files being present in the master branch of Specter-desktop. So the fix is to render that file rather from the dummy ext repo rather than specter-desktop.