### PR TITLE
fix: add _arm64 suffix to macOS specterd binary name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,7 +173,7 @@ jobs:
           #   arch_label: osx_x64
           - runner: macos-14      # Apple Silicon (free tier)
             arch: arm64
-            arch_label: osx
+            arch_label: osx_arm64
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Problem

The Electron app expects `specterd-VERSION-osx_arm64.zip` but the release workflow produces `specterd-VERSION-osx.zip`, causing download failures:

```
Specterd version could not be validated. Trying again to download the Specter binary ...
Downloading from https://github.com/cryptoadvance/specter-desktop/releases/download/v2.1.2-pre4/specterd-v2.1.2-pre4-osx_arm64.zip
Error while trying to download specterd: null
```

The actual release artifact is named `specterd-v2.1.2-pre4-osx.zip` (without `_arm64`).

## Fix

Change `arch_label: osx` → `arch_label: osx_arm64` in the macOS build matrix.

## Impact

Future releases will have correctly named macOS ARM64 specterd binaries that the Electron app can find.

---

*Reported by a user running v2.1.2-pre4 on macOS.*