### PR TITLE
Remove Specter URI to avoid provisioning profiles (Apple)

### DIFF
--- a/pyinstaller/electron/build/entitlements.mac.plist
+++ b/pyinstaller/electron/build/entitlements.mac.plist
@@ -6,6 +6,11 @@
     <true/>
     <key>com.apple.security.device.camera</key>
     <true/>
+    <!-- 
+      this has been introduced with #2344
+      However it needs MAC provisioning profiles to be set up
+      And those trigger a App Review by Apple which we
+      currently want to avoid. Maybe later.
     <key>CFBundleURLTypes</key>
       <array>
         <dict>
@@ -17,5 +22,6 @@
           </array>
         </dict>
       </array>
+    -->
   </dict>
 </plist>


### PR DESCRIPTION
This addition in the entitlements-file caused #2356 . So let's remove it for now maybe adding it at a later stage.