### PR TITLE
Chore: Regex change to capture labels in wallet data imports better

### DIFF
--- a/src/cryptoadvance/specter/templates/wallet/new_wallet/components/import_wallet_account_map.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/new_wallet/components/import_wallet_account_map.jinja
@@ -90,7 +90,7 @@
             event.preventDefault()
             const clipboardData = event.clipboardData || window.clipboardData
             const pastedText = clipboardData.getData("text/plain")
-            const cleanedText = pastedText.replace(/("label":\s?"[^"]*")|\s/g, (_, label) => {
+            const cleanedText = pastedText.replace(/("label"\s?:\s?"[^"]*")|\s/g, (_, label) => {
                 if (label) {
                     return label.replace(/\n/g, ' ') // Convert newline characters to spaces within labels
                 } else {


### PR DESCRIPTION
Mini change to
https://github.com/cryptoadvance/specter-desktop/pull/2355

... to also identify a label like the one below with the "Home Key" (it has an `\n` after "label" which was not captured so far)

<img width="872" alt="image" src="https://github.com/cryptoadvance/specter-desktop/assets/70536101/3cc32ba6-6fcc-4de7-8d65-c9e9bd13c983">
