### PR TITLE
Warn on ColdCard Mk3 seed-entropy advisory at device setup

### DIFF
--- a/src/cryptoadvance/specter/static/output.css
+++ b/src/cryptoadvance/specter/static/output.css
@@ -1100,6 +1100,10 @@ input[type="number"]::-webkit-outer-spin-button,
   z-index: 50;
 }
 
+.z-20 {
+  z-index: 20;
+}
+
 .z-30 {
   z-index: 30;
 }

--- a/src/cryptoadvance/specter/templates/device/new_device/new_device_keys.jinja
+++ b/src/cryptoadvance/specter/templates/device/new_device/new_device_keys.jinja
@@ -30,10 +30,14 @@
                 </div>
             {% endif %}
             
-            <div id="coldcard-warning" class="warning {% if device_class.device_type != 'coldcard' %}hidden{% endif %}">
-                {{ _("Security notice:") }}
-                {{ _("Coinkite disclosed a firmware flaw that reduced generated-seed entropy on ColdCard Mk2/Mk3 (firmware 4.0.1-4.1.9) and Mk4/Mk5/Q before their fixed firmware. If your seed was generated on-device with fewer than 50 independent dice rolls, update firmware, generate a new seed and move your funds.") }}
-                <a href="https://blog.coinkite.com/coldcard-mk3-seed-generation-warning/" target="_blank" rel="noopener noreferrer">{{ _("Read Coinkite's advisory") }}</a>
+            <div id="coldcard-warning" class="flex p-4 mt-3 mb-4 bg-orange-100 text-orange-700 rounded-lg {% if device_class.device_type != 'coldcard' %}hidden{% endif %}" role="alert">
+                <img class="flex-shrink-0 w-6 h-6 mr-3" src="{{ url_for('static', filename='img/warning_sign.svg') }}" aria-hidden="true">
+                <span class="sr-only">{{ _("Security warning") }}</span>
+                <div>
+                    <span class="font-medium">{{ _("Security warning: ColdCard seed entropy advisory") }}</span><br>
+                    {{ _("Coinkite disclosed a firmware flaw that reduced generated-seed entropy on ColdCard Mk2/Mk3 (firmware 4.0.1-4.1.9) and Mk4/Mk5/Q before their fixed firmware. If your seed was generated on-device with fewer than 50 independent dice rolls, update firmware, generate a new seed and move your funds.") }}
+                    <a class="text-orange-700 underline" href="https://blog.coinkite.com/coldcard-mk3-seed-generation-warning/" target="_blank" rel="noopener noreferrer">{{ _("Read Coinkite's advisory") }}</a>
+                </div>
             </div>
 
             <div id="coldcard-instructions" class="{%if device_class.device_type != 'coldcard' %}hidden{% endif %}">

--- a/src/cryptoadvance/specter/templates/device/new_device/new_device_keys.jinja
+++ b/src/cryptoadvance/specter/templates/device/new_device/new_device_keys.jinja
@@ -31,7 +31,7 @@
             {% endif %}
             
             <div id="coldcard-warning" class="warning {% if device_class.device_type != 'coldcard' %}hidden{% endif %}">
-                ⚠️ {{ _("Security notice:") }}
+                {{ _("Security notice:") }}
                 {{ _("Coinkite disclosed a firmware flaw that reduced generated-seed entropy on ColdCard Mk3 (firmware 4.0.1-5.0.3) and pre-fix Mk4/Q. If your seed was generated on-device without extra dice rolls, update firmware, generate a new seed and move your funds.") }}
                 <a href="https://blog.coinkite.com/coldcard-mk3-seed-generation-warning/" target="_blank" rel="noopener noreferrer">{{ _("Read Coinkite's advisory") }}</a>
             </div>

--- a/src/cryptoadvance/specter/templates/device/new_device/new_device_keys.jinja
+++ b/src/cryptoadvance/specter/templates/device/new_device/new_device_keys.jinja
@@ -32,7 +32,7 @@
             
             <div id="coldcard-warning" class="warning {% if device_class.device_type != 'coldcard' %}hidden{% endif %}">
                 {{ _("Security notice:") }}
-                {{ _("Coinkite disclosed a firmware flaw that reduced generated-seed entropy on ColdCard Mk3 (firmware 4.0.1-5.0.3) and pre-fix Mk4/Q. If your seed was generated on-device without extra dice rolls, update firmware, generate a new seed and move your funds.") }}
+                {{ _("Coinkite disclosed a firmware flaw that reduced generated-seed entropy on ColdCard Mk2/Mk3 (firmware 4.0.1-4.1.9) and Mk4/Mk5/Q before their fixed firmware. If your seed was generated on-device with fewer than 50 independent dice rolls, update firmware, generate a new seed and move your funds.") }}
                 <a href="https://blog.coinkite.com/coldcard-mk3-seed-generation-warning/" target="_blank" rel="noopener noreferrer">{{ _("Read Coinkite's advisory") }}</a>
             </div>
 

--- a/src/cryptoadvance/specter/templates/device/new_device/new_device_keys.jinja
+++ b/src/cryptoadvance/specter/templates/device/new_device/new_device_keys.jinja
@@ -30,6 +30,12 @@
                 </div>
             {% endif %}
             
+            <div id="coldcard-warning" class="warning {% if device_class.device_type != 'coldcard' %}hidden{% endif %}">
+                ⚠️ {{ _("Security notice:") }}
+                {{ _("Coinkite disclosed a firmware flaw that reduced generated-seed entropy on ColdCard Mk3 (firmware 4.0.1-5.0.3) and pre-fix Mk4/Q. If your seed was generated on-device without extra dice rolls, update firmware, generate a new seed and move your funds.") }}
+                <a href="https://blog.coinkite.com/coldcard-mk3-seed-generation-warning/" target="_blank" rel="noopener noreferrer">{{ _("Read Coinkite's advisory") }}</a>
+            </div>
+
             <div id="coldcard-instructions" class="{%if device_class.device_type != 'coldcard' %}hidden{% endif %}">
                 <p>{{ _("Connect your ColdCard to the computer via USB and unlock it or upload a wallet export file from micro SD card.") }}</p>
 

--- a/src/cryptoadvance/specter/templates/device/new_device_manual.jinja
+++ b/src/cryptoadvance/specter/templates/device/new_device_manual.jinja
@@ -49,7 +49,7 @@
 
 					<p class="mt-3 mb-0 selection-button cursor-pointer" data-style="text-decoration: underline; cursor: pointer;" onclick="showPageOverlay('usb_import_account_number')">{{ _("Specify account number (advanced)") }}</p>
 
-					<div class="flex space-x-3 mt-3">
+					<div class="flex space-x-3 mt-3 relative z-20">
 						<qr-scanner id="xpub-scan">
 							<a slot="button" href="#" class="button mb-3">
 								<img src="{{ url_for('static', filename='img/qr-code.svg') }}" data-style="width: 26px; margin-right: 2px;" class="svg-white"> {{ _("Scan QR Code") }}


### PR DESCRIPTION
## Summary

Shows a security warning on the ColdCard device-setup page, linking Coinkite's advisory.

In July 2026 Coinkite [disclosed](https://blog.coinkite.com/coldcard-mk3-seed-generation-warning/) a firmware build error that reduced generated-seed entropy on **ColdCard Mk3** (firmware 4.0.1-5.0.3) and pre-fix **Mk4/Q**. Specter doesn't generate the ColdCard seed, so this isn't a Specter flaw — but users who add a ColdCard via Specter may hold funds on an affected seed.

## Change

Single-template change in `new_device_keys.jinja`: a warning banner inserted right before the existing `#coldcard-instructions` block, reusing the established `device_class.device_type != 'coldcard'` guard, the existing `.warning` CSS class, and the `{{ _() }}` i18n convention. It renders only for ColdCard (device_type "coldcard" has no subclasses, so Passport/Keystone/Cobo are unaffected). No Python/route/model changes.

Refs #2675.
