### PR TITLE
[tests] Fix node2 RPC port & add missing elm mark

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -195,7 +195,7 @@ def bitcoin_regtest(request) -> BitcoindPlainController:
 def bitcoin_regtest2(request) -> BitcoindPlainController:
     """If a test needs two nodes ..."""
     bitcoind_regtest = instantiate_bitcoind_controller(
-        request, rpcport=18544, extra_args=None
+        request, rpcport=18545, extra_args=None
     )
     try:
         assert bitcoind_regtest.get_rpc().test_connection()

--- a/tests/test_managers_wallet.py
+++ b/tests/test_managers_wallet.py
@@ -162,7 +162,7 @@ def test_WalletManager_2_nodes(
     assert list(wm.rpcs.keys()) == [
         "regtest",
     ]  # wm.rpcs looks like this: {'regtest': <BitcoinRpc http://localhost:18543>, 'regtest2': <BitcoinRpc http://localhost:18544>}
-    assert wm.rpc.port == 18544
+    assert wm.rpc.port == 18545
     assert wm.wallets_names == ["wallet_for_test_with_two_nodes"]
     assert wm.chain == "regtest"
     assert wm.working_folder.endswith("test")

--- a/tests/test_node_controller.py
+++ b/tests/test_node_controller.py
@@ -57,6 +57,7 @@ def test_fetch_wallet_addresses_for_mining(caplog, wallets_filled_data_folder):
     assert "bcrt1q4h86vfanswhsle63hw2muv9h5a45cg2878uez5" in addresses
 
 
+@pytest.mark.elm
 @pytest.mark.slow
 def test_node_running_elements(caplog, request):
     # TODO: Refactor this to use conftest.instantiate_bitcoind_controller


### PR DESCRIPTION
- Set second test bitcoin node RPC port to 18545 (i/o 18544) to avoid P2P port conflict with first node
- Add missing "elm" mark to test_node_controller.py::test_node_running_elements