### PR TITLE
fixes #2319

### DIFF
--- a/src/cryptoadvance/specter/server_endpoints/wallets/wallets_api.py
+++ b/src/cryptoadvance/specter/server_endpoints/wallets/wallets_api.py
@@ -916,7 +916,7 @@ def txlist_to_csv(
                 tx["blockheight"] = "Unconfirmed"
         # For txs, the relevant amount is flow_amount
         if amount_logic == "flow":
-            tx["amount"] = tx.flow_amount
+            tx["amount"] = tx["flow_amount"]
         amount_price = "not supported"
         rate = "not supported"
         if tx.get("blocktime"):


### PR DESCRIPTION
I couldn't reproduce the exact error of #2319 but i got an exception like:
```
[2023-05-01 13:44:34,800] INFO in controller: GET, /wallets/wallets_overview/full_transactions.csvexportPrices=false&search=&sortby=time&sortdir=desc, 200, took,  545, ms
Debugging middleware caught exception in streamed response at a point where response headers were already sent.
Traceback (most recent call last):
  File "/home/kim/src/specter-desktop/.env/lib/python3.10/site-packages/werkzeug/wsgi.py", line 500, in __next__
    return self._next()
  File "/home/kim/src/specter-desktop/.env/lib/python3.10/site-packages/werkzeug/wrappers/response.py", line 50, in _iter_encoded
    for item in iterable:
  File "/home/kim/src/specter-desktop/.env/lib/python3.10/site-packages/flask/helpers.py", line 129, in generator
    yield from gen
  File "/home/kim/src/specter-desktop/src/cryptoadvance/specter/server_endpoints/wallets/wallets_api.py", line 919, in txlist_to_csv
    tx["amount"] = tx.flow_amount
AttributeError: 'dict' object has no attribute 'flow_amount'
[2023-05-01 13:44:35,778] INFO in spectrum: Syncprocess now subscribed to 700 scripthashes (58%, 19.444444444444443 scripts/s)
```

This should fix this