### PR TITLE
Fix REST auth errors for Flask-HTTPAuth 4.8.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,7 @@ Flask-Babel==3.1.0
 Flask-Cors==6.0.0
 Flask-Login==0.6.3
 Flask-RESTful==0.3.10
-Flask-HTTPAuth==4.8.0
+Flask-HTTPAuth==4.8.1
 hwi==3.1.0
 python-dotenv==1.2.2
 requests==2.33.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -267,9 +267,9 @@ flask-cors==6.0.0 \
     --hash=sha256:4592c1570246bf7beee96b74bc0adbbfcb1b0318f6ba05c412e8909eceec3393 \
     --hash=sha256:6332073356452343a8ccddbfec7befdc3fdd040141fe776ec9b94c262f058657
     # via -r requirements.in
-flask-httpauth==4.8.0 \
-    --hash=sha256:66568a05bc73942c65f1e2201ae746295816dc009edd84b482c44c758d75097a \
-    --hash=sha256:a58fedd09989b9975448eef04806b096a3964a7feeebc0a78831ff55685b62b0
+flask-httpauth==4.8.1 \
+    --hash=sha256:0080393d70e12327781f7509115175ec5e47209816489a620d4fd39e20cea2e8 \
+    --hash=sha256:88499b22f1353893743c3cd68f2ca561c4ad9ef75cd6bcc7f621161cd0e80744
     # via -r requirements.in
 flask-login==0.6.3 \
     --hash=sha256:5e23d14a607ef12806c699590b89d0f0e0d67baeec599d75947bf9c147330333 \

--- a/src/cryptoadvance/specter/api/security.py
+++ b/src/cryptoadvance/specter/api/security.py
@@ -1,4 +1,5 @@
-""" Security Related things for the REST-API """
+"""Security Related things for the REST-API"""
+
 import logging, jwt
 from functools import wraps
 
@@ -12,6 +13,18 @@ from . import auth
 from flask import current_app as app
 
 logger = logging.getLogger(__name__)
+
+
+@auth.error_handler
+@token_auth.error_handler
+def auth_error(status):
+    """Return REST API authentication failures as JSON.
+
+    Flask-HTTPAuth 4.8.1 changed the default unauthorized response body to
+    plain text ("Unauthorized Access"). The REST API has historically returned
+    Flask-RESTful JSON error objects, and clients/tests rely on that shape.
+    """
+    return abort(status)
 
 
 @auth.verify_password


### PR DESCRIPTION
## Summary
- keeps Dependabot's `Flask-HTTPAuth` 4.8.0 → 4.8.1 bump
- adds explicit Flask-HTTPAuth error handlers for Basic and Bearer auth
- preserves the REST API's existing Flask-RESTful JSON error body for 401/403 responses

## Root cause
`Flask-HTTPAuth` 4.8.1 changed the default unauthorized response body to plain text (`Unauthorized Access`). The REST API tests and clients expect JSON error objects from Flask-RESTful, so unauthenticated REST requests returned status 401 but no longer returned parseable JSON.

This fixes the red `test` job from #2665:
- `tests/test_rest.py::test_rr_psbt_get`
- `tests/test_rest.py::test_rr_psbt_post`

The `extension-smoketest` failure in #2665 was a separate external fetch reset while generating an extension template (`requests.exceptions.ConnectionError: Connection reset by peer` from `extension_gen.py`), not caused by this dependency bump.

## Local verification
```bash
bash tests/install_noded.sh --bitcoin binary
export PATH="$PWD/tests/bitcoin/bin:$PATH"
pytest tests/test_rest.py::test_rr_psbt_get tests/test_rest.py::test_rr_psbt_post -q -vv --tb=short
pytest tests/test_rest.py -q --tb=short
black --check src/cryptoadvance/specter/api/security.py
git diff --check
```

Results:
- focused reproduced failures: 2 passed
- `tests/test_rest.py`: 2 passed
- black check: passed
- diff whitespace check: passed

Supersedes/fixes #2665 if maintainers prefer not to push directly to the Dependabot branch.
