### PR TITLE
Optional ENFORCE_HWI_INITIALISATION_AT_STARTUP

### DIFF
--- a/src/cryptoadvance/specter/config.py
+++ b/src/cryptoadvance/specter/config.py
@@ -82,6 +82,9 @@ class BaseConfig(object):
     CERT = os.getenv("CERT", None)
     KEY = os.getenv("KEY", None)
 
+    # It might be necessary to enforce the HWI initialisation
+    ENFORCE_HWI_INITIALISATION_AT_STARTUP = False
+
     # This will be used to search for a bitcoin.conf in order to enable the
     # auth method "RPC password as pin"
     RASPIBLITZ_SPECTER_RPC_LOGIN_BITCOIN_CONF_LOCATION = os.getenv(

--- a/src/cryptoadvance/specter/hwi_rpc.py
+++ b/src/cryptoadvance/specter/hwi_rpc.py
@@ -66,7 +66,7 @@ class HWIBridge(JSONRPC):
     All methods of this class are callable over JSON-RPC, except _underscored.
     """
 
-    def __init__(self):
+    def __init__(self, enforce_hwi_initialisation=False):
         self.exposed_rpc = {
             "enumerate": self.enumerate,
             "detect_device": self.detect_device,
@@ -81,6 +81,13 @@ class HWIBridge(JSONRPC):
             "extract_master_blinding_key": self.extract_master_blinding_key,
             "bitbox02_pairing": self.bitbox02_pairing,
         }
+        if enforce_hwi_initialisation:
+            # Running enumerate after beginning an interaction with a specific device
+            # crashes python or make HWI misbehave. For now we just get all connected
+            # devices once per session and save them.
+            logger.info("Initializing HWI...")  # to explain user why it takes so long
+            self.enumerate()
+            logger.info("Finished initializing HWI!")
         self.devices = []
 
     @locked(hwilock)

--- a/src/cryptoadvance/specter/hwi_rpc.py
+++ b/src/cryptoadvance/specter/hwi_rpc.py
@@ -81,11 +81,7 @@ class HWIBridge(JSONRPC):
             "extract_master_blinding_key": self.extract_master_blinding_key,
             "bitbox02_pairing": self.bitbox02_pairing,
         }
-        # Running enumerate after beginning an interaction with a specific device
-        # crashes python or make HWI misbehave. For now we just get all connected
-        # devices once per session and save them.
-        logger.info("Initializing HWI...")  # to explain user why it takes so long
-        self.enumerate()
+        self.devices = []
 
     @locked(hwilock)
     def enumerate(self, passphrase="", chain=""):

--- a/src/cryptoadvance/specter/server.py
+++ b/src/cryptoadvance/specter/server.py
@@ -177,7 +177,7 @@ def init_app(app: SpecterFlask, hwibridge=False, specter=None):
     specter.initialize()
 
     # HWI
-    specter.hwi = HWIBridge()
+    specter.hwi = HWIBridge(app.config["ENFORCE_HWI_INITIALISATION_AT_STARTUP"])
 
     login_manager = LoginManager()
     login_manager.session_protection = app.config.get("SESSION_PROTECTION", "strong")


### PR DESCRIPTION
This will make the HWI initialisation not default at startup but it's enforcable via setting `ENFORCE_HWI_INITIALISATION_AT_STARTUP` to TRUE.