### PR TITLE
Bugfix: Exception thrown when trying to add a device without node connection

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -114,6 +114,6 @@ extension_smoketest_task:
     - python3 -m cryptoadvance.specter server --config DevelopmentConfig --debug  2> specter.log &
     - sleep 15
     - cat specter.log | grep "Service CicdtestService activated (alpha)"
-    - apt-get -y install curl
+    - apt-get update && apt-get -y install curl
     - curl http://127.0.0.1:25441/svc/cicdtest/ | grep "CicdtestService 4thewin."
     

--- a/src/cryptoadvance/specter/node.py
+++ b/src/cryptoadvance/specter/node.py
@@ -65,6 +65,12 @@ class NonExistingNode(PersistentObject):
     def rpc(self):
         return None
 
+    @property
+    def network_parameters(self):
+        if self.is_running:
+            return get_network(self.chain)
+        return get_network("main")
+
     def check_blockheight(self):
         """check_blockheight is a method which is probably deprecated.
         It should return True if there are new blocks available since check_info has been called
@@ -198,10 +204,6 @@ class AbstractNode(NonExistingNode):
             return 99999
 
     # ... and more derived properties which already calculate stuff based on those information
-
-    @property
-    def network_parameters(self):
-        return get_network(self.chain)
 
     @property
     def is_testnet(self):

--- a/src/cryptoadvance/specter/node.py
+++ b/src/cryptoadvance/specter/node.py
@@ -67,6 +67,9 @@ class NonExistingNode(PersistentObject):
 
     @property
     def network_parameters(self):
+        ''' Is needed for creating devices/xpubs as they ask which network to use.
+        So this is a convenient thing especially for prod
+        '''
         return get_network("main")
 
     def check_blockheight(self):

--- a/src/cryptoadvance/specter/node.py
+++ b/src/cryptoadvance/specter/node.py
@@ -67,9 +67,7 @@ class NonExistingNode(PersistentObject):
 
     @property
     def network_parameters(self):
-        ''' Is needed for creating devices/xpubs as they ask which network to use.
-        So this is a convenient thing especially for prod
-        '''
+        """Needed for the derivation path in xpubs when adding a device."""
         return get_network("main")
 
     def check_blockheight(self):
@@ -220,9 +218,7 @@ class AbstractNode(NonExistingNode):
 
     @property
     def network_parameters(self):
-        '''
-        helpful if the cache is not filled. Not good for regtest but let's optimize for prod.
-        '''
+        """Uses an RPC call since AbstractNode has no cache"""
         if self.is_running:
             return get_network(self.chain)
         return get_network("main")

--- a/src/cryptoadvance/specter/node.py
+++ b/src/cryptoadvance/specter/node.py
@@ -220,6 +220,9 @@ class AbstractNode(NonExistingNode):
 
     @property
     def network_parameters(self):
+        '''
+        helpful if the cache is not filled. Not good for regtest but let's optimize for prod.
+        '''
         if self.is_running:
             return get_network(self.chain)
         return get_network("main")

--- a/src/cryptoadvance/specter/node.py
+++ b/src/cryptoadvance/specter/node.py
@@ -67,8 +67,6 @@ class NonExistingNode(PersistentObject):
 
     @property
     def network_parameters(self):
-        if self.is_running:
-            return get_network(self.chain)
         return get_network("main")
 
     def check_blockheight(self):
@@ -216,6 +214,12 @@ class AbstractNode(NonExistingNode):
             return False
         else:
             return True
+
+    @property
+    def network_parameters(self):
+        if self.is_running:
+            return get_network(self.chain)
+        return get_network("main")
 
     def check_blockheight(self):
         """Should return True if there are new blocks available since check_info has been called


### PR DESCRIPTION
Fixes https://github.com/cryptoadvance/specter-desktop/issues/2260

`NonExistingNode` gets a `network_parameter `property.