### PR TITLE
ci: harden elements GPG key import in install_noded.sh

### DIFF
--- a/tests/install_noded.sh
+++ b/tests/install_noded.sh
@@ -317,14 +317,18 @@ function gpg_verify_sums {
     fi
     local imported=0
     for fpr in "${keys[@]}"; do
-        # Try keys.openpgp.org first, then keyserver.ubuntu.com.
-        if curl -fsSL "https://keys.openpgp.org/vks/v1/by-fingerprint/${fpr}" 2>/dev/null \
-            | gpg --import 2>/dev/null; then
-            imported=$((imported + 1))
-            continue
-        fi
-        if curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x${fpr}&options=mr" 2>/dev/null \
-            | gpg --import 2>/dev/null; then
+        # Import from both sources. Some keyservers may return partial key
+        # material for old signatures (e.g. missing signing subkeys).
+        # Importing from both increases robustness while keeping the same
+        # pinned trust anchors for verification.
+        curl -fsSL "https://keys.openpgp.org/vks/v1/by-fingerprint/${fpr}" 2>/dev/null \
+            | gpg --import 2>/dev/null || true
+        curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x${fpr}&options=mr" 2>/dev/null \
+            | gpg --import 2>/dev/null || true
+
+        # Count this key as imported if it exists in the keyring after the
+        # multi-source import attempts.
+        if gpg --list-keys --with-colons "$fpr" 2>/dev/null | grep -q '^pub:'; then
             imported=$((imported + 1))
         fi
     done


### PR DESCRIPTION
## Summary
This PR fixes a deterministic CI bootstrap failure in the shared `Install elementsd` step (`tests/install_noded.sh --elements binary`).

In failing runs, GPG verification of `elements/SHA256SUMS.asc` failed with `NO_PUBKEY 2F2A88D7F8D68E87`, which caused all three test jobs (`test`, `extension-smoketest`, `cypress`) to fail before executing project tests.

## Root cause
`gpg_verify_sums()` imported from `keys.openpgp.org` first and `continue`d on success, skipping ubuntu keyserver fallback. In some runs this led to incomplete key material for older signatures/subkeys, so no trusted `VALIDSIG` was found.

## Change
- Import release keys from **both** sources (`keys.openpgp.org` and `keyserver.ubuntu.com`) instead of short-circuiting after the first import.
- Count a key as imported only if the key exists in the local keyring after attempts.

Security posture is unchanged: verification still requires `VALIDSIG` for the pinned trusted primary fingerprint and still enforces committed SHA256 trust anchors.

## Validation
- `bash -n tests/install_noded.sh`
- Local run: `./tests/install_noded.sh --debug --elements binary`
  - confirms `GOODSIG 2F2A88...` + `VALIDSIG ... 8CC974...`
  - completes elementsd install successfully

## Expected impact
Once merged, rerunning PR #2620 should no longer fail in `Install elementsd` due to this key-import path.