### PR TITLE
Bugfix: Add missing signet key

### DIFF
--- a/src/cryptoadvance/specter/rpc.py
+++ b/src/cryptoadvance/specter/rpc.py
@@ -60,7 +60,13 @@ def get_rpcconfig(datadir=get_default_datadir()) -> dict:
     }
     """
     config = {
-        "bitcoin.conf": {"default": {}, "main": {}, "test": {}, "regtest": {}},
+        "bitcoin.conf": {
+            "default": {},
+            "main": {},
+            "test": {},
+            "regtest": {},
+            "signet": {},
+        },
         "cookies": {},
     }
     if not os.path.isdir(datadir):  # we don't know where to search for files

--- a/src/cryptoadvance/specter/templates/wallet/new_wallet/components/import_wallet_account_map.jinja
+++ b/src/cryptoadvance/specter/templates/wallet/new_wallet/components/import_wallet_account_map.jinja
@@ -90,7 +90,7 @@
             event.preventDefault()
             const clipboardData = event.clipboardData || window.clipboardData
             const pastedText = clipboardData.getData("text/plain")
-            const cleanedText = pastedText.replace(/("label":\s?"[^"]*")|\s/g, (_, label) => {
+            const cleanedText = pastedText.replace(/("label"\s?:\s?"[^"]*")|\s/g, (_, label) => {
                 if (label) {
                     return label.replace(/\n/g, ' ') // Convert newline characters to spaces within labels
                 } else {

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -57,6 +57,7 @@ def test_get_rpcconfig1():
         "main": {"rpcport": "8332"},
         "regtest": {"rpcport": "18443"},
         "test": {"rpcport": "18332"},
+        "signet": {},
     }
 
 
@@ -88,6 +89,7 @@ def test_get_rpcconfig2(empty_data_folder):
             "zmqpubhashblock": "tcp://127.0.0.1:29000",
         },
         "test": {},
+        "signet": {},
     }
 
 


### PR DESCRIPTION
Signet was missing in `get_rpcconfig()` resulting in such an error:

```
Traceback (most recent call last):
  File "/Users/manolis/.pyenv/versions/.specter/lib/python3.10/site-packages/flask/app.py", line 1523, in full_dispatch_request
    rv = self.dispatch_request()
  File "/Users/manolis/.pyenv/versions/.specter/lib/python3.10/site-packages/flask/app.py", line 1509, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
  File "/Users/manolis/.pyenv/versions/.specter/lib/python3.10/site-packages/flask_login/utils.py", line 290, in decorated_view
    return current_app.ensure_sync(func)(*args, **kwargs)
  File "/Users/manolis/coding/repos/specter-desktop/src/cryptoadvance/specter/server_endpoints/nodes.py", line 68, in node_settings_new_node_get
    node = Node.from_json(
  File "/Users/manolis/coding/repos/specter-desktop/src/cryptoadvance/specter/node.py", line 348, in from_json
    return cls(
  File "/Users/manolis/coding/repos/specter-desktop/src/cryptoadvance/specter/node.py", line 327, in __init__
    self.rpc = self._get_rpc()
  File "/Users/manolis/coding/repos/specter-desktop/src/cryptoadvance/specter/node.py", line 395, in _get_rpc
    rpc_conf_arr = autodetect_rpc_confs(
  File "/Users/manolis/coding/repos/specter-desktop/src/cryptoadvance/specter/rpc.py", line 207, in autodetect_rpc_confs
    conf_arr.extend(_detect_rpc_confs_via_datadir(datadir=datadir))
  File "/Users/manolis/coding/repos/specter-desktop/src/cryptoadvance/specter/rpc.py", line 141, in _detect_rpc_confs_via_datadir
    if "rpcuser" in config["bitcoin.conf"][network]:
KeyError: 'signet'
```