### PR TITLE
Feature: Enable import of a multisig wallet that uses a multi-descriptor

### DIFF
--- a/src/cryptoadvance/specter/managers/wallet_manager.py
+++ b/src/cryptoadvance/specter/managers/wallet_manager.py
@@ -159,7 +159,6 @@ class WalletManager:
             if wallets_update_list:
                 loaded_wallets = self.rpc.listwallets()
                 for wallet in wallets_update_list:
-
                     wallet_alias = wallets_update_list[wallet]["alias"]
                     wallet_name = wallets_update_list[wallet]["name"]
                     # wallet from json not yet loaded in Bitcoin Core?!
@@ -331,7 +330,9 @@ class WalletManager:
             # a reasonable core version
             return 200000
 
-    def create_wallet(self, name, sigs_required, key_type, keys, devices, keep_multi=False, **kwargs):
+    def create_wallet(
+        self, name, sigs_required, key_type, keys, devices, keep_multi=False, **kwargs
+    ):
         try:
             walletsindir = [
                 wallet["name"] for wallet in self.rpc.listwalletdir()["wallets"]

--- a/src/cryptoadvance/specter/managers/wallet_manager.py
+++ b/src/cryptoadvance/specter/managers/wallet_manager.py
@@ -331,7 +331,7 @@ class WalletManager:
             # a reasonable core version
             return 200000
 
-    def create_wallet(self, name, sigs_required, key_type, keys, devices, **kwargs):
+    def create_wallet(self, name, sigs_required, key_type, keys, devices, keep_multi=False, **kwargs):
         try:
             walletsindir = [
                 wallet["name"] for wallet in self.rpc.listwalletdir()["wallets"]
@@ -353,6 +353,7 @@ class WalletManager:
             key_type,
             keys,
             devices,
+            keep_multi,
             self.bitcoin_core_version_raw,
             **kwargs,
         )

--- a/src/cryptoadvance/specter/templates/wallet/components/wallet_pdf.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/components/wallet_pdf.jinja
@@ -38,9 +38,9 @@
         doc.setFontSize(16);
         {% if wallet.is_multisig %}
             if ('{{ wallet.address_type }}' == 'bech32') {
-                doc.text('{{ wallet.sigs_required }} of {{ wallet.keys | length }} {{ _("multisig") }} (sorted, native segwit)', 105, currentHeight, {align: 'center'});
+                doc.text('{{ wallet.sigs_required }} of {{ wallet.keys | length }} multisig {% if not wallet.keep_multi %}(key order is irrelevant{% else %}(key order matters (multi){% endif %}, native segwit)', 105, currentHeight, {align: 'center'});
             } else {
-                doc.text('{{ wallet.sigs_required }} of {{ wallet.keys | length }} {{ _("multisig") }} (sorted, nested segwit)', 105, currentHeight, {align: 'center'});
+                doc.text('{{ wallet.sigs_required }} of {{ wallet.keys | length }} multisig {% if not wallet.keep_multi %}(key order is irrelevant{% else %}(key order matters (multi){% endif %}, nested segwit)', 105, currentHeight, {align: 'center'});
             }
             currentHeight += 7;
         {% else %}

--- a/src/cryptoadvance/specter/templates/wallet/new_wallet/new_wallet.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/new_wallet/new_wallet.jinja
@@ -11,7 +11,7 @@
 		{% endif %}
 
 		{% if wallet_type == 'multisig' %}
-			<p>{{ _("We use sorted multisig (BIP-67), so ")}}<b>{{ _("order is NOT important.") }}</b> {{ _('Please read the ')}}<a data-style="color: #fff" href="https://specter-desktop-docs.netlify.app/multisig-guide/" target="_blank">{{ _("multisig guide")}}</a>.</p>
+			<p>{{ _("We use sorted multisig (BIP-67) when generating multisig wallet, so ")}}<b>{{ _("the order of your devices is NOT important.") }}</b> {{ _('Please read the ')}}<a data-style="color: #fff" href="https://specter-desktop-docs.netlify.app/multisig-guide/" target="_blank">{{ _("multisig guide")}}</a>.</p>
 		{% endif %}
 
 		<div class="grid grid-cols-3 gap-5 my-10">

--- a/src/cryptoadvance/specter/util/wallet_importer.py
+++ b/src/cryptoadvance/specter/util/wallet_importer.py
@@ -232,14 +232,28 @@ class WalletImporter:
             ):
                 kwargs["blinding_key"] = self.descriptor.blinding_key.key
 
-            self.wallet = wallet_manager.create_wallet(
-                name=self.wallet_name,
-                sigs_required=self.sigs_required,
-                key_type=self.address_type,
-                keys=self.keys,
-                devices=self.cosigners,
-                **kwargs,
-            )
+            # Keep multi descriptor
+            # For multi() descriptors is_sorted returns False
+            if not self.descriptor.is_sorted:
+                self.wallet = wallet_manager.create_wallet(
+                    name=self.wallet_name,
+                    sigs_required=self.sigs_required,
+                    key_type=self.address_type,
+                    keys=self.keys,
+                    devices=self.cosigners,
+                    keep_multi=True,
+                    **kwargs,
+                )
+            else: 
+                self.wallet = wallet_manager.create_wallet(
+                    name=self.wallet_name,
+                    sigs_required=self.sigs_required,
+                    key_type=self.address_type,
+                    keys=self.keys,
+                    devices=self.cosigners,
+                    keep_multi=False,
+                    **kwargs,
+                )
         except Exception as e:
             logger.exception(e)
             raise SpecterError(f"Failed to create wallet: {e} (check logs for details)")

--- a/src/cryptoadvance/specter/util/wallet_importer.py
+++ b/src/cryptoadvance/specter/util/wallet_importer.py
@@ -68,10 +68,8 @@ class WalletImporter:
         self.wallet_type = "multisig" if self.descriptor.is_basic_multisig else "simple"
 
     def check_chain(self, node):
-
         cosigner: Device
         for cosigner in self.cosigners:
-
             key_chain_list = [key.is_testnet for key in cosigner.keys]
             logger.debug(key_chain_list)
             if node.is_testnet not in key_chain_list:
@@ -244,7 +242,7 @@ class WalletImporter:
                     keep_multi=True,
                     **kwargs,
                 )
-            else: 
+            else:
                 self.wallet = wallet_manager.create_wallet(
                     name=self.wallet_name,
                     sigs_required=self.sigs_required,

--- a/src/cryptoadvance/specter/wallet/wallet.py
+++ b/src/cryptoadvance/specter/wallet/wallet.py
@@ -128,8 +128,6 @@ class Wallet(AbstractWallet):
         if not isinstance(descriptor, str):
             descriptor = str(descriptor)
         self.descriptor = self.DescriptorCls.from_string(descriptor)
-        logger.debug(f"This is the passed descriptor to the wallet: {descriptor}")
-        logger.debug(f"This is the descriptor of the wallet: {self.descriptor}")
         if self.descriptor.num_branches != 2:
             raise SpecterError(
                 f"Descriptor has {self.descriptor.num_branches} branches, but we need 2."
@@ -262,7 +260,6 @@ class Wallet(AbstractWallet):
 
     @classmethod
     def merge_descriptors(cls, recv_descriptor: str, change_descriptor=None) -> str:
-        logger.debug("Running merge_descriptors ...")
         """Parses string with descriptors (change is optional) and creates a combined one"""
         if change_descriptor is None and "/0/*" not in recv_descriptor:
             raise SpecterError("Receive descriptor has strange derivation path")

--- a/src/cryptoadvance/specter/wallet/wallet.py
+++ b/src/cryptoadvance/specter/wallet/wallet.py
@@ -231,7 +231,9 @@ class Wallet(AbstractWallet):
         return get_network(self.chain)
 
     @classmethod
-    def construct_descriptor(cls, sigs_required, key_type, keys, devices, keep_multi) -> Descriptor:
+    def construct_descriptor(
+        cls, sigs_required, key_type, keys, devices, keep_multi
+    ) -> Descriptor:
         """
         Creates a wallet descriptor from arguments.
         We need to pass `devices` for Liquid wallet, here it's not used.
@@ -260,7 +262,7 @@ class Wallet(AbstractWallet):
 
     @classmethod
     def merge_descriptors(cls, recv_descriptor: str, change_descriptor=None) -> str:
-        logger.debug('Running merge_descriptors ...')
+        logger.debug("Running merge_descriptors ...")
         """Parses string with descriptors (change is optional) and creates a combined one"""
         if change_descriptor is None and "/0/*" not in recv_descriptor:
             raise SpecterError("Receive descriptor has strange derivation path")
@@ -506,7 +508,8 @@ class Wallet(AbstractWallet):
 
     def check_unused(self):
         """Check current receive address is unused and get new if needed
-        Used means: the given address having a non-zero amount received in transactions with zero confirmations."""
+        Used means: the given address having a non-zero amount received in transactions with zero confirmations.
+        """
         addr = self.address
         try:
             while self.rpc.getreceivedbyaddress(addr, 0) != 0:
@@ -676,7 +679,7 @@ class Wallet(AbstractWallet):
             manager,
             old_format_detected=wallet_dict["old_format_detected"],
             last_block=last_block,
-            keep_multi = keep_multi
+            keep_multi=keep_multi,
         )
 
     def get_info(self):
@@ -882,7 +885,7 @@ class Wallet(AbstractWallet):
             "devices": [device.alias for device in self.devices],
             "sigs_required": self.sigs_required,
             "blockheight": self.blockheight,
-            "keep_multi": self.keep_multi
+            "keep_multi": self.keep_multi,
         }
         if for_export:
             o["labels"] = self.export_labels()
@@ -1060,7 +1063,6 @@ class Wallet(AbstractWallet):
         transactions = self._transactions.get_transactions()
         result = []
         for tx in transactions:
-
             if isinstance(tx["address"], str):
                 tx["label"] = self.getlabel(tx["address"])
                 addr_obj = self.get_address_obj(tx["address"])


### PR DESCRIPTION
- Besides copy changes to reflect the additional functionality, this PR mainly introduces a `keep_multi` parameter to ensure that an imported multisig wallet with a `multi` descriptor is not changing to a `sortedmulti` descriptor as is currently the case.
- New multisig wallets created with Specter still use `sortedmulti`
