### PR TITLE
Fix wallet load error on incomplete gettransaction (Failed to load utxos, IndexError: list index out of range)

### DIFF
--- a/src/cryptoadvance/specter/wallet/wallet.py
+++ b/src/cryptoadvance/specter/wallet/wallet.py
@@ -732,17 +732,10 @@ class Wallet(AbstractWallet):
                         # It may be related to https://github.com/bitcoin/bitcoin/issues/28555
                         # In this case we decode the raw transaction to get the data we want.
                         raw_transaction_hex = tx_from_core["hex"]
-                        raw_transaction = self.rpc.decoderawtransaction(
-                            raw_transaction_hex
-                        )
-                        searched_raw_vout = [
-                            _output
-                            for _output in raw_transaction["vout"]
-                            if _output["n"] == utxo_vout
-                        ][0]
-                        tx_copy["amount"] = searched_raw_vout["value"]
-                        script_pubkey = searched_raw_vout["scriptPubKey"]
-                        tx_copy["address"] = script_pubkey["address"]
+                        parsed_transaction = self.TxCls.from_string(raw_transaction_hex)
+                        out = parsed_transaction.vout[utxo_vout]
+                        tx_copy["amount"] = round(out.value * 1e-8, 8)
+                        tx_copy["address"] = out.script_pubkey.address(self.network)
 
                 # Append the copy to the _full_utxo list
                 _full_utxo.append(tx_copy)

--- a/src/cryptoadvance/specter/wallet/wallet.py
+++ b/src/cryptoadvance/specter/wallet/wallet.py
@@ -732,14 +732,17 @@ class Wallet(AbstractWallet):
                         # It may be related to https://github.com/bitcoin/bitcoin/issues/28555
                         # In this case we decode the raw transaction to get the data we want.
                         raw_transaction_hex = tx_from_core["hex"]
-                        raw_transaction = self.rpc.decoderawtransaction(raw_transaction_hex)
+                        raw_transaction = self.rpc.decoderawtransaction(
+                            raw_transaction_hex
+                        )
                         searched_raw_vout = [
                             _output
                             for _output in raw_transaction["vout"]
                             if _output["n"] == utxo_vout
                         ][0]
                         tx_copy["amount"] = searched_raw_vout["value"]
-                        tx_copy["address"] = searched_raw_vout["scriptPubKey"]["address"]
+                        script_pubkey = searched_raw_vout["scriptPubKey"]
+                        tx_copy["address"] = script_pubkey["address"]
 
                 # Append the copy to the _full_utxo list
                 _full_utxo.append(tx_copy)


### PR DESCRIPTION
The error happens when the wallet has some locked outputs in `listlockunspent` and the corresponding `gettransaction` doesn't contain the details of this particular output.

It may be related to https://github.com/bitcoin/bitcoin/issues/28555. It is at least the same symptom.

The locked outputs were locked by creating a transaction in Specter. This has happened to me multiple times.

The UI says it failed to load the wallet with the following error: Failed to load utxos, IndexError: list index out of range

The raw transaction does contain the missing output so we use that instead.

<details><summary>
Here's an example that generates the error:
</summary>

```
listlockunspent:
[
  {
    "txid": "<some txid>",
    "vout": 0
  }
]

gettransaction <some txid>:
{
  "amount": <redacted>,
  "fee": <redacted>,
  "confirmations": <redacted>,
  "blockhash": "<redacted>",
  "blockheight": <redacted>,
  "blockindex": <redacted>,
  "blocktime": <redacted>,
  "txid": "<some tx id>",
  "wtxid": "<redacted>",
  "walletconflicts": [
  ],
  "time": <redacted>,
  "timereceived": <redacted>,
  "bip125-replaceable": "no",
  "details": [
    {
      "address": "<redacted>",
      "category": "send",
      "amount": <redacted>,
      "label": "<redacted>",
      "vout": 1,
      "fee": <redacted>,
      "abandoned": false
    }
  ],
  "hex": "<some raw tx hex>",
  "lastprocessedblock": {
    "hash": "<redacted>",
    "height": <redacted>
  }
}

decoderawtransaction <some raw tx hex>:
{
  "txid": "<some txid>",
  "hash": "<redacted>",
  "version": 2,
  "size": <redacted>,
  "vsize": <redacted>,
  "weight": <redacted>,
  "locktime": <redacted>,
  "vin": [
    {
      "txid": "<some other txid>",
      "vout": 0,
      "scriptSig": {
        "asm": "",
        "hex": ""
      },
      "txinwitness": [
        "<redacted>",
        "<redacted>"
      ],
      "sequence": <redacted>
    }
  ],
  "vout": [
    {
      "value": <redacted>,
      "n": 0,
      "scriptPubKey": {
        "asm": "<redacted>",
        "desc": "<redacted>",
        "hex": "<redacted>",
        "address": "<redacted>",
        "type": "<redacted>"
      }
    },
    {
      "value": <redacted>,
      "n": 1,
      "scriptPubKey": {
        "asm": "<redacted>",
        "desc": "<redacted>",
        "hex": "<redacted>",
        "address": "<redacted>",
        "type": "<redacted>"
      }
    }
  ]
}
```

</details>

Note: I'm connecting to a Bitcoin Core version v27.1.0.