### PR TITLE
Pin Werkzeug below 3.1 for Flask 2.2 compatibility

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,8 @@
 certifi==2024.7.4
 Click==8.1.7
 Flask==2.2.5
+# Flask 2.2.x test_client uses werkzeug.__version__, removed in Werkzeug 3.1.
+Werkzeug==3.0.6
 Flask-Babel==3.1.0
 Flask-Cors==6.0.0
 Flask-Login==0.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -907,10 +907,11 @@ urllib3==2.7.0 \
     --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
     --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
     # via requests
-werkzeug==3.1.6 \
-    --hash=sha256:210c6bede5a420a913956b4791a7f4d6843a43b6fcee4dfa08a65e93007d0d25 \
-    --hash=sha256:7ddf3357bb9564e407607f988f683d72038551200c704012bb9a4c523d42f131
+werkzeug==3.0.6 \
+    --hash=sha256:1bc0c2310d2fbb07b1dd1105eba2f7af72f322e1e455f2f93c993bee8c8a5f17 \
+    --hash=sha256:a8dd59d4de28ca70471a34cba79bed5f7ef2e036a76b3ab0835474246eb41f8d
     # via
+    #   -r requirements.in
     #   flask
     #   flask-cors
     #   flask-login

--- a/requirements.txt
+++ b/requirements.txt
@@ -907,9 +907,9 @@ urllib3==2.7.0 \
     --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
     --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
     # via requests
-werkzeug==3.0.3 \
-    --hash=sha256:097e5bfda9f0aba8da6b8545146def481d06aa7d3266e7448e2cccf67dd8bd18 \
-    --hash=sha256:fc9645dc43e03e4d630d23143a04a7f947a9a3b5727cd535fdfe155a17cc48c8
+werkzeug==3.1.6 \
+    --hash=sha256:210c6bede5a420a913956b4791a7f4d6843a43b6fcee4dfa08a65e93007d0d25 \
+    --hash=sha256:7ddf3357bb9564e407607f988f683d72038551200c704012bb9a4c523d42f131
     # via
     #   flask
     #   flask-cors


### PR DESCRIPTION
This keeps the Dependabot Werkzeug security bump green for the current Flask 2.2 stack by pinning Werkzeug to 3.0.6 instead of 3.1.6.

Why:
- The red pytest job in #2658 fails when creating Flask's test client.
- Flask 2.2.5 still reads `werkzeug.__version__` in `flask/testing.py`.
- Werkzeug removed `__version__` in 3.1, producing `AttributeError: module 'werkzeug' has no attribute '__version__'`.
- Upgrading Flask to 3.x is not currently viable because `cryptoadvance-spectrum==0.8.0` requires `Flask<2.3`, and `flask-babel==3.1.0` imports Flask internals removed in newer Flask.

Verification performed locally with Python 3.10:
- Fresh venv install: `pip install -r requirements.txt --require-hashes` ✅
- `pip install -e ".[test]"` ✅
- `pytest tests/test_hwi_server.py -q -p no:cacheprovider` ✅ — `7 passed`

This supersedes #2658's exact Werkzeug 3.1.6 target with the latest compatible Werkzeug 3.0.x patch release.
