### PR TITLE
Add auto-generated release notes and lncm Docker trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -587,6 +587,21 @@ jobs:
           # Strip leading whitespace from heredoc
           sed -i 's/^          //' release-body.md
 
+      - name: Generate release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+
+          # Use GitHub API to auto-generate "What's Changed" from merged PRs
+          NOTES=$(gh api repos/${{ github.repository }}/releases/generate-notes \
+            -f tag_name="${VERSION}" \
+            --jq '.body') || true
+
+          if [ -n "$NOTES" ]; then
+            echo "$NOTES" >> release-body.md
+          fi
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -595,3 +610,28 @@ jobs:
           draft: true  # Draft first, review before publishing
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  trigger-docker:
+    name: Trigger lncm Docker build
+    needs: create-release
+    runs-on: ubuntu-latest
+    if: ${{ !cancelled() && needs.create-release.result == 'success' }}
+    steps:
+      - name: Trigger lncm/docker-specter-desktop
+        env:
+          AARON_TOKEN: ${{ secrets.AARON_TRIGGER }}
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+
+          if [ -z "$AARON_TOKEN" ]; then
+            echo "AARON_TRIGGER secret not set, skipping Docker trigger"
+            exit 0
+          fi
+
+          curl -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${AARON_TOKEN}" \
+            https://api.github.com/repos/lncm/docker-specter-desktop/actions/workflows/dispatch.yml/dispatches \
+            -d "{\"ref\":\"master\", \"inputs\": {\"tag\": \"${VERSION}\"}}"
+
+          echo "Triggered lncm/docker-specter-desktop build for ${VERSION}"


### PR DESCRIPTION
Two additions to the release workflow:

### 1. Auto-generated release notes
Uses GitHub's `generate-notes` API to populate the `# Release notes` section with a "What's Changed" list of merged PRs since the previous tag. Falls back gracefully if the API call fails.

### 2. lncm Docker trigger
Adds a `trigger-docker` job that dispatches the [lncm/docker-specter-desktop](https://github.com/lncm/docker-specter-desktop) workflow after a successful release — same as the old GitLab CI `release_docker` job.

Uses the `AARON_TRIGGER` secret (already configured). Skips gracefully if the secret is not set.

Addresses the two remaining gaps from the GitLab CI → GitHub Actions migration.