### PR TITLE
Fix: wrap livereload.js in DEBUG conditional

### DIFF
--- a/src/cryptoadvance/specter/templates/base.jinja
+++ b/src/cryptoadvance/specter/templates/base.jinja
@@ -13,7 +13,9 @@
 		<link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='typography.css') }}?{{rand}}">
 		<link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='output.css') }}?{{rand}}">
 
+		{% if config.DEBUG %}
 		<script>document.write('<script src="http://' + (location.host || 'localhost').split(':')[0] + ':35729/livereload.js?snipver=1"></' + 'script>')</script>
+		{% endif %}
 		<script type="text/javascript" src="{{ url_for('static', filename='helpers.js') }}"></script>
 
 		{% include "includes/helpers.jinja" %}


### PR DESCRIPTION
The `livereload.js` script tag in `base.jinja` loads unconditionally — including in production. This causes:

- **Mixed content warnings** (HTTP script loaded on HTTPS pages)
- **Failed network requests** to `localhost:35729` on every page load
- **Console errors** for all users

### Fix
Wrap the script tag in `{% if config.DEBUG %}` so it only loads during development.

### Before
```html
<script>document.write('<script src="http://...livereload.js..."></' + 'script>')</script>
```

### After
```html
{% if config.DEBUG %}
<script>document.write('<script src="http://...livereload.js..."></' + 'script>')</script>
{% endif %}
```

Fixes #2460