### PR TITLE
Fix PyInstaller specterd backports import

### DIFF
--- a/pyinstaller/requirements.txt
+++ b/pyinstaller/requirements.txt
@@ -7,6 +7,7 @@
 pyinstaller==6.11.1
 pyinstaller-hooks-contrib>=2024.0
 setuptools>=78.1.1
+backports.tarfile==1.2.0
 
 # Platform helpers
 altgraph>=0.17


### PR DESCRIPTION
## Summary
Fix the Linux PyInstaller `specterd` smoke test crash caused by the newer setuptools/jaraco stack importing `backports` at runtime:

```text
ModuleNotFoundError: No module named 'backports'
```

`pyinstaller/requirements.txt` already installs unpinned/newer PyInstaller build-time tooling (`setuptools>=78.1.1`, `pyinstaller-hooks-contrib>=2024.0`). Current setuptools pulls in jaraco modules that import `backports.tarfile`; making that dependency explicit lets PyInstaller discover and bundle the `backports` namespace via its hooks.

This fixes the failure seen in #2628's `Build & smoke-test specterd (Linux)` job:
https://github.com/cryptoadvance/specter-desktop/actions/runs/31517010771/job/93864564829?pr=2628

## Verification
Ran the same local build/smoke path as `.github/workflows/test-specterd-build.yml` on Python 3.10:

- `pip install -r requirements.txt --require-hashes`
- `pip install -e ".[test]"`
- `pip install build==0.10.0`
- `python3 -m build`
- `pip install ./dist/cryptoadvance_specter-*.whl`
- `pip install -r pyinstaller/requirements.txt`
- `(cd pyinstaller && pyinstaller specterd.spec)`
- `./pyinstaller/dist/specterd --help`
- `./pyinstaller/dist/specterd server --help`

Both smoke commands completed successfully. During the build PyInstaller also processed `hook-backports.tarfile.py` / `hook-backports.py`, confirming the missing namespace is now included.
