### PR TITLE
Fix typos in comments and strings

### DIFF
--- a/src/cryptoadvance/specter/cli/cli_noded.py
+++ b/src/cryptoadvance/specter/cli/cli_noded.py
@@ -397,7 +397,7 @@ def endless_loop(
             break
         except Exception as e:
             logger.debug(
-                f"Caught {e.__module__}, Couldn't mine, assume SIGTERM occured => exiting!"
+                f"Caught {e.__module__}, Couldn't mine, assume SIGTERM occurred => exiting!"
             )
             break
     if prevent_mining_file.is_file():

--- a/src/cryptoadvance/specter/persistence.py
+++ b/src/cryptoadvance/specter/persistence.py
@@ -143,7 +143,7 @@ def _write_json_file(content, path, lock=None):
             with open(path, "w") as f:
                 json.dump(content, f, indent=4)
 
-            # check if write was sucessful
+            # check if write was successful
             with open(path, "r") as f:
                 c = json.load(f)
 

--- a/src/cryptoadvance/specter/process_controller/node_controller.py
+++ b/src/cryptoadvance/specter/process_controller/node_controller.py
@@ -49,7 +49,7 @@ class Btcd_conn:
     @property
     def ipaddress(self):
         if self._ipaddress is None:
-            raise Exception("ipadress is none")
+            raise Exception("ip_address is none")
         else:
             return self._ipaddress
 

--- a/src/cryptoadvance/specter/util/fee_estimation.py
+++ b/src/cryptoadvance/specter/util/fee_estimation.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 class FeeEstimationResult:
-    """A tiny object to pass the Fee Estimation Results around including a list of errors which might have occured"""
+    """A tiny object to pass the Fee Estimation Results around including a list of errors which might have occurred"""
 
     def __init__(self, result):
         self.result = result

--- a/src/cryptoadvance/specter/wallet/txlist.py
+++ b/src/cryptoadvance/specter/wallet/txlist.py
@@ -568,7 +568,7 @@ class TxList(dict, AbstractTxListContext):
         full=True will add a "hex" key
         decode=True will decode transaction similar to Core's decoderawtransaction
         """
-        # if we don't know blockheigth or transaction
+        # if we don't know blockheight or transaction
         # we invalidate which results in asking core
         if txid in self and self[txid]["blockheight"] == None:
             self.invalidate(txid)

--- a/src/cryptoadvance/specterext/notifications/websockets_server_client.py
+++ b/src/cryptoadvance/specterext/notifications/websockets_server_client.py
@@ -16,8 +16,8 @@ class WebsocketServer:
     """
     A forever lived websockets server in a different thread.
     The server has 2 main functions:
-    1. Recieve messages from webbrowser websocket connections and call notification_manager.create_and_show
-    2. Recieve messages (notifications) from python websocket connection (broadcaster) and send them to the webbrowser websocket connections
+    1. Receive messages from webbrowser websocket connections and call notification_manager.create_and_show
+    2. Receive messages (notifications) from python websocket connection (broadcaster) and send them to the webbrowser websocket connections
     Each message must contain a user_token, which is checked against user_manager.user.websocket_token to make sure this is a legitimate user.
     Otherwise the user_token will not be found in user_manager.user.websocket_token and rejected.
     Before the python websocket connection is established, the set_as_broadcaster method should be called to inform self that this user_token will be a broadcaster
@@ -269,12 +269,12 @@ class WebsocketServer:
         if user_token in self.get_broadcaster_tokens():
             if self.verbose_debug:
                 logger.debug(
-                    f"message from user with broadcaster_token recieved. Sending to websockets"
+                    f"message from user with broadcaster_token received. Sending to websockets"
                 )
             self._send_to_websockets(message_dictionary, user_token)
         elif user:
             if self.verbose_debug:
-                logger.debug(f"message from user recieved. Creating Notification")
+                logger.debug(f"message from user received. Creating Notification")
             self._create_notification(message_dictionary, user)
         else:
             logger.warning(


### PR DESCRIPTION
Small cleanup — fixes spelling errors in comments, docstrings, and log messages across 6 files:

| File | Typo | Fix |
|------|------|-----|
| `websockets_server_client.py` | recieve/recieved | receive/received |
| `txlist.py` | blockheigth | blockheight |
| `fee_estimation.py` | occured | occurred |
| `cli_noded.py` | occured | occurred |
| `node_controller.py` | ipadress | ip_address |
| `persistence.py` | sucessful | successful |

No functional changes — comments and strings only.