### PR TITLE
remove enumerate in HWIBridge init

### DIFF
--- a/src/cryptoadvance/specter/hwi_rpc.py
+++ b/src/cryptoadvance/specter/hwi_rpc.py
@@ -81,11 +81,6 @@ class HWIBridge(JSONRPC):
             "extract_master_blinding_key": self.extract_master_blinding_key,
             "bitbox02_pairing": self.bitbox02_pairing,
         }
-        # Running enumerate after beginning an interaction with a specific device
-        # crashes python or make HWI misbehave. For now we just get all connected
-        # devices once per session and save them.
-        logger.info("Initializing HWI...")  # to explain user why it takes so long
-        self.enumerate()
 
     @locked(hwilock)
     def enumerate(self, passphrase="", chain=""):

--- a/src/cryptoadvance/specter/hwi_rpc.py
+++ b/src/cryptoadvance/specter/hwi_rpc.py
@@ -81,6 +81,7 @@ class HWIBridge(JSONRPC):
             "extract_master_blinding_key": self.extract_master_blinding_key,
             "bitbox02_pairing": self.bitbox02_pairing,
         }
+        self.devices = []
 
     @locked(hwilock)
     def enumerate(self, passphrase="", chain=""):


### PR DESCRIPTION
Removes initial enumeration of the devices before Specter starts.

Close https://github.com/cryptoadvance/specter-desktop/issues/2343

Requires careful testing on Mac and Windows (tested on Linux, seems to work fine).

Test process for Jade, Ledger and Trezor:
- start Specter with connected but locked hardware wallet
- unlock and go through some HWI functions - add keys, display address, send tx or whatever
- start Specter without any HW connected
- connect and use HWI functions
