### PR TITLE
Remove whitespace from wallet importer to fix importing via copy-paste from pdf

### DIFF
--- a/src/cryptoadvance/specter/util/wallet_importer.py
+++ b/src/cryptoadvance/specter/util/wallet_importer.py
@@ -38,7 +38,7 @@ class WalletImporter:
         if device_manager is None:
             device_manager = specter.device_manager
         try:
-            self.wallet_data = json.loads(wallet_json)
+            self.wallet_data = json.loads("".join(wallet_json.split()))
             (
                 self.wallet_name,
                 recv_descriptor,


### PR DESCRIPTION
When importing your wallet by copy and pasting the descriptor from the Specter backup pdf it fails as copying from a pdf leaves whitespaces in the string. This is rejected by specter because of the whitespace. This PR strips any whitespaces from the import string before importing.