### PR TITLE
Bugfix: Jade displaying wrong multisig addresses for descriptors using multi()

### DIFF
--- a/src/cryptoadvance/specter/devices/hwi/jade.py
+++ b/src/cryptoadvance/specter/devices/hwi/jade.py
@@ -556,10 +556,11 @@ class JadeClient(HardwareWalletClient):
             paths.append(parse_path(path))
 
         # sort origins, signers and paths according to origins (like in _get_multisig_name)
-        signer_origins, signers, paths = [
-            list(a) for a in zip(*sorted(zip(signer_origins, signers, paths)))
-        ]
-
+        # But, only sort if sorted_multi is used (and thus the order of xpubs is not relevant)
+        if multisig.is_sorted:
+            signer_origins, signers, paths = [
+                list(a) for a in zip(*sorted(zip(signer_origins, signers, paths)))
+            ]
         # Get a deterministic name for this multisig wallet
         script_variant = self._convertAddrType(addr_type, multisig=True)
         multisig_name = self._get_multisig_name(
@@ -572,7 +573,7 @@ class JadeClient(HardwareWalletClient):
             self._network(),
             multisig_name,
             script_variant,
-            True,  # always use sorted
+            multisig.is_sorted,
             multisig.thresh,
             signers,
         )

--- a/src/cryptoadvance/specter/templates/includes/hwi/components/wallet.jinja
+++ b/src/cryptoadvance/specter/templates/includes/hwi/components/wallet.jinja
@@ -1,13 +1,13 @@
 {% if wallet is defined %}
 
-<div id="hwi_display_address" class="flex-center flex-column hidden" data-style="overflow-wrap: break-word;">
+<div id="hwi_display_address" class="flex-center flex-column hidden p-4 bg-dark-800" data-style="overflow-wrap: break-word;">
     <h2>{{ _("Confirm Address") }}</h2><br>
     <div>
         {{ _("Please confirm address matches on your ")}}<span id="hwi_device_name">{{ _('device')}}</span><br><br>
         {{ _("Expected address") }}:<br><span id="expected_address"></span>
     </div>
-    <div class="flex-center">
-        <img src="{{ url_for('static', filename='img/loader_boxes.svg') }}"/>
+    <div class="flex justify-center mt-4 ">
+        <img src="{{ url_for('static', filename='img/loader_boxes.svg') }}" class="w-16 h-16"/>
     </div>
 </div>
 


### PR DESCRIPTION
When using a multisig wallet with `multi()` instead of a `sortedmulti()` descriptor the Jade was displaying wrong addresses since the function to register the multisig configuration on the Jade was always called with `sorted` set to `True`.

TODOs
- [x] Fix the UI for the address display overlay

![telegram-cloud-photo-size-2-5404405852078722861-y](https://github.com/cryptoadvance/specter-desktop/assets/70536101/73845474-6b27-4733-9cf0-ed5df32aafc9)
