### PR TITLE
ci: cache electron binaries + retry downloads on 502

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -280,13 +280,32 @@ jobs:
           node ./set-version $VERSION ../dist/specterd
           cd ../..
 
+      - name: Cache Electron binaries
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/electron
+            ~/.cache/electron-builder
+          key: electron-linux-${{ hashFiles('pyinstaller/electron/package-lock.json') }}
+          restore-keys: electron-linux-
+
       - name: Build Electron app
         run: |
           cd pyinstaller/electron
           cp -R ../../src/cryptoadvance/specter/static/fonts \
                 ../../src/cryptoadvance/specter/static/output.css \
                 ../../src/cryptoadvance/specter/static/typography.css .
-          npm run dist -- --linux
+          # Retry: electron-builder downloads from github.com occasionally 502
+          # (see release run 24636274855).
+          attempt=0
+          until npm run dist -- --linux; do
+            attempt=$((attempt + 1))
+            if [ $attempt -ge 3 ]; then
+              echo "electron-builder failed after $attempt attempts"; exit 1
+            fi
+            echo "Attempt $attempt failed; retrying in $((attempt * 15))s..."
+            sleep $((attempt * 15))
+          done
           cd ../..
 
       - name: Package release
@@ -338,6 +357,15 @@ jobs:
           node ./set-version.js $VERSION ../dist/specterd.exe
           cd ../..
 
+      - name: Cache Electron binaries
+        uses: actions/cache@v4
+        with:
+          path: |
+            /tmp/electron-home/.cache/electron
+            /tmp/electron-home/.cache/electron-builder
+          key: electron-win-${{ hashFiles('pyinstaller/electron/package-lock.json') }}
+          restore-keys: electron-win-
+
       - name: Build Electron app
         env:
           HOME: /tmp/electron-home
@@ -347,7 +375,17 @@ jobs:
           cp -R ../../src/cryptoadvance/specter/static/fonts \
                 ../../src/cryptoadvance/specter/static/output.css \
                 ../../src/cryptoadvance/specter/static/typography.css .
-          npm run dist -- --win
+          # Retry: electron-builder downloads from github.com occasionally 502
+          # (see release run 24636274855).
+          attempt=0
+          until npm run dist -- --win; do
+            attempt=$((attempt + 1))
+            if [ $attempt -ge 3 ]; then
+              echo "electron-builder failed after $attempt attempts"; exit 1
+            fi
+            echo "Attempt $attempt failed; retrying in $((attempt * 15))s..."
+            sleep $((attempt * 15))
+          done
           cd ../..
 
       - name: Package release
@@ -460,13 +498,32 @@ jobs:
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
 
+      - name: Cache Electron binaries
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/electron
+            ~/Library/Caches/electron-builder
+          key: electron-mac-${{ hashFiles('pyinstaller/electron/package-lock.json') }}
+          restore-keys: electron-mac-
+
       - name: Build Electron app
         run: |
           cd pyinstaller/electron
           cp -R ../../src/cryptoadvance/specter/static/fonts \
                 ../../src/cryptoadvance/specter/static/output.css \
                 ../../src/cryptoadvance/specter/static/typography.css .
-          npm run dist -- --mac
+          # Retry: electron-builder downloads from github.com occasionally 502
+          # (see release run 24636274855).
+          attempt=0
+          until npm run dist -- --mac; do
+            attempt=$((attempt + 1))
+            if [ $attempt -ge 3 ]; then
+              echo "electron-builder failed after $attempt attempts"; exit 1
+            fi
+            echo "Attempt $attempt failed; retrying in $((attempt * 15))s..."
+            sleep $((attempt * 15))
+          done
           cd ../..
         env:
           # electron-builder reads these for notarization

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,6 +267,15 @@ jobs:
           name: specterd-linux
           path: ./release-artifacts
 
+      - name: Cache Electron binaries
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/electron
+            ~/.cache/electron-builder
+          key: electron-linux-${{ hashFiles('pyinstaller/electron/package-lock.json') }}
+          restore-keys: electron-linux-
+
       - name: Prepare Electron build
         run: |
           VERSION=${GITHUB_REF#refs/tags/}
@@ -279,15 +288,6 @@ jobs:
           npm ci
           node ./set-version $VERSION ../dist/specterd
           cd ../..
-
-      - name: Cache Electron binaries
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/electron
-            ~/.cache/electron-builder
-          key: electron-linux-${{ hashFiles('pyinstaller/electron/package-lock.json') }}
-          restore-keys: electron-linux-
 
       - name: Build Electron app
         run: |
@@ -330,6 +330,10 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: electronuserland/builder:wine
+    env:
+      # Shared HOME so `npm ci` (electron postinstall) and electron-builder
+      # write to the same ~/.cache/electron path — kept cacheable across runs.
+      HOME: /tmp/electron-home
     steps:
       - uses: actions/checkout@v4
         with:
@@ -338,12 +342,22 @@ jobs:
       - name: Install system dependencies
         run: |
           apt-get update && apt-get install -y unzip
+          mkdir -p $HOME
 
       - name: Download specterd Windows artifact
         uses: actions/download-artifact@v4
         with:
           name: specterd-windows
           path: ./release-artifacts
+
+      - name: Cache Electron binaries
+        uses: actions/cache@v4
+        with:
+          path: |
+            /tmp/electron-home/.cache/electron
+            /tmp/electron-home/.cache/electron-builder
+          key: electron-win-${{ hashFiles('pyinstaller/electron/package-lock.json') }}
+          restore-keys: electron-win-
 
       - name: Prepare Electron build
         run: |
@@ -357,20 +371,8 @@ jobs:
           node ./set-version.js $VERSION ../dist/specterd.exe
           cd ../..
 
-      - name: Cache Electron binaries
-        uses: actions/cache@v4
-        with:
-          path: |
-            /tmp/electron-home/.cache/electron
-            /tmp/electron-home/.cache/electron-builder
-          key: electron-win-${{ hashFiles('pyinstaller/electron/package-lock.json') }}
-          restore-keys: electron-win-
-
       - name: Build Electron app
-        env:
-          HOME: /tmp/electron-home
         run: |
-          mkdir -p $HOME
           cd pyinstaller/electron
           cp -R ../../src/cryptoadvance/specter/static/fonts \
                 ../../src/cryptoadvance/specter/static/output.css \
@@ -439,6 +441,15 @@ jobs:
           name: specterd-macos-arm64
           path: ./release-artifacts
 
+      - name: Cache Electron binaries
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/electron
+            ~/Library/Caches/electron-builder
+          key: electron-mac-${{ hashFiles('pyinstaller/electron/package-lock.json') }}
+          restore-keys: electron-mac-
+
       - name: Import code signing certificate
         if: env.HAVE_APPLE_CERT == 'true'
         env:
@@ -497,15 +508,6 @@ jobs:
           cd ../..
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
-
-      - name: Cache Electron binaries
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/Library/Caches/electron
-            ~/Library/Caches/electron-builder
-          key: electron-mac-${{ hashFiles('pyinstaller/electron/package-lock.json') }}
-          restore-keys: electron-mac-
 
       - name: Build Electron app
         run: |


### PR DESCRIPTION
## Summary

- Cache `~/.cache/electron` (and electron-builder cache) across release runs, keyed on `pyinstaller/electron/package-lock.json` hash, per target (linux/win/mac). After the first release, electron runtime is served from GitHub Actions cache, not `github.com/electron/electron/releases/download`.
- Wrap each `npm run dist` in a 3-attempt retry loop (15s / 30s backoff) to absorb transient `github.com` 502s on cache-miss runs (first release after an electron bump).

## Context

Release run [24636274855](https://github.com/cryptoadvance/specter-desktop/actions/runs/24636274855/job/72032429160) failed on the Windows Electron build with:

```
⨯ cannot resolve https://github.com/electron/electron/releases/download/v39.8.5/electron-v39.8.5-win32-x64.zip: status code 502
```

Root cause is a transient CDN flake. The `ERR_ELECTRON_BUILDER_CANNOT_EXECUTE` that follows is electron-builder's generic wrapper for "child process exited non-zero" — app-builder did execute (Go stack trace proves it), it just exited 1 after the 502. Linux/macOS Electron builds succeeded in the same run on the same node_modules, ruling out a noexec/chmod theory.

## Test plan

- [ ] Push a test tag (e.g. `v2.1.8-pre4`) and confirm first run populates cache
- [ ] Re-run the release workflow; confirm `Cache Electron binaries` reports a hit and no electron zip is downloaded
- [ ] Intentionally bust the cache key (bump electron) and confirm retry wrapper absorbs a simulated 502 (or just confirm cache-miss path still completes the build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)