### PR TITLE
Fix: close open serial ports before connecting to Jade (#2343)

### DIFF
--- a/src/cryptoadvance/specter/devices/hwi/jadepy/jade_serial.py
+++ b/src/cryptoadvance/specter/devices/hwi/jadepy/jade_serial.py
@@ -49,6 +49,15 @@ class JadeSerialImpl:
     def connect(self):
         assert self.ser is None
 
+                # Close any open serial ports to avoid 'resource busy' errors
+        for port_info in list_ports.comports():
+            try:
+                tmp_ser = serial.Serial(port_info.device)
+                if tmp_ser.is_open:
+                    tmp_ser.close()
+            except serial.SerialException:
+                pass
+
         logger.info("Connecting to {} at {}".format(self.device, self.baud))
         self.ser = serial.Serial(
             self.device, self.baud, timeout=self.timeout, write_timeout=self.timeout


### PR DESCRIPTION
This patch resolves bug-bounty issue #2343 by closing any existing serial port connections before establishing a new connection. It iterates through `serial.tools.list_ports`, attempts to open each port and closes it if open. This prevents 'resource busy' errors and crashes when Jade is already being used by another app.