### PR TITLE
Remove duplicate imports in server.py

### DIFF
--- a/src/cryptoadvance/specter/server.py
+++ b/src/cryptoadvance/specter/server.py
@@ -21,11 +21,6 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 from werkzeug.wrappers import Response
 
 from cryptoadvance.specter.hwi_rpc import HWIBridge
-from cryptoadvance.specter.liquid.rpc import LiquidRPC
-from cryptoadvance.specter.managers.service_manager import ExtensionManager
-from cryptoadvance.specter.rpc import BitcoinRPC
-from cryptoadvance.specter.services import callbacks
-from cryptoadvance.specter.util.reflection import get_template_static_folder
 
 from .htmlsafebabel import HTMLSafeBabel
 from .hwi_server import hwi_server


### PR DESCRIPTION
In `src/cryptoadvance/specter/server.py`, there are 5 imports that appear twice — once near the top (lines 8-12) and again a few lines below (lines 24-28):

- `from cryptoadvance.specter.liquid.rpc import LiquidRPC`
- `from cryptoadvance.specter.managers.service_manager import ExtensionManager`
- `from cryptoadvance.specter.rpc import BitcoinRPC`
- `from cryptoadvance.specter.services import callbacks`
- `from cryptoadvance.specter.util.reflection import get_template_static_folder`

Python just silently ignores the second import so nothing breaks, but it adds clutter and looks like something went wrong during a merge or copy-paste. This PR removes the duplicate block (lines 24-28) while keeping the unique `HWIBridge` import that was between them.