### PR TITLE
docs(ci): record cutover commit + verify branch protection

### DIFF
--- a/docs/ci-migration-evidence.md
+++ b/docs/ci-migration-evidence.md
@@ -70,8 +70,10 @@ Strict frontend-touching coverage (changes under `src/cryptoadvance/specter/stat
 | Field                | Value                                                      |
 |----------------------|------------------------------------------------------------|
 | Evidence captured at | 2026-04-19                                                 |
-| Latest master commit | `62ea0265` (2026-04-17 20:33 UTC)                          |
+| Cutover merged at    | `fdd1cd8f` (PR #2610, 2026-04-19 16:32 UTC)                |
+| Latest pre-cutover master commit | `62ea0265` (2026-04-17 20:33 UTC)              |
 | `test.yml` added at  | `a24df2eb` (2026-04-17 18:50 UTC)                          |
+| Required checks post-cutover | `test`, `cypress`, `extension-smoketest`, `black` — all pinned to `app_id:15368` (github-actions) |
 | Author               | @k9ert                                                     |
 
 ## Rollback contract


### PR DESCRIPTION
## Summary

Throwaway verification PR per the branch-protection runbook in #2610 (step 5). Updates `docs/ci-migration-evidence.md` to record:
- Cutover merge commit `fdd1cd8f` (2026-04-19 16:32 UTC)
- Final required-check state: `test`, `cypress`, `extension-smoketest`, `black` — all pinned to `app_id:15368` (github-actions)

## What to verify

- [ ] Four required checks appear on this PR: `test`, `cypress`, `extension-smoketest`, `black`
- [ ] No Cirrus CI contexts appear
- [ ] Merge is blocked until all four pass
- [ ] After all four green, merge is allowed

## Test plan

- [ ] Confirm the 4 contexts are all present and labeled "Required"
- [ ] Confirm Cirrus is fully disconnected (no Cirrus webhook fires, no stale contexts)
- [ ] Merge and announce cutover complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)