### PR TITLE
Bugfixes/improvements based on developer testing feedback

### DIFF
--- a/src/cryptoadvance/specter/templates/node/node_settings.jinja
+++ b/src/cryptoadvance/specter/templates/node/node_settings.jinja
@@ -116,7 +116,10 @@
 				{% if node_alias %}
 					<button type="submit" name="action" value="delete" class="button">{{ _("Delete") }}</button>
 				{% endif %}
-				<button type="submit" class="button bg-accent text-white" name="action" value="connect" data-cy="connect-btn">{{ _("Connect") }}</button>
+				<button id="connect-btn" type="submit" class="button bg-accent text-white" name="action" value="connect" data-cy="connect-btn">
+					<span id="connect-text">{{ _("Connect") }}</span>
+                	<img class="hidden rounded-full w-4 h-4 animate-spin" id="connecting-indicator" src="{{ url_for('static', filename='img/refresh.svg') }}"/>
+				</button>
 			</div>
 
 			{% if failed_test %}
@@ -233,6 +236,14 @@
 			connectionNameElement.style.display = 'none';
 		}
     }
+
+	const connectBtn = document.getElementById('connect-btn')
+    const connectText = document.getElementById('connect-text');
+    const connectingIndicator = document.getElementById('connecting-indicator')
+    connectBtn.addEventListener('click', () => {
+        connectText.classList.add('hidden')
+        connectingIndicator.classList.remove('hidden')
+    })
 
 </script>
 {% endblock %}

--- a/src/cryptoadvance/specter/templates/wallet/new_wallet/components/import_wallet_account_map.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/new_wallet/components/import_wallet_account_map.jinja
@@ -47,6 +47,9 @@
             document.getElementById("txt").value = result;
         });
 
+        // This is needed to access the scanner object from outside of the module
+        window.scanner = scanner
+
         document.getElementById("scanme").addEventListener("click", function(){
             try{
                 scanner.start();
@@ -83,4 +86,18 @@
 			});
 		}
 	});
+
+	function onCancelOverlay() {
+        if (window.scanner) {
+            document.getElementById("popup").style.display = 'none';
+            window.scanner.stop();
+        }
+	}
+
+    // Deletes the global scanner property again if there is a reload
+    window.addEventListener('unload', () => {
+        if (window.scanner) {
+            delete window.scanner
+        }
+    })
 </script>

--- a/src/cryptoadvance/specter/templates/welcome/components/remaining_remarks.jinja
+++ b/src/cryptoadvance/specter/templates/welcome/components/remaining_remarks.jinja
@@ -1,5 +1,5 @@
 <p>{{ _("For more information, take a look at our ") }} 
-    <a href="https://specter-desktop-docs.netlify.app/" title="Documentation" alt="Documentation link">documentation</a>
+    <a href="https://specter-desktop-docs.netlify.app/" target="_blank" title="Documentation" alt="Documentation link">documentation</a>
     {{ _(" and ") }}
     <a href="https://specter-desktop-docs.netlify.app/faq/" target="_blank" title="FAQs" alt="FAQs link">FAQs</a>
     {{ _(". You can file") }}

--- a/src/cryptoadvance/specterext/spectrum/templates/spectrum/index.jinja
+++ b/src/cryptoadvance/specterext/spectrum/templates/spectrum/index.jinja
@@ -58,7 +58,10 @@
             {% if node_is_available %}
                 <button type="submit" class="button" name="action" value="delete">{{ _("Delete") }}</button>
             {% endif %}
-            <button type="submit" class="button bg-accent text-white" name="action" value="connect">{{ _("Connect") }}</button>
+            <button id="connect-btn" type="submit" class="button bg-accent text-white" name="action" value="connect">
+                <span id="connect-text">{{ _("Connect") }}</span>
+                <img class="hidden rounded-full w-4 h-4 animate-spin" id="connecting-indicator" src="{{ url_for('static', filename='img/refresh.svg') }}"/>
+            </button>
         </div>
     </form>
 {% endblock %}
@@ -107,5 +110,14 @@
     this.elec_option_list.addEventListener('click', (event) => {
         this.showElecOption("list")
     });
+
+    const connectBtn = document.getElementById('connect-btn')
+    const connectText = document.getElementById('connect-text');
+    const connectingIndicator = document.getElementById('connecting-indicator')
+    connectBtn.addEventListener('click', () => {
+        connectText.classList.add('hidden')
+        connectingIndicator.classList.remove('hidden')
+    })
+
   </script>
 {% endblock %}

--- a/src/cryptoadvance/specterext/spectrum/templates/spectrum/spectrum_setup.jinja
+++ b/src/cryptoadvance/specterext/spectrum/templates/spectrum/spectrum_setup.jinja
@@ -50,10 +50,12 @@
 
 <script>
     let backButton = document.getElementById('back-button');
-    backButton.setAttribute('href', document.referrer); // Just to have the link preview and open in a new tab functionality, probably not needed here
-    backButton.addEventListener('click', () => {
-        history.back();
-        return false;
-    })
+    if (backButton) {
+        backButton.setAttribute('href', document.referrer); // Just to have the link preview and open in a new tab functionality, probably not needed here
+        backButton.addEventListener('click', () => {
+            history.back();
+            return false;
+        })
+    }
 </script>
 {% endblock %}


### PR DESCRIPTION
- Fixes #2282 - The scanner is now stopped if the user closes the overlay without finishing the scanning process (either by clicking the close button or by clicking outside of the overlay).
- Improves the UX when connecting to a node: A spinning loading icon is now indicating that sth. is happening so users don't jump to the conclusion sth. is wrong and doesn't work.
- Small bug fixes (https://github.com/cryptoadvance/specter-desktop/commit/1b8aabe9c3098344df3016513346013eb8b5d745 and https://github.com/cryptoadvance/specter-desktop/pull/2283/commits/3226564dfaf5b11c89820e603383859edaf01ef3)