### PR TITLE
Enable Taproot support for Trezor

### DIFF
--- a/src/cryptoadvance/specter/devices/trezor.py
+++ b/src/cryptoadvance/specter/devices/trezor.py
@@ -6,9 +6,9 @@ class Trezor(HWIDevice):
     device_type = "trezor"
     name = "Trezor"
     icon = "img/devices/trezor_icon.svg"
-
     supports_hwi_toggle_passphrase = True
     supports_hwi_multisig_display_address = True
+    taproot_support = True
 
     @classmethod
     def get_client(cls, *args, **kwargs):

--- a/src/cryptoadvance/specter/node.py
+++ b/src/cryptoadvance/specter/node.py
@@ -725,11 +725,7 @@ class Node(AbstractNode):
     @property
     def taproot_support(self):
         try:
-            # currently only master branch supports tr() descriptors
-            # TODO: replace to 220000
-            return (self.bitcoin_core_version_raw >= 219900) and (
-                self.info.get("softforks", {}).get("taproot", {}).get("active", False)
-            )
+            return self.bitcoin_core_version_raw >= 220000
         except Exception as e:
             logger.exception(e)
             return False


### PR DESCRIPTION
This enables adding taproot derivation keys and choosing a Taproot wallet with Trezor devices.

<img width="736" alt="grafik" src="https://user-images.githubusercontent.com/70536101/223795686-3e74d8c9-104a-4052-802b-06f175f8d3dc.png">

![grafik](https://user-images.githubusercontent.com/70536101/223795561-105e802c-a4cb-4f5e-94c0-c40aefe04487.png)
 