### PR TITLE
Bugfix: Specter app doesn't close after downloading

### DIFF
--- a/pyinstaller/electron/main.js
+++ b/pyinstaller/electron/main.js
@@ -155,7 +155,7 @@ const download = (uri, filename, callback) => {
 
         progressBar.on('aborted', () => {
           logger.info('Download was aborted before it could finish.')
-          progressBar = null
+          
         });
 
         // Loggin the download progress
@@ -325,6 +325,7 @@ app.whenReady().then(() => {
     logger.info("Creating specterd-binaries folder");
     fs.mkdirSync(specterdDirPath, { recursive: true });
   }
+
   let versionData
   // Download specterd, run sha256sum on it and then set your own versionData in dev, should look this:
   // {
@@ -337,7 +338,7 @@ app.whenReady().then(() => {
   else {
     versionData = require('./version-data.json')
   }
-  
+
   if (!appSettings.versionInitialized || appSettings.versionInitialized != versionData.version) {
     logger.info(`Updating ${appSettingsPath} : ${JSON.stringify(appSettings)}`);
     appSettings.specterdVersion = versionData.version
@@ -608,6 +609,7 @@ app.on('window-all-closed', function(){
   }
 });
 
+// Cleanup before quitting (helps prevent memory leaks)
 app.on('before-quit', (event) => {
   if (!quitted) {
     logger.info('Quitting ...')
@@ -615,7 +617,10 @@ app.on('before-quit', (event) => {
     quitSpecterd()
     if (mainWindow && !mainWindow.isDestroyed()) {
       if (progressBar) {
-          progressBar.destroy()
+          // You can only destroy the progress bar if it hadn't been closed before
+          if (progressBar.browserWindow) {
+            progressBar.destroy()
+          }
           progressBar = null
         }
        mainWindow.destroy()

--- a/pyinstaller/electron/main.js
+++ b/pyinstaller/electron/main.js
@@ -325,8 +325,19 @@ app.whenReady().then(() => {
     logger.info("Creating specterd-binaries folder");
     fs.mkdirSync(specterdDirPath, { recursive: true });
   }
-
-  let versionData = require('./version-data.json')
+  let versionData
+  // Download specterd, run sha256sum on it and then set your own versionData in dev, should look this:
+  // {
+  //   "version": "v2.0.0-pre32",
+  //   "sha256": "aa049abf3e75199bad26fbded08ee5911ad48e325b42c43ec195136bd0736785"
+  // }
+  if (isDev) {
+    versionData = require('./version-data-dev.json')
+  }
+  else {
+    versionData = require('./version-data.json')
+  }
+  
   if (!appSettings.versionInitialized || appSettings.versionInitialized != versionData.version) {
     logger.info(`Updating ${appSettingsPath} : ${JSON.stringify(appSettings)}`);
     appSettings.specterdVersion = versionData.version

--- a/pyinstaller/electron/version-data-dev.json
+++ b/pyinstaller/electron/version-data-dev.json
@@ -1,0 +1,5 @@
+{
+  "version": "v2.0.0-pre32",
+  "sha256": "aa049abf3e75199bad26fbded08ee5911ad48e325b42c43ec195136bd0736785"
+}
+


### PR DESCRIPTION
You can only destroy the progress bar if it hadn't been closed before which is done by default if the download is completed.

Fixes https://github.com/cryptoadvance/specter-desktop/issues/2267