### PR TITLE
Chore: pin babel to 2.11.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools<=65.7.0", 
     "setuptools_scm[toml]>=6.2", 
-    "babel",
+    "babel==2.11.0",
     "build==0.10.0",
     "wheel",
     "twine"


### PR DESCRIPTION
fixes #2280