### PR TITLE
Chore(deps): bundle 5 green low-risk dependabot bumps

### DIFF
--- a/pyinstaller/electron/package-lock.json
+++ b/pyinstaller/electron/package-lock.json
@@ -4580,9 +4580,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -8516,9 +8516,9 @@
       }
     },
     "tar": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "requires": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/pyinstaller/electron/package-lock.json
+++ b/pyinstaller/electron/package-lock.json
@@ -4722,9 +4722,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "engines": {
         "node": ">=14.14"
@@ -8635,9 +8635,9 @@
       }
     },
     "tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true
     },
     "tmp-promise": {

--- a/pyinstaller/electron/yarn.lock
+++ b/pyinstaller/electron/yarn.lock
@@ -2472,9 +2472,9 @@ supports-color@^7.1.0:
     has-flag "^4.0.0"
 
 tar@^7.4.3, tar@^7.5.6, tar@^7.5.7:
-  version "7.5.13"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.13.tgz#0d214ed56781a26edc313581c0e2d929ceeb866d"
-  integrity sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==
+  version "7.5.22"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.22.tgz#a696f998136e71487dc3f869a85bba2c67971ba9"
+  integrity sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==
   dependencies:
     "@isaacs/fs-minipass" "^4.0.0"
     chownr "^3.0.0"

--- a/pyinstaller/electron/yarn.lock
+++ b/pyinstaller/electron/yarn.lock
@@ -2532,9 +2532,9 @@ tmp-promise@^3.0.2:
     tmp "^0.2.0"
 
 tmp@^0.2.0:
-  version "0.2.5"
-  resolved "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz"
-  integrity sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.7.tgz#26f4db11d1601ce8012dcb8a798ece1c06a99059"
+  integrity sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==
 
 tough-cookie@~2.5.0:
   version "2.5.0"

--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ Flask-APScheduler==1.12.4
 gunicorn==23.0.0
 simple-websocket==0.8.1
 protobuf==4.23.3
-PyJWT==2.12.0
+PyJWT==2.13.0
 pytimeparse==1.1.8
 psycopg2-binary==2.9.5
 aioitertools==0.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -752,9 +752,9 @@ pycparser==2.22 \
     --hash=sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6 \
     --hash=sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc
     # via cffi
-pyjwt==2.12.0 \
-    --hash=sha256:2f62390b667cd8257de560b850bb5a883102a388829274147f1d724453f8fb02 \
-    --hash=sha256:9bb459d1bdd0387967d287f5656bf7ec2b9a26645d1961628cda1764e087fd6e
+pyjwt==2.13.0 \
+    --hash=sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423 \
+    --hash=sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728
     # via -r requirements.in
 pyopenssl==26.0.0 \
     --hash=sha256:df94d28498848b98cc1c0ffb8ef1e71e40210d3b0a8064c9d29571ed2904bf81 \
@@ -893,6 +893,7 @@ typing-extensions==4.15.0 \
     # via
     #   cryptography
     #   hwi
+    #   pyjwt
     #   pyopenssl
 tzdata==2024.1 \
     --hash=sha256:2674120f8d891909751c38abcdfd386ac0a5a1127954fbc332af6b5ceae07efd \

--- a/requirements.txt
+++ b/requirements.txt
@@ -902,9 +902,9 @@ tzlocal==5.2 \
     --hash=sha256:49816ef2fe65ea8ac19d19aa7a1ae0551c834303d5014c6d5a62e4cbda8047b8 \
     --hash=sha256:8d399205578f1a9342816409cc1e46a93ebd5755e39ea2d85334bea911bf0e6e
     # via apscheduler
-urllib3==2.6.3 \
-    --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed \
-    --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
+urllib3==2.7.0 \
+    --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
+    --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
     # via requests
 werkzeug==3.0.3 \
     --hash=sha256:097e5bfda9f0aba8da6b8545146def481d06aa7d3266e7448e2cccf67dd8bd18 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -438,9 +438,9 @@ hwi==3.1.0 \
     --hash=sha256:21ba92bb06e2f805e2806c686f2c50d02db6826a363b01e44052415755504d6f \
     --hash=sha256:42e875cbb616a91638fb90679cad93edb5075bf375e92fc1709be9b2a3dfd59c
     # via -r requirements.in
-idna==3.7 \
-    --hash=sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc \
-    --hash=sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0
+idna==3.15 \
+    --hash=sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8 \
+    --hash=sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc
     # via requests
 itsdangerous==2.2.0 \
     --hash=sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef \


### PR DESCRIPTION
Bundles 5 low-risk open dependabot PRs into one, to reduce merge overhead.
Each upstream dependabot commit is merged as-is (authorship preserved) — the resulting diff is exactly the union of the 5 PRs.

| PR | Bump | Type |
|----|------|------|
| #2656 | pyjwt 2.12.0 → 2.13.0 | minor, direct (python) |
| #2657 | idna 3.7 → 3.15 | minor, transitive via requests (python) |
| #2661 | urllib3 2.6.3 → 2.7.0 | minor, transitive via requests (python) |
| #2650 | tar 7.5.13 → 7.5.22 | patch, dev-only (electron) |
| #2629 | tmp 0.2.5 → 0.2.7 | patch, dev-only (electron) |

Selection criterion: **only PRs whose own CI is fully green**, no major bumps, no API-surface changes, no application code touched. Diff is limited to `requirements.in` / `requirements.txt` and `pyinstaller/electron/{package-lock.json,yarn.lock}`.

### Verification

Python lockfile regenerated from scratch with `pip-compile --generate-hashes requirements.in` (Python 3.10): **all 72 packages resolve to identical versions with identical hash sets** as the merged file. This also confirms the constraint graph is satisfiable — `urllib3==2.7.0` and `idna==3.15` are both accepted by `requests==2.31.0`.

### Deliberately excluded

- **#2649** (pyasn1) and **#2665** (flask-httpauth) — were in an earlier revision of this PR, dropped because their own CI is red (Linux smoke-test / `test` respectively).
- **#2658** werkzeug 3.0.3→3.1.6 — CI red, and feeds flask/flask-cors/flask-login.
- **#2663** requests 2.31→2.33 (also edits `pyproject.toml`), **#2660** python-dotenv 0.21→1.2 (major), **#2659** black 22→26 (repo-wide reformat), **#2662** pytest 7→9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
