### PR TITLE
bump spectrum, remove donation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,6 @@ We plan to add support for other hardware wallets as they come up. If you are in
 ## Help wanted: Do you like Specter?
 Please help us to push forward, fix bugs, refine FAQs and please help each other in the support channel.
 As a small team on a tiny budget we are working hard to make Specter better every day – for Bitcoin, for you and for us.
-We are quite overwhelmed with the response, the guides and shout-outs. Thank you!
-Stepan, Ben, Kim, all the fellow Specter-Builders & Moritz
 
 ## How to run
 

--- a/README.md
+++ b/README.md
@@ -71,8 +71,6 @@ As a small team on a tiny budget we are working hard to make Specter better ever
 We are quite overwhelmed with the response, the guides and shout-outs. Thank you!
 Stepan, Ben, Kim, all the fellow Specter-Builders & Moritz
 
-[Donations are welcome](https://donate.specter.solutions/apps/3k77BAT6zshCGNd3i7gw9WKwXQy1/pos)
-
 ## How to run
 
 ### Using the Specter Desktop app

--- a/requirements.in
+++ b/requirements.in
@@ -33,5 +33,5 @@ psycopg2-binary==2.9.5
 cryptoadvance-liquidissuer==0.2.4
 specterext-exfund==0.1.7
 specterext-faucet==0.1.2
-cryptoadvance.spectrum==0.4.2
+cryptoadvance.spectrum==0.5.0
 specterext-stacktrack==0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -119,9 +119,9 @@ cryptoadvance-liquidissuer==0.2.4 \
     --hash=sha256:5a2c531801854c5a4a46daf184877e22f731cdb42d2cfb840785bda7371ba6fb \
     --hash=sha256:9e468f3e35ecc566b3f74a2263677cf26632548abb194521dba15ad37acd1e9b
     # via -r requirements.in
-cryptoadvance.spectrum==0.4.2 \
-    --hash=sha256:4467c180b88d19037d2d926377ae95f441d2e649c871b8cecb42a7b8b80c5382 \
-    --hash=sha256:895ce7ac04f55752f6ccd1e2bbe153b1bda1d225860cb99a8e1d15f3a83998aa
+cryptoadvance.spectrum==0.5.0 \
+    --hash=sha256:1d17d7e6a54478cac7d935b61f50bb5ea383a96b2fd88f2e9fcdac3233a84bd1 \
+    --hash=sha256:6f6ae02a23ea4f69f7a567ee7b4d3683c9d1ad2d8f93e6c4c85f2de34d66332d
     # via -r requirements.in
 cryptography==3.4.7 \
     --hash=sha256:0f1212a66329c80d68aeeb39b8a16d54ef57071bf22ff4e521657b27372e327d \


### PR DESCRIPTION
Bump Spectrum to `v0.5.0` which is effectively this PR:
https://github.com/cryptoadvance/spectrum/pull/48