### PR TITLE
Patched Fix Electron vulnerable to out-of-package code execution when…

### DIFF
--- a/pyinstaller/electron/yarn.lock
+++ b/pyinstaller/electron/yarn.lock
@@ -704,9 +704,9 @@ electron-publish@23.6.0:
     lazy-val "^1.0.5"
     mime "^2.5.2"
 
-electron@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.npmjs.org/electron/-/electron-22.1.0.tgz"
+electron@^22.3.21:
+  version "22.3.21"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-22.3.21.tgz#a817446cc1e62e9650522fa7eae389f9fc5b5e19"
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^16.11.26"


### PR DESCRIPTION
… launched with arbitrary cwd

This project used electron is a framework which lets you write cross-platform desktop applications using JavaScript, HTML and CSS. Affected of this project are vulnerable to Arbitrary Code Execution allowing out-of-package code execution when apps are launched as command-line executables.

```diff
diff --git a/lib/internal/modules/run_main.js b/lib/internal/modules/run_main.js
- index 5a50d5d6afab6e6648f72a1c0efa1df4cd80bcd9..0be45309028b00a6957ee473322a9452a7fa7d67 100644
--- a/lib/internal/modules/run_main.js
+ +++ b/lib/internal/modules/run_main.js
@@ -13,6 +13,12 @@ const {
```
CWE-94
`CVSS:3.1/AV:L/AC:L/PR:L/UI:R/S:U/C:L/I:H/A:L`
CVE-2023-39956