### PR TITLE
fix: secure Docker bind default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,4 +64,4 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 # Expose ports
 EXPOSE 25441 25442 25443 
 
-ENTRYPOINT ["/usr/local/bin/python3", "-m", "cryptoadvance.specter", "server", "--host", "0.0.0.0"]
+ENTRYPOINT ["/usr/local/bin/python3", "-m", "cryptoadvance.specter", "server"]

--- a/src/cryptoadvance/specter/cli/cli_server.py
+++ b/src/cryptoadvance/specter/cli/cli_server.py
@@ -31,7 +31,6 @@ def cli():
 # set to 0.0.0.0 to make it available outside
 @click.option(
     "--host",
-    default="127.0.0.1",
     help="if you specify --host 0.0.0.0 then specter will be available in your local LAN.",
 )
 # for https:
@@ -119,6 +118,13 @@ def server(
     if port:
         app.config["PORT"] = int(port)
 
+    if host is None:
+        host = app.config["HOST"]
+        if not isinstance(host, str) or not host.strip():
+            raise click.ClickException(
+                "Configured HOST must be a non-empty hostname or IP address."
+            )
+
     # devstatus_threshold
     if devstatus_threshold is not None:
         app.config["SERVICES_DEVSTATUS_THRESHOLD"] = devstatus_threshold
@@ -167,6 +173,21 @@ def server(
         formatter = logging.Formatter(app.config["SPECTER_LOGFORMAT"])
         fh.setFormatter(formatter)
         logging.getLogger().addHandler(fh)
+
+    if (
+        not hwibridge
+        and not is_loopback_host(host)
+        and app.specter.config["auth"].get("method", "none") == "none"
+    ):
+        logger.warning(
+            " * ############################# Warning! #############################\n"
+            " * Specter is listening on non-loopback host %s with authentication disabled.\n"
+            " * Anyone who can reach port %s can access this Specter instance.\n"
+            " * Please enable authentication in Settings -> Authentication.\n"
+            " * ####################################################################",
+            host,
+            app.config["PORT"],
+        )
 
     toraddr_file = path.join(app.specter.data_folder, "onion.txt")
 
@@ -232,6 +253,18 @@ def server(
     if debug is None:
         debug = app.config["DEBUG"]
     run(debug=debug)
+
+
+def is_loopback_host(host):
+    """Return whether host identifies an IPv4/IPv6 loopback interface."""
+    if host.lower() == "localhost":
+        return True
+    try:
+        from ipaddress import ip_address
+
+        return ip_address(host).is_loopback
+    except ValueError:
+        return False
 
 
 def configure_ssl(kwargs, app_config, ssl):

--- a/tests/test_cli_server.py
+++ b/tests/test_cli_server.py
@@ -1,8 +1,12 @@
+import json
 import logging
 import os
+import subprocess
 import sys
 import traceback
+from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 from cryptoadvance.specter.cli import server
 from mock import MagicMock, call, patch
@@ -95,6 +99,7 @@ def test_server_host_and_port(init_app, create_app, caplog):
 def test_server_debug(init_app, create_app, caplog):
     """This test will fail if you have turned on live-logging in pyproject.toml (log_cli = 1 )"""
     caplog.set_level(logging.DEBUG)
+    create_app.return_value = configured_mock_app()
     runner = CliRunner()
     result = runner.invoke(server, ["--debug", "--no-filelog"])
     print(result.output)
@@ -180,3 +185,140 @@ def tidy_up():
         os.remove("bla")
     if os.path.exists("blub"):
         os.remove("blub")
+
+
+def configured_mock_app(host="127.0.0.1", auth_method="none"):
+    mock_app = MagicMock()
+    config = dict(mock_config_dict, HOST=host, PORT=123, CERT=None, KEY=None)
+    mock_app.config.__getitem__.side_effect = config.__getitem__
+    mock_app.specter.config = {"auth": {"method": auth_method}, "tor_status": False}
+    return mock_app
+
+
+def test_docker_entrypoint_uses_configured_host():
+    dockerfile = Path(__file__).parent.parent / "Dockerfile"
+    entrypoint_line = next(
+        line
+        for line in dockerfile.read_text().splitlines()
+        if line.startswith("ENTRYPOINT")
+    )
+    entrypoint = json.loads(entrypoint_line.removeprefix("ENTRYPOINT "))
+
+    assert entrypoint == [
+        "/usr/local/bin/python3",
+        "-m",
+        "cryptoadvance.specter",
+        "server",
+    ]
+
+
+def test_host_environment_configures_production_host():
+    env = os.environ.copy()
+    env["HOST"] = "0.0.0.0"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from cryptoadvance.specter.config import ProductionConfig; "
+            "print(ProductionConfig.HOST)",
+        ],
+        check=True,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.stdout.strip() == "0.0.0.0"
+
+
+@patch("cryptoadvance.specter.cli.cli_server.create_app")
+@patch("cryptoadvance.specter.cli.cli_server.init_app")
+def test_server_inherits_configured_host(init_app, create_app):
+    create_app.return_value = configured_mock_app(host="192.168.1.10")
+
+    result = CliRunner().invoke(server, ["--no-filelog"])
+
+    assert result.exit_code == 0
+    create_app.return_value.run.assert_called_once_with(
+        debug="WURSTBROT",
+        host="192.168.1.10",
+        port=123,
+        extra_files=["templates"],
+    )
+
+
+@patch("cryptoadvance.specter.cli.cli_server.create_app")
+@patch("cryptoadvance.specter.cli.cli_server.init_app")
+def test_explicit_host_overrides_configured_host(init_app, create_app):
+    create_app.return_value = configured_mock_app(host="192.168.1.10")
+
+    result = CliRunner().invoke(server, ["--host", "127.0.0.2", "--no-filelog"])
+
+    assert result.exit_code == 0
+    create_app.return_value.config.__setitem__.assert_called_once_with(
+        "HOST", "127.0.0.2"
+    )
+    assert create_app.return_value.run.call_args.kwargs["host"] == "127.0.0.2"
+
+
+@patch("cryptoadvance.specter.cli.cli_server.create_app")
+def test_invalid_configured_host_fails_with_clear_error(create_app):
+    create_app.return_value = configured_mock_app(host="")
+
+    result = CliRunner().invoke(server, ["--no-filelog"])
+
+    assert result.exit_code != 0
+    assert "Configured HOST must be a non-empty hostname or IP address" in result.output
+    create_app.return_value.run.assert_not_called()
+
+
+@patch("cryptoadvance.specter.cli.cli_server.create_app")
+@patch("cryptoadvance.specter.cli.cli_server.init_app")
+@pytest.mark.parametrize("host", ["127.0.0.1", "127.0.0.2", "localhost", "::1"])
+def test_unauthenticated_loopback_host_does_not_warn(
+    init_app, create_app, caplog, host
+):
+    create_app.return_value = configured_mock_app(host=host)
+
+    result = CliRunner().invoke(server, ["--no-filelog"])
+
+    assert result.exit_code == 0
+    assert "authentication disabled" not in caplog.text
+
+
+@patch("cryptoadvance.specter.cli.cli_server.create_app")
+@patch("cryptoadvance.specter.cli.cli_server.init_app")
+def test_unauthenticated_external_host_warns(init_app, create_app, caplog):
+    create_app.return_value = configured_mock_app(host="0.0.0.0")
+    caplog.set_level(logging.WARNING)
+
+    result = CliRunner().invoke(server, ["--no-filelog"])
+
+    assert result.exit_code == 0
+    assert "non-loopback host 0.0.0.0 with authentication disabled" in caplog.text
+    assert "Anyone who can reach port 123" in caplog.text
+
+
+@patch("cryptoadvance.specter.cli.cli_server.create_app")
+@patch("cryptoadvance.specter.cli.cli_server.init_app")
+def test_authenticated_external_host_does_not_warn(init_app, create_app, caplog):
+    create_app.return_value = configured_mock_app(
+        host="0.0.0.0", auth_method="usernamepassword"
+    )
+
+    result = CliRunner().invoke(server, ["--no-filelog"])
+
+    assert result.exit_code == 0
+    assert "authentication disabled" not in caplog.text
+
+
+@patch("cryptoadvance.specter.cli.cli_server.create_app")
+@patch("cryptoadvance.specter.cli.cli_server.init_app")
+def test_external_hwibridge_does_not_warn(init_app, create_app, caplog):
+    create_app.return_value = configured_mock_app(host="0.0.0.0")
+
+    result = CliRunner().invoke(server, ["--hwibridge", "--no-filelog"])
+
+    assert result.exit_code == 0
+    assert "authentication disabled" not in caplog.text


### PR DESCRIPTION
## Summary

- stop the production image from binding to all interfaces by default
- honor the existing HOST configuration when --host is omitted while keeping explicit CLI precedence
- warn when an explicitly external normal server bind runs without authentication
- validate malformed configured hosts and preserve the warning in the file log

## Usage

External Docker access now requires an explicit opt-in:

    docker run -e HOST=0.0.0.0 -p 25441:25441 ghcr.io/cryptoadvance/specter-desktop

If authentication is disabled, Specter emits a prominent exposure warning.

## Verification

- 16 focused CLI server tests pass
- Black check passes
- git diff --check passes