### PR TITLE
Fix url_for crash in rpcpasswordaspin login when Bitcoin Core is unreachable

### DIFF
--- a/src/cryptoadvance/specter/server_endpoints/auth.py
+++ b/src/cryptoadvance/specter/server_endpoints/auth.py
@@ -92,7 +92,7 @@ def login_method_rpcpasswordaspin():
             flash(
                 "No RPC connection to Bitcoin Core found. Cannot Log you in.", "error"
             )
-            return redirect(url_for("login"))
+            return redirect(url_for("auth_endpoint.login"))
         conf = confs[0]
         rpc = BitcoinRPC(**conf)
 
@@ -101,7 +101,7 @@ def login_method_rpcpasswordaspin():
         flash(
             "It seems that there is no working RPC connection to Bitcoin Core. Cannot Log you in."
         )
-        return redirect(url_for("login"))
+        return redirect(url_for("auth_endpoint.login"))
     orig_password = rpc.password
     rpc.password = request.form["password"]
     if rpc.password == request.form["password"] and rpc.test_connection():


### PR DESCRIPTION
## Bug

When Bitcoin Core RPC is unreachable (e.g. after a RaspiBlitz update), the `rpcpasswordaspin` login method crashes with:

```
werkzeug.routing.exceptions.BuildError: Could not build url for endpoint 'login'. Did you mean 'liveness' instead?
```

Instead of showing the user a flash message like *"No RPC connection to Bitcoin Core found"*, they get an unhandled server error page.

## Root Cause

`login_method_rpcpasswordaspin()` uses `url_for("login")` (bare endpoint name) on two error paths (lines 95 and 104), but the endpoint is registered under the `auth_endpoint` blueprint and must be referenced as `url_for("auth_endpoint.login")`.

Every other `url_for` call in the codebase already uses the fully-qualified name:
- `auth.py:194` — `url_for("auth_endpoint.login")` ✅
- `auth.py:217` — `url_for("auth_endpoint.login")` ✅
- `settings.py:472` — `url_for("auth_endpoint.login")` ✅
- `login.jinja` — `url_for('auth_endpoint.login')` ✅
- `base.jinja` — `url_for('auth_endpoint.logout')` ✅

Only these two error paths in `login_method_rpcpasswordaspin` used the bare name.

## Fix

Two-character change: `url_for("login")` → `url_for("auth_endpoint.login")` on both error paths.

## Impact

This specifically affects RaspiBlitz setups (`rpcpasswordaspin` auth method was created for RaspiBlitz, as noted in the code comments). When Bitcoin Core is unreachable during login, users now get the intended flash error message instead of a crash.

Fixes raspiblitz/raspiblitz#5224