### PR TITLE
fix login  open redirect due to next parameter manipulation

### DIFF
--- a/src/cryptoadvance/specter/helpers.py
+++ b/src/cryptoadvance/specter/helpers.py
@@ -345,3 +345,6 @@ def get_address_from_dict(data_dict):
     if addr and addr != "Fee":
         return addr
     raise RuntimeError(f"Missing address info in object {data_dict}")
+
+def is_relative_url(url):
+     return re.match(r"^\/[^\/\\]", url)

--- a/src/cryptoadvance/specter/helpers.py
+++ b/src/cryptoadvance/specter/helpers.py
@@ -346,5 +346,6 @@ def get_address_from_dict(data_dict):
         return addr
     raise RuntimeError(f"Missing address info in object {data_dict}")
 
+
 def is_relative_url(url):
-     return re.match(r"^\/[^\/\\]", url)
+    return re.match(r"^\/[^\/\\]", url)

--- a/src/cryptoadvance/specter/server_endpoints/auth.py
+++ b/src/cryptoadvance/specter/server_endpoints/auth.py
@@ -1,6 +1,7 @@
 import random
 import time
 
+
 from flask import Blueprint, Flask
 from flask import current_app as app
 from flask import jsonify, redirect, render_template, request, url_for
@@ -9,7 +10,7 @@ from flask_login import current_user, login_required, logout_user
 
 from cryptoadvance.specter.specter import Specter
 
-from ..helpers import alias
+from ..helpers import alias , is_relative_url
 from ..server_endpoints import flash
 from ..services import ExtensionException
 from ..user import User, hash_password, verify_password
@@ -235,7 +236,7 @@ def redirect_login(request):
     if app.specter.hide_sensitive_info:
         app.specter.update_hide_sensitive_info(False, current_user)
 
-    if request.form.get("next") and request.form.get("next") != "None":
+    if (request.form.get("next") and request.form.get("next") != "None") and is_relative_url(request.form["next"]):
         response = redirect(request.form["next"])
     else:
         response = redirect(url_for("index"))

--- a/src/cryptoadvance/specter/server_endpoints/auth.py
+++ b/src/cryptoadvance/specter/server_endpoints/auth.py
@@ -10,7 +10,7 @@ from flask_login import current_user, login_required, logout_user
 
 from cryptoadvance.specter.specter import Specter
 
-from ..helpers import alias , is_relative_url
+from ..helpers import alias, is_relative_url
 from ..server_endpoints import flash
 from ..services import ExtensionException
 from ..user import User, hash_password, verify_password
@@ -236,7 +236,9 @@ def redirect_login(request):
     if app.specter.hide_sensitive_info:
         app.specter.update_hide_sensitive_info(False, current_user)
 
-    if (request.form.get("next") and request.form.get("next") != "None") and is_relative_url(request.form["next"]):
+    if (
+        request.form.get("next") and request.form.get("next") != "None"
+    ) and is_relative_url(request.form["next"]):
         response = redirect(request.form["next"])
     else:
         response = redirect(url_for("index"))


### PR DESCRIPTION
during login on specter desktop , the next parameter can be changed to different domain and a user will be redirected to that domain . This can be used in phishing attack , all attacker need to do is to have the user click on a link with the tampered "next" parameter