### PR TITLE
Add startup warning when SECRET_KEY is a known default

### DIFF
--- a/src/cryptoadvance/specter/server.py
+++ b/src/cryptoadvance/specter/server.py
@@ -108,6 +108,24 @@ def create_app(config=None):
     logger.info(f"Configuration: {config}")
     app.config.from_object(config)
     logger.info(f"SPECTER_DATA_FOLDER: {app.config['SPECTER_DATA_FOLDER']}")
+
+    # Warn if someone is running with a default SECRET_KEY on a non-localhost address.
+    # This can happen if SPECTER_CONFIG isn't set and someone accidentally ships with DevelopmentConfig.
+    _insecure_defaults = ("development key", "test key")
+    if app.config.get("SECRET_KEY") in _insecure_defaults:
+        host = app.config.get("HOST", "127.0.0.1")
+        if host not in ("127.0.0.1", "localhost", "0.0.0.0"):
+            logger.warning(
+                "WARNING: SECRET_KEY is set to a known default value and HOST is '%s'. "
+                "This is insecure for anything other than local development. "
+                "Please use ProductionConfig or set a proper SECRET_KEY.",
+                host,
+            )
+        else:
+            logger.info(
+                "Running with a default SECRET_KEY. Fine for local dev, not for production."
+            )
+
     # Might be convenient to know later where it came from (see Service configuration)
     app.config["SPECTER_CONFIGURATION_CLASS_FULLNAME"] = config_name
     if not app.config.get("ENABLE_WERZEUG_REQUEST_LOGGING"):


### PR DESCRIPTION
Fixes #2551

Right now if someone runs Specter with DevelopmentConfig or TestConfig on a non-localhost address, there's no indication that the SECRET_KEY is insecure. Flask uses this key for signing session cookies and CSRF tokens, so a predictable key means an attacker could forge sessions.

### What this does

Added a simple check in `create_app()` that runs after the config is loaded:

- If `SECRET_KEY` is one of the known defaults (`"development key"` or `"test key"`) **and** the `HOST` is not localhost, it logs a warning telling the user to switch to ProductionConfig or set a proper key.
- If it's a known default but running on localhost, it just logs an info line saying it's fine for local dev. No big deal.

No behavior changes, no breaking anything — just a log message to help people catch misconfigurations early.