### PR TITLE
Chore: Add flag to run elements in Cypress test script

### DIFF
--- a/cypress/integration/spec_connections.js
+++ b/cypress/integration/spec_connections.js
@@ -28,22 +28,29 @@ describe('Connecting nodes', () => {
     })
   
     it('Connect with Liquid node', () => {
-      cy.get('#node-switch-icon').click()
-      cy.get('[data-cy="new-connection-btn"]').click()
-      cy.get('#name').clear()
-      cy.get('#name').type("Liquid")
-      cy.get('#username').clear()
-      cy.get('#username').type('liquid')
-      cy.get('#password').clear()
-      cy.get('#password').type('secret')
-      cy.get('#host').clear()
-      cy.get('#host').type('http://localhost')
-      cy.get('#port').clear()
-      cy.get('#port').type(8040)
-      cy.get('[data-cy="connect-btn"]').click()
+      cy.isElementsRunning().then((isRunning) => {
+        if (isRunning) {
+          cy.get('#node-switch-icon').click()
+          cy.get('[data-cy="new-connection-btn"]').click()
+          cy.get('#name').clear()
+          cy.get('#name').type("Liquid")
+          cy.get('#username').clear()
+          cy.get('#username').type('liquid')
+          cy.get('#password').clear()
+          cy.get('#password').type('secret')
+          cy.get('#host').clear()
+          cy.get('#host').type('http://localhost')
+          cy.get('#port').clear()
+          cy.get('#port').type(8040)
+          cy.get('[data-cy="connect-btn"]').click()
+        } 
+        else {
+          cy.log('Test was skipped: Elementsd was not started by the test script.')
+          Cypress.runner.stop()
+        }
+      })
     })
 
-    // TODO: For testing the deletion we could delete the Liquid connection here if we don't run the Liquid tests
     it('Select Bitcoin Core connection', () => {
       cy.get('#node-switch-icon').click()
       cy.contains('Bitcoin Core').click()

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -21,8 +21,17 @@ module.exports = (on, config) => {
   // `config` is the resolved Cypress config
   const btc_conn_file = fs.readFileSync('btcd-conn.json');
   const btc_conn = JSON.parse(btc_conn_file);
-  const elm_conn_file = fs.readFileSync('elmd-conn.json');
-  const elm_conn = JSON.parse(elm_conn_file);
+  const elm_conn_file_path = 'elmd-conn.json';
+  // Elementsd is not always started
+  let elm_conn
+  if (fs.existsSync(elm_conn_file_path)) {
+    const elm_conn_file = fs.readFileSync(elm_conn_file_path);
+    elm_conn = JSON.parse(elm_conn_file);
+  }
+  else {
+    elm_conn = {}
+  }
+
   on('task', {
     'clear:specter-home': () => {
       console.log('Removing and recreating Specter-data-folder %s', btc_conn["specter_data_folder"])

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -29,7 +29,7 @@ module.exports = (on, config) => {
     elm_conn = JSON.parse(elm_conn_file);
   }
   else {
-    elm_conn = {}
+    elm_conn = ''
   }
 
   on('task', {
@@ -88,6 +88,16 @@ module.exports = (on, config) => {
     }
   })
 
-
+  on("task", {
+    isElementsRunning: () => {
+      const elm_conn_file_path = "elmd-conn.json";
+      if (fs.existsSync(elm_conn_file_path)) {
+        return true;
+      } 
+      else {
+        return false;
+      }
+    },
+  });
 
 }

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -271,3 +271,7 @@ Cypress.Commands.add("connect", () => {
   cy.get('#port').type(15443)
   cy.get('[data-cy="connect-btn"]').click()
 })
+
+Cypress.Commands.add("isElementsRunning", () => {
+  return cy.task("isElementsRunning");
+});

--- a/utils/test-cypress.sh
+++ b/utils/test-cypress.sh
@@ -18,16 +18,6 @@ if [ -z "$VIRTUAL_ENV" ]; then
   source ./.env/bin/activate
 fi
 
-# Only start elements if --with-elements flag is set
-start_elementsd=false
-while [[ "$#" -gt 0 ]]; do
-    case $1 in
-        --with-elementsd) start_elementsd=true;;
-        *) break;;
-    esac
-    shift
-done
-
 function check_consistency {
   if ! npm version 2> /dev/null 1>&2 ; then
     echo "npm is not on the PATH. Please install node and bring it on the PATH."
@@ -409,6 +399,9 @@ function parse_and_execute() {
     exit 0
   fi 
 
+  # Don't start elementsd unless --with-elements is set
+  # Usage: ./utils/test-cypress.sh --with-elements run
+  start_elementsd=false
   while [[ $# -gt 0 ]]
   do
   arg="$1"
@@ -424,6 +417,10 @@ function parse_and_execute() {
       ;;
     --elm-log-stdout)
       ELMLOGSTDOUT=true
+      shift
+      ;;
+    --with-elements)
+      start_elementsd=true
       shift
       ;;
     *)

--- a/utils/test-cypress.sh
+++ b/utils/test-cypress.sh
@@ -73,6 +73,7 @@ Subcommands:
 
 generic-options:
     --debug             Run as much stuff in debug as we can
+    --with-elements     In addition to bitcoind, also start elementsd
 EOF
 }
 

--- a/utils/test-cypress.sh
+++ b/utils/test-cypress.sh
@@ -177,7 +177,7 @@ function start_bitcoind {
 }
 
 function start_elementsd {
-  if [ $start_elementsd = true ]; then
+  if [ $USE_ELEMENTSD = true ]; then
     start_node --elements $*
   fi
 }
@@ -401,7 +401,7 @@ function parse_and_execute() {
 
   # Don't start elementsd unless --with-elements is set
   # Usage: ./utils/test-cypress.sh --with-elements run
-  start_elementsd=false
+  USE_ELEMENTSD=false
   while [[ $# -gt 0 ]]
   do
   arg="$1"
@@ -420,7 +420,7 @@ function parse_and_execute() {
       shift
       ;;
     --with-elements)
-      start_elementsd=true
+      USE_ELEMENTSD=true
       shift
       ;;
     *)

--- a/utils/test-cypress.sh
+++ b/utils/test-cypress.sh
@@ -18,6 +18,16 @@ if [ -z "$VIRTUAL_ENV" ]; then
   source ./.env/bin/activate
 fi
 
+# Only start elements if --with-elements flag is set
+start_elementsd=false
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --with-elementsd) start_elementsd=true;;
+        *) break;;
+    esac
+    shift
+done
+
 function check_consistency {
   if ! npm version 2> /dev/null 1>&2 ; then
     echo "npm is not on the PATH. Please install node and bring it on the PATH."
@@ -176,7 +186,9 @@ function start_bitcoind {
 }
 
 function start_elementsd {
-  start_node --elements $*
+  if [ $start_elementsd = true ]; then
+    start_node --elements $*
+  fi
 }
 
 function stop_bitcoind {


### PR DESCRIPTION
- Elementsd is not run unless `--with-elements` flag is set
- `isElementsRunning` check in Cypress added to run Liquid tests only if elementsd is running.

Usage:  `./utils/test-cypress.sh --with-elements run`