### PR TITLE
Accept descriptor QR exports from Specter DIY

### DIFF
--- a/src/cryptoadvance/specter/templates/device/components/add_keys.js
+++ b/src/cryptoadvance/specter/templates/device/components/add_keys.js
@@ -23,3 +23,15 @@ function setDeviceType(type) {
 		showNotification(`Device type changed to ${name}`);
 	}
 }
+
+function getXpubsFromDescriptor(descriptor) {
+	let data = "";
+	descriptor = descriptor.split("#")[0];
+	let matches = descriptor.matchAll(/\[([^\]]+)\]([A-Za-z0-9]+)/g);
+	for (let match of matches) {
+		if (/^[xyzuvt]pub/.test(match[2])) {
+			data += `[${match[1].replace(/'/g, 'h')}]${match[2]}\n`;
+		}
+	}
+	return data;
+}

--- a/src/cryptoadvance/specter/templates/device/new_device/new_device_keys.jinja
+++ b/src/cryptoadvance/specter/templates/device/new_device/new_device_keys.jinja
@@ -199,6 +199,18 @@
             }
         }
 
+        function getXpubsFromDescriptor(descriptor) {
+            let data = "";
+            descriptor = descriptor.split("#")[0];
+            let matches = descriptor.matchAll(/\[([^\]]+)\]([A-Za-z0-9]+)/g);
+            for (let match of matches) {
+                if (/^[xyzuvt]pub/.test(match[2])) {
+                    data += `[${match[1].replace(/'/g, 'h')}]${match[2]}\n`;
+                }
+            }
+            return data;
+        }
+
         function setupXpubsTable(device='null') {
 			let xpubsTable = document.getElementById('xpubs_table');
             xpubsTable.innerHTML = '';
@@ -471,6 +483,13 @@
                         let path = obj.path.replace(/'/g,'h').replace("m/","");
                         let str = `[${obj.xfp}/${path}]${obj.xpub}`;
                         addXpubs(str);
+                    } else if ("descriptor" in obj) {
+                        let data = getXpubsFromDescriptor(obj.descriptor);
+                        if (data) {
+                            addXpubs(data);
+                        } else {
+                            showError(`{{ _("Unknown key format") }}`);
+                        }
                     }else{
                         showError(`{{ _("Unknown key format") }}`);
                     }

--- a/src/cryptoadvance/specter/templates/device/new_device_manual.jinja
+++ b/src/cryptoadvance/specter/templates/device/new_device_manual.jinja
@@ -376,6 +376,8 @@ m/48h/{{ 0 if specter.info.chain == "main" else 1 }}h/0h/2h</textarea>
 									}
 								});
 								data += s;
+							} else if ("descriptor" in json) {
+								data += getXpubsFromDescriptor(json.descriptor);
 							} else if ("xfp" in json) {
 							// probably ColdCard multisig file
 								let s = "";
@@ -444,6 +446,14 @@ m/48h/{{ 0 if specter.info.chain == "main" else 1 }}h/0h/2h</textarea>
 					let str = `[${obj.xfp}/${path}]${obj.xpub}`;
 					addKeys(str);
 					setDeviceType('cobo');
+				}else if ("descriptor" in obj) {
+					let data = getXpubsFromDescriptor(obj.descriptor);
+					if (data) {
+						addKeys(data);
+						setDeviceType('specter');
+					} else {
+						showError(`{{ _("Unknown key format") }}`);
+					}
 				}else{
 					showError(`{{ _("Unknown key format") }}`);
 				}


### PR DESCRIPTION
Fixes #2625.

## Summary
- Parse JSON QR payloads that contain a Bitcoin output descriptor, like Specter DIY's wallet descriptor export.
- Extract origin-prefixed extended public keys from descriptor bodies and feed them into the existing xpub import paths.
- Keep existing Cobo/Coldcard JSON handling unchanged and support both current and legacy device import templates.

## Verification
- Ran a Node smoke test for descriptor extraction with singlesig, nested singlesig, and sortedmulti descriptor examples.
