### PR TITLE
Specter-DIY: import xpubs without the 3s timeout, one confirmation per key set, wrong-network handling

### DIFF
--- a/src/cryptoadvance/specter/devices/hwi/specter_diy.py
+++ b/src/cryptoadvance/specter/devices/hwi/specter_diy.py
@@ -23,6 +23,44 @@ from binascii import a2b_base64, b2a_base64
 py_enumerate = enumerate
 logger = logging.getLogger(__name__)
 
+# Prefix of the machine-parseable error the firmware sends back (as
+# "error: <this><network>") when it refuses a plain `xpub <path>` request
+# because the path's implied coin type doesn't match the network currently
+# active on the device. Keep in sync with specter-diy's
+# apps/xpubs/xpubs.py.
+_NETWORK_MISMATCH_PREFIX = "network mismatch: device is on "
+
+# Human-readable labels for the network identifiers the firmware reports,
+# matching the names shown on the device's own screen (embit's
+# NETWORKS[...]["name"]).
+_NETWORK_DISPLAY_NAMES = {
+    "main": "Mainnet",
+    "test": "Testnet",
+    "regtest": "Regtest",
+    "signet": "Signet",
+    "liquidv1": "Liquid",
+    "liquidtestnet": "Liquid Testnet",
+    "elementsregtest": "Liquid Regtest",
+}
+
+
+class SpecterDIYNetworkMismatchError(BadArgumentError):
+    """
+    The device refused an xpub request because the requested derivation's
+    coin type doesn't match the network currently active on the device
+    (e.g. asking for a mainnet-style key while the device is set to
+    Testnet). Raised instead of a generic BadArgumentError so callers can
+    tell the user exactly which network to switch the device to, the same
+    thing the device's own screen already told the person holding it.
+
+    :ivar device_network: the raw network identifier the device reported
+        (e.g. "test", "regtest") - not a display name.
+    """
+
+    def __init__(self, device_network: str, message: str) -> None:
+        super().__init__(message)
+        self.device_network = device_network
+
 
 class SpecterClient(HardwareWalletClient):
     """Create a client for a HID device that has already been opened.
@@ -92,7 +130,10 @@ class SpecterClient(HardwareWalletClient):
         """
         # xpub now requires on-device user confirmation and may take
         # arbitrarily long - wait indefinitely, same as sign_tx()
-        xpub = self.query("xpub %s" % bip32_path)
+        try:
+            xpub = self.query("xpub %s" % bip32_path)
+        except BadArgumentError as e:
+            raise self._network_mismatch_error(e) from e
         hd = ExtendedKey.deserialize(xpub)
         # Specter returns xpub with a prefix
         # for a network currently selected on the device
@@ -100,6 +141,36 @@ class SpecterClient(HardwareWalletClient):
             b"\x04\x88\xb2\x1e" if self.chain == Chain.MAIN else b"\x04\x35\x87\xcf"
         )
         return hd
+
+    def _network_mismatch_error(self, error: BadArgumentError) -> Exception:
+        """
+        Recognize the firmware's "network mismatch: device is on <network>"
+        response and turn it into a SpecterDIYNetworkMismatchError with a
+        message naming both networks involved. Any other BadArgumentError
+        is returned unchanged.
+        """
+        msg = str(error)
+        if not msg.startswith(_NETWORK_MISMATCH_PREFIX):
+            return error
+        device_network = msg[len(_NETWORK_MISMATCH_PREFIX) :].strip()
+        device_label = _NETWORK_DISPLAY_NAMES.get(
+            device_network, device_network.capitalize()
+        )
+        # We only know which *side* (main vs. everything test-like) of the
+        # network split we asked for - same ambiguity the device itself
+        # has, since testnet/signet/regtest/liquidtestnet all share BIP44
+        # coin type 1'. Naming the specific requested network would be a
+        # guess; naming the device's actual network (verbatim from the
+        # device) is not.
+        requested_label = (
+            "Mainnet" if self.chain == Chain.MAIN else "Testnet/Signet/Regtest"
+        )
+        return SpecterDIYNetworkMismatchError(
+            device_network,
+            "This Specter-DIY is currently set to %s, so it can't share a "
+            "%s key from here. Switch the device to %s and try again."
+            % (device_label, requested_label, requested_label),
+        )
 
     def begin_xpub_authorization(self, paths) -> bool:
         """

--- a/src/cryptoadvance/specter/devices/hwi/specter_diy.py
+++ b/src/cryptoadvance/specter/devices/hwi/specter_diy.py
@@ -43,6 +43,44 @@ _NETWORK_DISPLAY_NAMES = {
     "elementsregtest": "Liquid Regtest",
 }
 
+# Standard BIP44-style purposes that carry an implied coin type (and hence
+# an implied network). Keep in sync with specter-diy's apps/xpubs/scope.py.
+_STANDARD_PURPOSES = {44, 48, 49, 84, 86, 87}
+
+# By-name switch-to hint for a requested path's coin type, mirroring
+# specter-diy's network_hint_for_path(). Coin type 1' is shared by
+# testnet/signet/regtest/liquidtestnet/elementsregtest, so it can only be
+# named as the group.
+_COIN_TYPE_NETWORK_HINTS = {
+    0: "Mainnet",
+    1: "Testnet, Signet or Regtest",
+    1776: "Liquid",
+}
+
+
+def _requested_network_label(bip32_path):
+    """
+    The network a standard-purpose derivation path implies, by name, from
+    its coin type - or None if the path isn't standard-purpose (and so
+    carries no network meaning). Same logic the firmware applies.
+    """
+    parts = [p for p in str(bip32_path).strip().split("/") if p and p.lower() != "m"]
+    if len(parts) < 2:
+        return None
+
+    def _index(component):
+        component = component.strip().rstrip("h'")
+        return int(component)
+
+    try:
+        purpose = _index(parts[0])
+        coin_type = _index(parts[1])
+    except ValueError:
+        return None
+    if purpose not in _STANDARD_PURPOSES:
+        return None
+    return _COIN_TYPE_NETWORK_HINTS.get(coin_type)
+
 
 class SpecterDIYNetworkMismatchError(BadArgumentError):
     """
@@ -133,7 +171,7 @@ class SpecterClient(HardwareWalletClient):
         try:
             xpub = self.query("xpub %s" % bip32_path)
         except BadArgumentError as e:
-            raise self._network_mismatch_error(e) from e
+            raise self._network_mismatch_error(e, bip32_path) from e
         hd = ExtendedKey.deserialize(xpub)
         # Specter returns xpub with a prefix
         # for a network currently selected on the device
@@ -142,7 +180,9 @@ class SpecterClient(HardwareWalletClient):
         )
         return hd
 
-    def _network_mismatch_error(self, error: BadArgumentError) -> Exception:
+    def _network_mismatch_error(
+        self, error: BadArgumentError, bip32_path: str
+    ) -> Exception:
         """
         Recognize the firmware's "network mismatch: device is on <network>"
         response and turn it into a SpecterDIYNetworkMismatchError with a
@@ -156,15 +196,16 @@ class SpecterClient(HardwareWalletClient):
         device_label = _NETWORK_DISPLAY_NAMES.get(
             device_network, device_network.capitalize()
         )
-        # We only know which *side* (main vs. everything test-like) of the
-        # network split we asked for - same ambiguity the device itself
-        # has, since testnet/signet/regtest/liquidtestnet all share BIP44
-        # coin type 1'. Naming the specific requested network would be a
-        # guess; naming the device's actual network (verbatim from the
-        # device) is not.
-        requested_label = (
-            "Mainnet" if self.chain == Chain.MAIN else "Testnet, Signet or Regtest"
-        )
+        # Prefer the network implied by the path we actually asked for
+        # (its coin type) - that's unambiguous for mainnet (0') and Liquid
+        # (1776'), and for the shared 1' coin type it's the same group the
+        # device names on its own screen. Fall back to the client's chain
+        # only if the path isn't standard-purpose.
+        requested_label = _requested_network_label(bip32_path)
+        if requested_label is None:
+            requested_label = (
+                "Mainnet" if self.chain == Chain.MAIN else "Testnet, Signet or Regtest"
+            )
         return SpecterDIYNetworkMismatchError(
             device_network,
             "This Specter-DIY is currently set to %s, so it can't share a "

--- a/src/cryptoadvance/specter/devices/hwi/specter_diy.py
+++ b/src/cryptoadvance/specter/devices/hwi/specter_diy.py
@@ -62,19 +62,23 @@ def _requested_network_label(bip32_path):
     """
     The network a standard-purpose derivation path implies, by name, from
     its coin type - or None if the path isn't standard-purpose (and so
-    carries no network meaning). Same logic the firmware applies.
+    carries no network meaning). Matches the firmware rule: the purpose
+    and coin type must both be *hardened* for the path to carry network
+    semantics.
     """
     parts = [p for p in str(bip32_path).strip().split("/") if p and p.lower() != "m"]
     if len(parts) < 2:
         return None
 
-    def _index(component):
-        component = component.strip().rstrip("h'")
-        return int(component)
+    def _hardened_index(component):
+        component = component.strip()
+        if component[-1:] not in ("h", "H", "'"):
+            raise ValueError("not hardened")
+        return int(component[:-1])
 
     try:
-        purpose = _index(parts[0])
-        coin_type = _index(parts[1])
+        purpose = _hardened_index(parts[0])
+        coin_type = _hardened_index(parts[1])
     except ValueError:
         return None
     if purpose not in _STANDARD_PURPOSES:
@@ -193,25 +197,32 @@ class SpecterClient(HardwareWalletClient):
         if not msg.startswith(_NETWORK_MISMATCH_PREFIX):
             return error
         device_network = msg[len(_NETWORK_MISMATCH_PREFIX) :].strip()
-        device_label = _NETWORK_DISPLAY_NAMES.get(
-            device_network, device_network.capitalize()
+        # The device controls this string; never put it in the message
+        # verbatim (it's rendered, not escaped, in the UI). Only ever show
+        # a known, whitelisted label.
+        device_label = (
+            _NETWORK_DISPLAY_NAMES.get(device_network) or "an unknown network"
         )
-        # Prefer the network implied by the path we actually asked for
-        # (its coin type) - that's unambiguous for mainnet (0') and Liquid
-        # (1776'), and for the shared 1' coin type it's the same group the
-        # device names on its own screen. Fall back to the client's chain
-        # only if the path isn't standard-purpose.
+        # Name the network to switch to from the requested path's own coin
+        # type - unambiguous for mainnet (0') and Liquid (1776'), the
+        # shared group for 1'. If the coin type has no name we recognize,
+        # don't guess from the client's chain (that can produce a "switch
+        # to Mainnet" while the device already is on Mainnet) - say what
+        # the device's own screen says instead.
         requested_label = _requested_network_label(bip32_path)
-        if requested_label is None:
-            requested_label = (
-                "Mainnet" if self.chain == Chain.MAIN else "Testnet, Signet or Regtest"
+        if requested_label is not None:
+            message = (
+                "This Specter-DIY is currently set to %s, so it can't share a "
+                "%s key from here. Switch the device to %s and try again."
+                % (device_label, requested_label, requested_label)
             )
-        return SpecterDIYNetworkMismatchError(
-            device_network,
-            "This Specter-DIY is currently set to %s, so it can't share a "
-            "%s key from here. Switch the device to %s and try again."
-            % (device_label, requested_label, requested_label),
-        )
+        else:
+            message = (
+                "This Specter-DIY is currently set to %s, which doesn't match "
+                "the requested derivation. Switch the device to the network "
+                "that derivation is for and try again." % device_label
+            )
+        return SpecterDIYNetworkMismatchError(device_network, message)
 
     def begin_xpub_authorization(self, paths) -> bool:
         """
@@ -473,6 +484,11 @@ class SpecterUSBDevice(SpecterBase):
                 raw = self.ser.read(1)
                 res += raw
             except Exception as e:
+                raw = b""
+            if not raw:
+                # non-blocking read returned nothing (e.g. waiting for the
+                # user to confirm on the device) - yield the CPU instead
+                # of spinning on read(1)
                 time.sleep(0.01)
             if timeout is not None and time.time() > t0 + timeout:
                 self.ser.close()

--- a/src/cryptoadvance/specter/devices/hwi/specter_diy.py
+++ b/src/cryptoadvance/specter/devices/hwi/specter_diy.py
@@ -163,7 +163,7 @@ class SpecterClient(HardwareWalletClient):
         # guess; naming the device's actual network (verbatim from the
         # device) is not.
         requested_label = (
-            "Mainnet" if self.chain == Chain.MAIN else "Testnet/Signet/Regtest"
+            "Mainnet" if self.chain == Chain.MAIN else "Testnet, Signet or Regtest"
         )
         return SpecterDIYNetworkMismatchError(
             device_network,

--- a/src/cryptoadvance/specter/devices/hwi/specter_diy.py
+++ b/src/cryptoadvance/specter/devices/hwi/specter_diy.py
@@ -101,6 +101,55 @@ class SpecterClient(HardwareWalletClient):
         )
         return hd
 
+    def begin_xpub_authorization(self, paths) -> bool:
+        """
+        Authorize a whole set of xpub derivation paths with a *single*
+        on-device confirmation instead of one Confirm per
+        ``get_pubkey_at_path()`` call.
+
+        Uses the Specter-DIY ``xpubauth begin <scope>`` protocol: after one
+        approval, ``xpub <derivation>`` requests that fall inside the
+        approved scope are answered without a further prompt (each
+        authorized path exactly once). Call :meth:`end_xpub_authorization`
+        when done.
+
+        Returns ``True`` when the device authorized the scope, ``False``
+        when the firmware is too old to know ``xpubauth`` or rejected the
+        scope. The device only authorizes a scope for the network it is
+        currently on, so a ``False`` for one network's standard paths is
+        also the signal that the device is on a *different* network -
+        callers can use that instead of blindly asking for both.
+
+        Raises ``ActionCanceledError`` if the user declined on the device.
+        All ``paths`` must belong to the same network.
+        """
+        if not paths:
+            return False
+        try:
+            # no timeout: waits for the user to Confirm/Cancel on the device
+            self.query("xpubauth begin %s" % ";".join(paths))
+            return True
+        except UnavailableActionError:
+            logger.info(
+                "Specter-DIY firmware without 'xpubauth' support - "
+                "falling back to per-xpub confirmation"
+            )
+            return False
+        except BadArgumentError as e:
+            logger.info(
+                "Specter-DIY did not authorize the xpubauth scope (%s) - "
+                "falling back to per-xpub confirmation",
+                e,
+            )
+            return False
+
+    def end_xpub_authorization(self) -> None:
+        """Discard any active ``xpubauth`` authorization (best effort)."""
+        try:
+            self.query("xpubauth end")
+        except Exception as e:
+            logger.debug("xpubauth end failed: %s", e)
+
     def sign_b64psbt(self, psbt: str) -> str:
         # works with both PSBT and PSET
         return self.query("sign %s" % psbt)

--- a/src/cryptoadvance/specter/devices/hwi/specter_diy.py
+++ b/src/cryptoadvance/specter/devices/hwi/specter_diy.py
@@ -31,7 +31,10 @@ class SpecterClient(HardwareWalletClient):
     that hardware wallet subclasses should implement.
     """
 
-    # timeout large enough to handle xpub derivations
+    # bounded timeout for non-interactive operations (e.g. fingerprint,
+    # used for device discovery/identification). xpub now requires an
+    # on-device user confirmation, so get_pubkey_at_path() does not use
+    # this - it waits indefinitely, like sign_tx() already does.
     TIMEOUT = 3
 
     def __init__(self, path: str, password: str = "", expert: bool = False) -> None:
@@ -87,8 +90,9 @@ class SpecterClient(HardwareWalletClient):
         :param bip32_path: The BIP 32 derivation path
         :return: The extended public key
         """
-        # this should be fast
-        xpub = self.query("xpub %s" % bip32_path, timeout=self.TIMEOUT)
+        # xpub now requires on-device user confirmation and may take
+        # arbitrarily long - wait indefinitely, same as sign_tx()
+        xpub = self.query("xpub %s" % bip32_path)
         hd = ExtendedKey.deserialize(xpub)
         # Specter returns xpub with a prefix
         # for a network currently selected on the device

--- a/src/cryptoadvance/specter/hwi_rpc.py
+++ b/src/cryptoadvance/specter/hwi_rpc.py
@@ -8,6 +8,7 @@ from embit import bip32
 from embit.liquid import networks
 from flask import current_app as app
 from hwilib.common import Chain
+from hwilib.errors import ActionCanceledError
 from hwilib.devices.bitbox02 import Bitbox02Client
 from hwilib.devices.bitbox02_lib.util import BitBoxAppNoiseConfig
 from hwilib.devices.trezorlib.transport import get_transport
@@ -16,7 +17,7 @@ from usb1 import USBError
 
 from .devices import __all__ as device_classes
 from .devices.hwi.jade import JadeClient
-from .devices.hwi.specter_diy import SpecterClient, SpecterDIYNetworkMismatchError
+from .devices.hwi.specter_diy import SpecterClient
 from .helpers import (
     deep_update,
     hwi_get_config,
@@ -269,16 +270,18 @@ class HWIBridge(JSONRPC):
                 if derivation == "m":
                     return "[{}]{}\n".format(master_fpr, xpub)
                 return "[{}/{}]{}\n".format(master_fpr, derivation.split("m/")[1], xpub)
-            except SpecterDIYNetworkMismatchError:
-                # a specific, actionable message ("switch the device to
-                # X") - let it propagate as the RPC error instead of the
-                # generic warning below, so the UI can show it to the user
+            except ActionCanceledError:
+                # the user declined the export on the device - a None
+                # return is the caller's "cancelled, stop quietly" signal
+                logger.info("xpub export at %s cancelled on the device", derivation)
+                return None
+            except Exception:
+                # the network-mismatch error and every real failure carry
+                # something the user needs to see - propagate it so the
+                # JSON-RPC error reaches the UI (handleHWIError() escapes
+                # it before rendering) instead of vanishing into a log and
+                # leaving the caller with an ambiguous None
                 raise
-            except Exception as e:
-                logger.warning(
-                    f"Failed to import Nested Segwit singlesig mainnet key. Error: {e}"
-                )
-                logger.exception(e)
 
     @locked(hwilock)
     def begin_xpub_authorization(

--- a/src/cryptoadvance/specter/hwi_rpc.py
+++ b/src/cryptoadvance/specter/hwi_rpc.py
@@ -75,6 +75,8 @@ class HWIBridge(JSONRPC):
             "send_pin": self.send_pin,
             "extract_xpub": self.extract_xpub,
             "extract_xpubs": self.extract_xpubs,
+            "begin_xpub_authorization": self.begin_xpub_authorization,
+            "end_xpub_authorization": self.end_xpub_authorization,
             "display_address": self.display_address,
             "sign_tx": self.sign_tx,
             "sign_message": self.sign_message,
@@ -272,6 +274,68 @@ class HWIBridge(JSONRPC):
                     f"Failed to import Nested Segwit singlesig mainnet key. Error: {e}"
                 )
                 logger.exception(e)
+
+    @locked(hwilock)
+    def begin_xpub_authorization(
+        self,
+        paths=None,
+        device_type=None,
+        path=None,
+        fingerprint=None,
+        passphrase="",
+        chain="",
+    ):
+        """
+        Ask the device to authorize a whole set of xpub derivation ``paths``
+        (all on the same network) with a single on-device confirmation,
+        instead of one per subsequent extract_xpub() call. Currently only
+        Specter-DIY supports this.
+
+        Returns True if the device accepted the scope, False if this
+        device/firmware doesn't support it or rejected it (e.g. wrong
+        network) - callers should then just fall back to plain
+        extract_xpub() calls, which work either way. A cancellation on the
+        device propagates as an error, same as any other HWI call.
+        """
+        if not paths:
+            return False
+        with self._get_client(
+            device_type=device_type,
+            fingerprint=fingerprint,
+            path=path,
+            passphrase=passphrase,
+            chain=chain,
+        ) as client:
+            der = bip32.parse_path(paths[0])
+            client.chain = (
+                Chain.TEST if len(der) > 2 and der[1] == 0x80000001 else Chain.MAIN
+            )
+            begin = getattr(client, "begin_xpub_authorization", None)
+            if begin is None:
+                return False
+            return begin(paths)
+
+    @locked(hwilock)
+    def end_xpub_authorization(
+        self,
+        device_type=None,
+        path=None,
+        fingerprint=None,
+        passphrase="",
+        chain="",
+    ):
+        """Release any xpub authorization left active on the device (best effort)."""
+        with self._get_client(
+            device_type=device_type,
+            fingerprint=fingerprint,
+            path=path,
+            passphrase=passphrase,
+            chain=chain,
+        ) as client:
+            end = getattr(client, "end_xpub_authorization", None)
+            if end is not None:
+                end()
+        return True
 
     @locked(hwilock)
     def display_address(

--- a/src/cryptoadvance/specter/hwi_rpc.py
+++ b/src/cryptoadvance/specter/hwi_rpc.py
@@ -16,7 +16,7 @@ from usb1 import USBError
 
 from .devices import __all__ as device_classes
 from .devices.hwi.jade import JadeClient
-from .devices.hwi.specter_diy import SpecterClient
+from .devices.hwi.specter_diy import SpecterClient, SpecterDIYNetworkMismatchError
 from .helpers import (
     deep_update,
     hwi_get_config,
@@ -269,6 +269,11 @@ class HWIBridge(JSONRPC):
                 if derivation == "m":
                     return "[{}]{}\n".format(master_fpr, xpub)
                 return "[{}/{}]{}\n".format(master_fpr, derivation.split("m/")[1], xpub)
+            except SpecterDIYNetworkMismatchError:
+                # a specific, actionable message ("switch the device to
+                # X") - let it propagate as the RPC error instead of the
+                # generic warning below, so the UI can show it to the user
+                raise
             except Exception as e:
                 logger.warning(
                     f"Failed to import Nested Segwit singlesig mainnet key. Error: {e}"

--- a/src/cryptoadvance/specter/hwi_rpc.py
+++ b/src/cryptoadvance/specter/hwi_rpc.py
@@ -301,9 +301,33 @@ class HWIBridge(JSONRPC):
         network) - callers should then just fall back to plain
         extract_xpub() calls, which work either way. A cancellation on the
         device propagates as an error, same as any other HWI call.
+
+        Lifecycle note: begin_xpub_authorization / end_xpub_authorization
+        are separate RPCs, and the HWI connection is reopened per call, so
+        between them the authorization lives on the device on its own. It
+        is deliberately narrow - RAM only, bound to the current network,
+        limited to the exact confirmed paths, each consumable once, and
+        dropped by the firmware on lock / re-init / network change. The
+        residual exposure is: if the host process dies mid-batch, the
+        still-unread authorized paths stay authorized until one of those
+        events. Acceptable given the one-shot scope; a fully atomic
+        server-side begin->reads->end (an extract_xpub_batch RPC) and/or a
+        short firmware TTL for unused authorizations would close it and
+        are worth a follow-up. The self-contained _extract_xpubs_from_
+        client() path already wraps begin/end in try/finally within one
+        RPC; only the new_device_keys.jinja "Get via USB" flow spans
+        several.
         """
         if not paths:
             return False
+        # Don't trust the caller (the browser builds this list from DOM
+        # text, including user-entered custom derivations) to hand us
+        # clean BIP32 paths. Parse and re-serialise each one canonically
+        # here, at the RPC boundary, before it's joined into the firmware
+        # scope string - a stray ";" or range expression must not be able
+        # to ride in through a single list entry and widen the scope.
+        ders = [bip32.parse_path(p) for p in paths]
+        norm_paths = [bip32.path_to_str(d) for d in ders]
         with self._get_client(
             device_type=device_type,
             fingerprint=fingerprint,
@@ -311,14 +335,14 @@ class HWIBridge(JSONRPC):
             passphrase=passphrase,
             chain=chain,
         ) as client:
-            der = bip32.parse_path(paths[0])
+            der = ders[0]
             client.chain = (
                 Chain.TEST if len(der) > 2 and der[1] == 0x80000001 else Chain.MAIN
             )
             begin = getattr(client, "begin_xpub_authorization", None)
             if begin is None:
                 return False
-            return begin(paths)
+            return begin(norm_paths)
 
     @locked(hwilock)
     def end_xpub_authorization(

--- a/src/cryptoadvance/specter/hwi_rpc.py
+++ b/src/cryptoadvance/specter/hwi_rpc.py
@@ -480,112 +480,146 @@ class HWIBridge(JSONRPC):
             # See:
             #   https://github.com/satoshilabs/slips/blob/master/slip-0132.md
 
-            # Extract nested Segwit
-            try:
-                xpub = client.get_pubkey_at_path(
-                    "m/49h/0h/{}h".format(account)
-                ).to_string()
-                ypub = convert_xpub_prefix(xpub, b"\x04\x9d\x7c\xb2")
-                xpubs += "[{}/49'/0'/{}']{}\n".format(master_fpr, account, ypub)
-            except Exception as e:
-                logger.warning(
-                    f"Failed to import Nested Segwit singlesig mainnet key. Error {e}"
-                )
-                logger.exception(e)
+            mainnet_paths = [
+                "m/49h/0h/{}h".format(account),
+                "m/84h/0h/{}h".format(account),
+                "m/48h/0h/{}h/1h".format(account),
+                "m/48h/0h/{}h/2h".format(account),
+            ]
+            testnet_paths = [
+                "m/49h/1h/{}h".format(account),
+                "m/84h/1h/{}h".format(account),
+                "m/48h/1h/{}h/1h".format(account),
+                "m/48h/1h/{}h/2h".format(account),
+            ]
+
+            # Some devices (Specter-DIY) ask the user to confirm every single
+            # xpub export on-device. Where the client supports it, authorize
+            # the whole set of standard account paths with one scoped request:
+            # the user confirms once instead of once per key, and - since the
+            # device only authorizes a scope for the network it is currently
+            # on - a rejection tells us the device is on the *other* network,
+            # so we don't ask it (and prompt the user) for keys of a network
+            # it isn't even set to. Clients without this run both groups with
+            # the usual per-request flow, unchanged.
+            begin_auth = getattr(client, "begin_xpub_authorization", None)
+            fetch_mainnet = True
+            fetch_testnet = True
+            scoped = False
+            if begin_auth is not None:
+                client.chain = Chain.MAIN
+                if begin_auth(mainnet_paths):
+                    scoped = True
+                    fetch_testnet = False
+                else:
+                    client.chain = Chain.TEST
+                    if begin_auth(testnet_paths):
+                        scoped = True
+                        fetch_mainnet = False
 
             try:
-                # native Segwit
-                xpub = client.get_pubkey_at_path(
-                    "m/84h/0h/{}h".format(account)
-                ).to_string()
-                zpub = convert_xpub_prefix(xpub, b"\x04\xb2\x47\x46")
-                xpubs += "[{}/84'/0'/{}']{}\n".format(master_fpr, account, zpub)
-            except Exception as e:
-                logger.warning(
-                    f"Failed to import native Segwit singlesig mainnet key: {e}"
-                )
-                logger.exception(e)
+                if fetch_mainnet:
+                    client.chain = Chain.MAIN
+                    # Nested Segwit
+                    try:
+                        xpub = client.get_pubkey_at_path(mainnet_paths[0]).to_string()
+                        ypub = convert_xpub_prefix(xpub, b"\x04\x9d\x7c\xb2")
+                        xpubs += "[{}/49'/0'/{}']{}\n".format(master_fpr, account, ypub)
+                    except Exception as e:
+                        logger.warning(
+                            f"Failed to import Nested Segwit singlesig mainnet key. Error {e}"
+                        )
+                        logger.exception(e)
 
-            try:
-                # Multisig nested Segwit
-                xpub = client.get_pubkey_at_path(
-                    "m/48h/0h/{}h/1h".format(account)
-                ).to_string()
-                Ypub = convert_xpub_prefix(xpub, b"\x02\x95\xb4\x3f")
-                xpubs += "[{}/48'/0'/{}'/1']{}\n".format(master_fpr, account, Ypub)
-            except Exception as e:
-                logger.warning(
-                    f"Failed to import Nested Segwit multisig mainnet key: {e}"
-                )
-                logger.exception(e)
+                    try:
+                        # native Segwit
+                        xpub = client.get_pubkey_at_path(mainnet_paths[1]).to_string()
+                        zpub = convert_xpub_prefix(xpub, b"\x04\xb2\x47\x46")
+                        xpubs += "[{}/84'/0'/{}']{}\n".format(master_fpr, account, zpub)
+                    except Exception as e:
+                        logger.warning(
+                            f"Failed to import native Segwit singlesig mainnet key: {e}"
+                        )
+                        logger.exception(e)
 
-            try:
-                # Multisig native Segwit
-                xpub = client.get_pubkey_at_path(
-                    "m/48h/0h/{}h/2h".format(account)
-                ).to_string()
-                Zpub = convert_xpub_prefix(xpub, b"\x02\xaa\x7e\xd3")
-                xpubs += "[{}/48'/0'/{}'/2']{}\n".format(master_fpr, account, Zpub)
-            except Exception as e:
-                logger.warning(
-                    f"Failed to import native Segwit multisig mainnet key {e}"
-                )
-                logger.exception(e)
+                    try:
+                        # Multisig nested Segwit
+                        xpub = client.get_pubkey_at_path(mainnet_paths[2]).to_string()
+                        Ypub = convert_xpub_prefix(xpub, b"\x02\x95\xb4\x3f")
+                        xpubs += "[{}/48'/0'/{}'/1']{}\n".format(
+                            master_fpr, account, Ypub
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            f"Failed to import Nested Segwit multisig mainnet key: {e}"
+                        )
+                        logger.exception(e)
 
-            # And testnet
-            client.chain = Chain.TEST
+                    try:
+                        # Multisig native Segwit
+                        xpub = client.get_pubkey_at_path(mainnet_paths[3]).to_string()
+                        Zpub = convert_xpub_prefix(xpub, b"\x02\xaa\x7e\xd3")
+                        xpubs += "[{}/48'/0'/{}'/2']{}\n".format(
+                            master_fpr, account, Zpub
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            f"Failed to import native Segwit multisig mainnet key {e}"
+                        )
+                        logger.exception(e)
 
-            try:
-                # Testnet nested Segwit
-                xpub = client.get_pubkey_at_path(
-                    "m/49h/1h/{}h".format(account)
-                ).to_string()
-                upub = convert_xpub_prefix(xpub, b"\x04\x4a\x52\x62")
-                xpubs += "[{}/49'/1'/{}']{}\n".format(master_fpr, account, upub)
-            except Exception as e:
-                logger.warning(
-                    f"Failed to import Nested Segwit singlesig testnet key: {e}"
-                )
-                logger.exception(e)
+                if fetch_testnet:
+                    client.chain = Chain.TEST
+                    try:
+                        # Testnet nested Segwit
+                        xpub = client.get_pubkey_at_path(testnet_paths[0]).to_string()
+                        upub = convert_xpub_prefix(xpub, b"\x04\x4a\x52\x62")
+                        xpubs += "[{}/49'/1'/{}']{}\n".format(master_fpr, account, upub)
+                    except Exception as e:
+                        logger.warning(
+                            f"Failed to import Nested Segwit singlesig testnet key: {e}"
+                        )
+                        logger.exception(e)
 
-            try:
-                # Testnet native Segwit
-                xpub = client.get_pubkey_at_path(
-                    "m/84h/1h/{}h".format(account)
-                ).to_string()
-                vpub = convert_xpub_prefix(xpub, b"\x04\x5f\x1c\xf6")
-                xpubs += "[{}/84'/1'/{}']{}\n".format(master_fpr, account, vpub)
-            except Exception as e:
-                logger.warning(
-                    f"Failed to import native Segwit singlesig testnet key: {e}"
-                )
-                logger.exception(e)
+                    try:
+                        # Testnet native Segwit
+                        xpub = client.get_pubkey_at_path(testnet_paths[1]).to_string()
+                        vpub = convert_xpub_prefix(xpub, b"\x04\x5f\x1c\xf6")
+                        xpubs += "[{}/84'/1'/{}']{}\n".format(master_fpr, account, vpub)
+                    except Exception as e:
+                        logger.warning(
+                            f"Failed to import native Segwit singlesig testnet key: {e}"
+                        )
+                        logger.exception(e)
 
-            try:
-                # Testnet multisig nested Segwit
-                xpub = client.get_pubkey_at_path(
-                    "m/48h/1h/{}h/1h".format(account)
-                ).to_string()
-                Upub = convert_xpub_prefix(xpub, b"\x02\x42\x89\xef")
-                xpubs += "[{}/48'/1'/{}'/1']{}\n".format(master_fpr, account, Upub)
-            except Exception as e:
-                logger.warning(
-                    f"Failed to import Nested Segwit multisigsig testnet key: {e}"
-                )
-                logger.exception(e)
+                    try:
+                        # Testnet multisig nested Segwit
+                        xpub = client.get_pubkey_at_path(testnet_paths[2]).to_string()
+                        Upub = convert_xpub_prefix(xpub, b"\x02\x42\x89\xef")
+                        xpubs += "[{}/48'/1'/{}'/1']{}\n".format(
+                            master_fpr, account, Upub
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            f"Failed to import Nested Segwit multisigsig testnet key: {e}"
+                        )
+                        logger.exception(e)
 
-            try:
-                # Testnet multisig native Segwit
-                xpub = client.get_pubkey_at_path(
-                    "m/48h/1h/{}h/2h".format(account)
-                ).to_string()
-                Vpub = convert_xpub_prefix(xpub, b"\x02\x57\x54\x83")
-                xpubs += "[{}/48'/1'/{}'/2']{}\n".format(master_fpr, account, Vpub)
-            except Exception as e:
-                logger.warning(
-                    f"Failed to import native Segwit multisig testnet key: {e}"
-                )
-                logger.exception(e)
+                    try:
+                        # Testnet multisig native Segwit
+                        xpub = client.get_pubkey_at_path(testnet_paths[3]).to_string()
+                        Vpub = convert_xpub_prefix(xpub, b"\x02\x57\x54\x83")
+                        xpubs += "[{}/48'/1'/{}'/2']{}\n".format(
+                            master_fpr, account, Vpub
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            f"Failed to import native Segwit multisig testnet key: {e}"
+                        )
+                        logger.exception(e)
+            finally:
+                if scoped:
+                    client.end_xpub_authorization()
 
             # Do proper cleanup otherwise have to reconnect device to access again
             client.close()

--- a/src/cryptoadvance/specter/static/hwi.js
+++ b/src/cryptoadvance/specter/static/hwi.js
@@ -167,6 +167,42 @@ class HWIBridge {
         });
     }
 
+    async beginXpubAuthorization(device, paths, passphrase="", chain=""){
+        /**
+            Asks the device to authorize a whole set of xpub derivation paths
+            (same network) with a single on-device confirmation. Returns
+            true if the device took the scope - subsequent getXpub() calls
+            for those paths then return without a further prompt. Returns
+            false if the device/firmware doesn't support this (callers
+            should just keep calling getXpub() per path as before).
+        **/
+        if(!('passphrase' in device)){
+            device.passphrase = passphrase;
+        }
+        return await this.requestToHwiBridge('begin_xpub_authorization', {
+            device_type: device.type,
+            paths: paths,
+            path: device.path,
+            passphrase: device.passphrase,
+            chain: chain,
+        });
+    }
+
+    async endXpubAuthorization(device, passphrase="", chain=""){
+        /**
+            Releases an authorization started with beginXpubAuthorization().
+        **/
+        if(!('passphrase' in device)){
+            device.passphrase = passphrase;
+        }
+        return await this.requestToHwiBridge('end_xpub_authorization', {
+            device_type: device.type,
+            path: device.path,
+            passphrase: device.passphrase,
+            chain: chain,
+        });
+    }
+
     async getMasterBlindingKey(device, passphrase="", chain=""){
         if(!('passphrase' in device)){
             device.passphrase = passphrase;

--- a/src/cryptoadvance/specter/templates/device/new_device/new_device_keys.jinja
+++ b/src/cryptoadvance/specter/templates/device/new_device/new_device_keys.jinja
@@ -347,13 +347,21 @@
             // the whole set up front instead - getXpub() below then returns
             // without a further prompt for each authorized derivation.
             // Devices/firmware that don't support this just return false
-            // here and the loop falls back to its normal per-key prompts.
+            // here and the loop falls back to its normal per-key prompts;
+            // an explicit Cancel on the device throws, and must abort the
+            // whole import rather than fall through to per-key prompts.
             let xpubAuthorized = false;
             if (pendingRows.length > 0) {
                 let pendingDerivations = pendingRows.map(
                     xpubRow => document.getElementById(xpubRow.id + '-derivation').innerHTML
                 );
-                xpubAuthorized = await beginXpubAuthorization(device, pendingDerivations, "", "{specter.chain}");
+                try {
+                    xpubAuthorized = await beginXpubAuthorization(device, pendingDerivations, "", "{specter.chain}");
+                } catch (error) {
+                    // beginXpubAuthorization() already showed the reason
+                    // (cancelled / device error). A "no" ends it here.
+                    return;
+                }
             }
 
             try {

--- a/src/cryptoadvance/specter/templates/device/new_device/new_device_keys.jinja
+++ b/src/cryptoadvance/specter/templates/device/new_device/new_device_keys.jinja
@@ -358,17 +358,17 @@
 
             try {
                 for (let xpubRow of pendingRows) {
-                    let xpub = await getXpub(device,
-                        document.getElementById(xpubRow.id + '-derivation').innerHTML,
-                        "",
-                        "{specter.chain}"
-                    );
+                    let derivation = document.getElementById(xpubRow.id + '-derivation').innerHTML;
+                    let xpub = await getXpub(device, derivation, "", "{specter.chain}");
                     if(xpub == null){
-                        showError(`{{ _("Failed to retrive device data. Please try again.") }}`);
+                        // getXpub() has already surfaced the specific reason
+                        // (e.g. "This Specter-DIY is on Mainnet - switch it to
+                        // Testnet") via handleHWIError; don't stack a generic
+                        // "failed, try again" on top of it.
                         return;
                     }
 
-                    addXpub('Custom', document.getElementById(xpubRow.id + '-derivation').innerHTML, xpub)
+                    addXpub('Custom', derivation, xpub)
                 }
             } finally {
                 if (xpubAuthorized) {

--- a/src/cryptoadvance/specter/templates/device/new_device/new_device_keys.jinja
+++ b/src/cryptoadvance/specter/templates/device/new_device/new_device_keys.jinja
@@ -338,23 +338,42 @@
             }
 
             let xpubsTable = document.getElementById('xpubs_table');
-            
-            for (let xpubRow of [].slice.call(xpubsTable.children, 0, xpubsTable.children.length - 3)) {
-                if (document.getElementById(xpubRow.id + '-xpub').childNodes[0].innerHTML != '-') {
-                    continue
-                }
 
-                let xpub = await getXpub(device,
-                    document.getElementById(xpubRow.id + '-derivation').innerHTML,
-                    "",
-                    "{specter.chain}"
+            let pendingRows = [].slice.call(xpubsTable.children, 0, xpubsTable.children.length - 3)
+                .filter(xpubRow => document.getElementById(xpubRow.id + '-xpub').childNodes[0].innerHTML == '-');
+
+            // Some devices (Specter-DIY) ask for an on-device confirmation
+            // for every single key below. Ask for one confirmation covering
+            // the whole set up front instead - getXpub() below then returns
+            // without a further prompt for each authorized derivation.
+            // Devices/firmware that don't support this just return false
+            // here and the loop falls back to its normal per-key prompts.
+            let xpubAuthorized = false;
+            if (pendingRows.length > 0) {
+                let pendingDerivations = pendingRows.map(
+                    xpubRow => document.getElementById(xpubRow.id + '-derivation').innerHTML
                 );
-                if(xpub == null){
-                    showError(`{{ _("Failed to retrive device data. Please try again.") }}`);
-                    return;
-                }
+                xpubAuthorized = await beginXpubAuthorization(device, pendingDerivations, "", "{specter.chain}");
+            }
 
-                addXpub('Custom', document.getElementById(xpubRow.id + '-derivation').innerHTML, xpub)
+            try {
+                for (let xpubRow of pendingRows) {
+                    let xpub = await getXpub(device,
+                        document.getElementById(xpubRow.id + '-derivation').innerHTML,
+                        "",
+                        "{specter.chain}"
+                    );
+                    if(xpub == null){
+                        showError(`{{ _("Failed to retrive device data. Please try again.") }}`);
+                        return;
+                    }
+
+                    addXpub('Custom', document.getElementById(xpubRow.id + '-derivation').innerHTML, xpub)
+                }
+            } finally {
+                if (xpubAuthorized) {
+                    await endXpubAuthorization(device, "", "{specter.chain}");
+                }
             }
         });
     </script>

--- a/src/cryptoadvance/specter/templates/includes/hwi/components/select_device.jinja
+++ b/src/cryptoadvance/specter/templates/includes/hwi/components/select_device.jinja
@@ -138,7 +138,7 @@
         }
 
         if (fingerprint && device.fingerprint != fingerprint) {
-            handleHWIError(`{{ _("Selected device does not have matching signing key.") }}`);
+            showError(`{{ _("Selected device does not have matching signing key.") }}`);
             return;
         }
         showHWIProgress(`{{ _("Signing message...") }}`, `{{ _("Confirm on your") }} ${capitalize(device.type)}.`);

--- a/src/cryptoadvance/specter/templates/includes/hwi/components/wallet.jinja
+++ b/src/cryptoadvance/specter/templates/includes/hwi/components/wallet.jinja
@@ -35,7 +35,7 @@
         }
 
         if (fingerprint && device.fingerprint != fingerprint) {
-            handleHWIError(`{{ _("Selected device does not have matching signing key.") }}`);
+            showError(`{{ _("Selected device does not have matching signing key.") }}`);
             return;
         }
         showHWIProgress(`{{ _("Signing transaction...") }}`, `{{ _("Confirm on your") }} ${capitalize(device.type)}.`);
@@ -111,7 +111,7 @@
         }
 
         if (fingerprint && device.fingerprint != fingerprint) {
-            handleHWIError("Device fingerprints don't match. You have probably selected the wrong device.")
+            showError("Device fingerprints don't match. You have probably selected the wrong device.")
             return
         }
 

--- a/src/cryptoadvance/specter/templates/includes/hwi/hwi.jinja
+++ b/src/cryptoadvance/specter/templates/includes/hwi/hwi.jinja
@@ -58,6 +58,12 @@
         if(error.message !== undefined){
             error = error.message;
         }
+        if(typeof error === 'string'){
+            // the JSON-RPC layer wraps every failure as "Internal error: <msg>." -
+            // unhelpful for the user-actionable ones (e.g. "switch the device to
+            // Testnet"), and it doubles the trailing period. Strip both.
+            error = error.replace(/^Internal error:\s*/, '').replace(/\.\.$/, '.');
+        }
         showError(error, 10000);
         if(overlayIsActive()){
             hidePageOverlay();

--- a/src/cryptoadvance/specter/templates/includes/hwi/hwi.jinja
+++ b/src/cryptoadvance/specter/templates/includes/hwi/hwi.jinja
@@ -58,13 +58,22 @@
         if(error.message !== undefined){
             error = error.message;
         }
-        if(typeof error === 'string' && error.indexOf('This Specter-DIY is currently set to') !== -1){
-            // Only this one message: it's a full user-actionable sentence
-            // ("...Switch the device to Mainnet and try again."), but the
-            // JSON-RPC layer wraps every -32000 error as "Internal error:
-            // <msg>." so it reads like a crash and gets a doubled period.
-            // Left untouched for every other device/error.
-            error = error.replace(/^Internal error:\s*/, '').replace(/\.\.$/, '.');
+        if(typeof error === 'string'){
+            if(error.indexOf('This Specter-DIY is currently set to') !== -1){
+                // our own whitelist-built sentence; the JSON-RPC layer
+                // wraps every -32000 error as "Internal error: <msg>." so
+                // it reads like a crash and gets a doubled period. Left
+                // untouched for every other device/error.
+                error = error.replace(/^Internal error:\s*/, '').replace(/\.\.$/, '.');
+            }
+            // An HWI error string can carry text straight from a connected
+            // device (the firmware echoes "error: <...>" through, and HWI
+            // does the same for other wallets). showError() renders via
+            // innerHTML, so escape it here - this is the one place
+            // untrusted device text enters the notification system.
+            error = error.replace(/[&<>"']/g, function(c){
+                return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c];
+            });
         }
         showError(error, 10000);
         if(overlayIsActive()){

--- a/src/cryptoadvance/specter/templates/includes/hwi/hwi.jinja
+++ b/src/cryptoadvance/specter/templates/includes/hwi/hwi.jinja
@@ -58,10 +58,12 @@
         if(error.message !== undefined){
             error = error.message;
         }
-        if(typeof error === 'string'){
-            // the JSON-RPC layer wraps every failure as "Internal error: <msg>." -
-            // unhelpful for the user-actionable ones (e.g. "switch the device to
-            // Testnet"), and it doubles the trailing period. Strip both.
+        if(typeof error === 'string' && error.indexOf('This Specter-DIY is currently set to') !== -1){
+            // Only this one message: it's a full user-actionable sentence
+            // ("...Switch the device to Mainnet and try again."), but the
+            // JSON-RPC layer wraps every -32000 error as "Internal error:
+            // <msg>." so it reads like a crash and gets a doubled period.
+            // Left untouched for every other device/error.
             error = error.replace(/^Internal error:\s*/, '').replace(/\.\.$/, '.');
         }
         showError(error, 10000);
@@ -212,19 +214,23 @@
     async function beginXpubAuthorization(device, paths, passphrase="", chain=""){
         // Ask the device to authorize a whole set of xpub paths (same
         // network) with a single confirmation, instead of one per
-        // subsequent getXpub() call. Only some devices (Specter-DIY)
-        // support this; returns false (no error, no overlay) otherwise -
-        // callers should just proceed with individual getXpub() calls.
+        // subsequent getXpub() call.
+        //
+        // Returns false when the device/firmware doesn't support this or
+        // rejected the scope (wrong network) - the RPC resolves to false
+        // without throwing, and the caller should fall back to individual
+        // getXpub() calls. Anything that *throws* here is a real failure
+        // or an explicit on-device Cancel: the toast is shown and the
+        // error re-raised so the caller aborts the whole operation
+        // instead of silently continuing with per-key prompts.
         showHWIProgress(`{{ _("Requesting access to public keys...") }}`,
             `{{ _("It may take a while.") }}<br><br>{{ _("Keep your") }} ${capitalize(device.type)} {{ _("connected") }}.`);
         let authorized = false;
         try {
             authorized = await hwi.beginXpubAuthorization(device, paths, passphrase, chain);
         } catch (error) {
-            // a real error (e.g. the user cancelled on the device) - not
-            // "unsupported", which resolves to false without throwing
             handleHWIError(error);
-            return false;
+            throw error;
         }
         hidePageOverlay();
         return authorized;

--- a/src/cryptoadvance/specter/templates/includes/hwi/hwi.jinja
+++ b/src/cryptoadvance/specter/templates/includes/hwi/hwi.jinja
@@ -203,6 +203,37 @@
         return result;
     }
 
+    async function beginXpubAuthorization(device, paths, passphrase="", chain=""){
+        // Ask the device to authorize a whole set of xpub paths (same
+        // network) with a single confirmation, instead of one per
+        // subsequent getXpub() call. Only some devices (Specter-DIY)
+        // support this; returns false (no error, no overlay) otherwise -
+        // callers should just proceed with individual getXpub() calls.
+        showHWIProgress(`{{ _("Requesting access to public keys...") }}`,
+            `{{ _("It may take a while.") }}<br><br>{{ _("Keep your") }} ${capitalize(device.type)} {{ _("connected") }}.`);
+        let authorized = false;
+        try {
+            authorized = await hwi.beginXpubAuthorization(device, paths, passphrase, chain);
+        } catch (error) {
+            // a real error (e.g. the user cancelled on the device) - not
+            // "unsupported", which resolves to false without throwing
+            handleHWIError(error);
+            return false;
+        }
+        hidePageOverlay();
+        return authorized;
+    }
+
+    async function endXpubAuthorization(device, passphrase="", chain=""){
+        try {
+            await hwi.endXpubAuthorization(device, passphrase, chain);
+        } catch (error) {
+            // best effort - the authorization also self-expires on the
+            // device, so a failure to explicitly release it isn't fatal
+            console.warn("endXpubAuthorization failed:", error);
+        }
+    }
+
     async function getMasterBlindingKey(device, passphrase="", chain=""){
         // detect device
         showHWIProgress(`{{ _("Extracting master blinding key...") }}`, 

--- a/tests/test_hwi_rpc.py
+++ b/tests/test_hwi_rpc.py
@@ -12,9 +12,131 @@
 import logging
 import io
 import pytest
+from unittest.mock import MagicMock
+
+from hwilib.common import Chain
+from hwilib.errors import ActionCanceledError
+
 from cryptoadvance.specter.hwi_rpc import HWIBridge
 from cryptoadvance.specter.key import Key
 from cryptoadvance.specter.util.descriptor import Descriptor
+
+
+class _FakeExtKey:
+    def __init__(self, path):
+        self._path = path
+
+    def to_string(self):
+        # a valid-looking xpub is required by convert_xpub_prefix; the exact
+        # value doesn't matter for these tests, only which path produced it
+        return (
+            "xpub6CUGRUonZSQ4TWtTMmzXdrXDtypWKiKrhko4egpiMZbpiaQL2jkwSB1icqYh2cfDf"
+            "Vxdx4df189oLKnC5fSwqPfgyP3hooxujYzAu3fDVmz#" + self._path
+        )
+
+
+class _FakeDiyClient:
+    """Minimal stand-in for SpecterClient with the batch-auth API."""
+
+    def __init__(self, network):
+        # network the (fake) device is currently on: "main" or "test"
+        self._network = network
+        self.chain = Chain.MAIN
+        self.calls = []
+
+    def get_master_fingerprint(self):
+        return bytes.fromhex("00000000")
+
+    def begin_xpub_authorization(self, paths):
+        self.calls.append(("begin", list(paths)))
+        coin = "0h" if self._network == "main" else "1h"
+        if all("/%s/" % coin in p or p.endswith("/%s" % coin) for p in paths):
+            return True
+        return False  # scope for the other network -> rejected
+
+    def end_xpub_authorization(self):
+        self.calls.append(("end", None))
+
+    def get_pubkey_at_path(self, path):
+        self.calls.append(("xpub", path))
+        return _FakeExtKey(path)
+
+    def close(self):
+        self.calls.append(("close", None))
+
+
+class _FakePlainClient:
+    """Stand-in for a client without the batch-auth API (e.g. Trezor)."""
+
+    def __init__(self):
+        self.chain = Chain.MAIN
+        self.calls = []
+
+    def get_master_fingerprint(self):
+        return bytes.fromhex("00000000")
+
+    def get_pubkey_at_path(self, path):
+        self.calls.append(("xpub", path))
+        return _FakeExtKey(path)
+
+    def close(self):
+        self.calls.append(("close", None))
+
+
+def _paths_requested(client):
+    return [p for kind, p in client.calls if kind == "xpub"]
+
+
+def test_extract_xpubs_mainnet_diy_confirms_once_and_skips_testnet():
+    client = _FakeDiyClient("main")
+    HWIBridge(skip_hwi_initialisation=True)._extract_xpubs_from_client(client)
+
+    kinds = [k for k, _ in client.calls]
+    assert kinds.count("begin") == 1  # single scoped confirmation
+    assert ("end", None) in client.calls
+    paths = _paths_requested(client)
+    assert paths == [
+        "m/49h/0h/0h",
+        "m/84h/0h/0h",
+        "m/48h/0h/0h/1h",
+        "m/48h/0h/0h/2h",
+    ]  # only the network the device is on, no testnet requests
+
+
+def test_extract_xpubs_testnet_diy_confirms_once_and_skips_mainnet():
+    client = _FakeDiyClient("test")
+    HWIBridge(skip_hwi_initialisation=True)._extract_xpubs_from_client(client)
+
+    assert _paths_requested(client) == [
+        "m/49h/1h/0h",
+        "m/84h/1h/0h",
+        "m/48h/1h/0h/1h",
+        "m/48h/1h/0h/2h",
+    ]
+
+
+def test_extract_xpubs_without_batch_auth_still_fetches_both_networks():
+    client = _FakePlainClient()
+    HWIBridge(skip_hwi_initialisation=True)._extract_xpubs_from_client(client)
+
+    assert _paths_requested(client) == [
+        "m/49h/0h/0h",
+        "m/84h/0h/0h",
+        "m/48h/0h/0h/1h",
+        "m/48h/0h/0h/2h",
+        "m/49h/1h/0h",
+        "m/84h/1h/0h",
+        "m/48h/1h/0h/1h",
+        "m/48h/1h/0h/2h",
+    ]
+
+
+def test_extract_xpubs_diy_cancellation_propagates():
+    client = _FakeDiyClient("main")
+    client.begin_xpub_authorization = MagicMock(side_effect=ActionCanceledError("nope"))
+    with pytest.raises(ActionCanceledError):
+        HWIBridge(skip_hwi_initialisation=True)._extract_xpubs_from_client(client)
+    assert ("close", None) in client.calls  # client still cleaned up
 
 
 @pytest.mark.skip()

--- a/tests/test_hwi_rpc.py
+++ b/tests/test_hwi_rpc.py
@@ -12,7 +12,8 @@
 import logging
 import io
 import pytest
-from unittest.mock import MagicMock
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
 
 from hwilib.common import Chain
 from hwilib.errors import ActionCanceledError
@@ -22,17 +23,24 @@ from cryptoadvance.specter.key import Key
 from cryptoadvance.specter.util.descriptor import Descriptor
 
 
+# A real, base58check-valid xpub. convert_xpub_prefix() runs
+# base58.decode_check() on whatever to_string() returns and re-encodes it
+# with the slip132 prefix, so this has to actually decode - a "looks like
+# an xpub" placeholder silently fails that conversion, _extract_xpubs_from_
+# client() swallows the per-key exception, and the test then asserts only
+# on which *paths* were requested while zero keys actually came back.
+_VALID_XPUB = (
+    "xpub661MyMwAqRbcEwCMnGLoVvi19EZQaXijFpNzxCgpC4Cs1onmKcddCwMH6P8DicQYDm"
+    "GjAcu5pNNciH3m5CFuZq2LmdNM4EYK9bqY5BFimfo"
+)
+
+
 class _FakeExtKey:
     def __init__(self, path):
         self._path = path
 
     def to_string(self):
-        # a valid-looking xpub is required by convert_xpub_prefix; the exact
-        # value doesn't matter for these tests, only which path produced it
-        return (
-            "xpub6CUGRUonZSQ4TWtTMmzXdrXDtypWKiKrhko4egpiMZbpiaQL2jkwSB1icqYh2cfDf"
-            "Vxdx4df189oLKnC5fSwqPfgyP3hooxujYzAu3fDVmz#" + self._path
-        )
+        return _VALID_XPUB
 
 
 class _FakeDiyClient:
@@ -87,9 +95,14 @@ def _paths_requested(client):
     return [p for kind, p in client.calls if kind == "xpub"]
 
 
+def _key_lines(result):
+    """The '[fpr/derivation]xpub' lines actually returned to the caller."""
+    return [ln for ln in result.split("\n") if ln.strip()]
+
+
 def test_extract_xpubs_mainnet_diy_confirms_once_and_skips_testnet():
     client = _FakeDiyClient("main")
-    HWIBridge(skip_hwi_initialisation=True)._extract_xpubs_from_client(client)
+    result = HWIBridge(skip_hwi_initialisation=True)._extract_xpubs_from_client(client)
 
     kinds = [k for k, _ in client.calls]
     assert kinds.count("begin") == 1  # single scoped confirmation
@@ -102,10 +115,25 @@ def test_extract_xpubs_mainnet_diy_confirms_once_and_skips_testnet():
         "m/48h/0h/0h/2h",
     ]  # only the network the device is on, no testnet requests
 
+    # and the keys actually came back, one line per requested path, with
+    # the slip132 prefix conversion applied (not swallowed as an error)
+    lines = _key_lines(result)
+    assert len(lines) == 4
+    assert [ln.split("]")[0] + "]" for ln in lines] == [
+        "[00000000/49'/0'/0']",
+        "[00000000/84'/0'/0']",
+        "[00000000/48'/0'/0'/1']",
+        "[00000000/48'/0'/0'/2']",
+    ]
+    assert lines[0].split("]")[1].startswith("ypub")
+    assert lines[1].split("]")[1].startswith("zpub")
+    assert lines[2].split("]")[1].startswith("Ypub")
+    assert lines[3].split("]")[1].startswith("Zpub")
+
 
 def test_extract_xpubs_testnet_diy_confirms_once_and_skips_mainnet():
     client = _FakeDiyClient("test")
-    HWIBridge(skip_hwi_initialisation=True)._extract_xpubs_from_client(client)
+    result = HWIBridge(skip_hwi_initialisation=True)._extract_xpubs_from_client(client)
 
     assert _paths_requested(client) == [
         "m/49h/1h/0h",
@@ -113,11 +141,23 @@ def test_extract_xpubs_testnet_diy_confirms_once_and_skips_mainnet():
         "m/48h/1h/0h/1h",
         "m/48h/1h/0h/2h",
     ]
+    lines = _key_lines(result)
+    assert len(lines) == 4
+    assert [ln.split("]")[0] + "]" for ln in lines] == [
+        "[00000000/49'/1'/0']",
+        "[00000000/84'/1'/0']",
+        "[00000000/48'/1'/0'/1']",
+        "[00000000/48'/1'/0'/2']",
+    ]
+    assert lines[0].split("]")[1].startswith("upub")
+    assert lines[1].split("]")[1].startswith("vpub")
+    assert lines[2].split("]")[1].startswith("Upub")
+    assert lines[3].split("]")[1].startswith("Vpub")
 
 
 def test_extract_xpubs_without_batch_auth_still_fetches_both_networks():
     client = _FakePlainClient()
-    HWIBridge(skip_hwi_initialisation=True)._extract_xpubs_from_client(client)
+    result = HWIBridge(skip_hwi_initialisation=True)._extract_xpubs_from_client(client)
 
     assert _paths_requested(client) == [
         "m/49h/0h/0h",
@@ -129,6 +169,7 @@ def test_extract_xpubs_without_batch_auth_still_fetches_both_networks():
         "m/48h/1h/0h/1h",
         "m/48h/1h/0h/2h",
     ]
+    assert len(_key_lines(result)) == 8  # all 8 keys converted and returned
 
 
 def test_extract_xpubs_diy_cancellation_propagates():
@@ -137,6 +178,26 @@ def test_extract_xpubs_diy_cancellation_propagates():
     with pytest.raises(ActionCanceledError):
         HWIBridge(skip_hwi_initialisation=True)._extract_xpubs_from_client(client)
     assert ("close", None) in client.calls  # client still cleaned up
+
+
+@contextmanager
+def _fake_client_cm(client):
+    yield client
+
+
+def test_begin_xpub_authorization_rejects_a_non_bip32_path():
+    bridge = HWIBridge(skip_hwi_initialisation=True)
+    with pytest.raises(Exception):
+        # never reaches the device - parsed and rejected at the RPC boundary
+        bridge.begin_xpub_authorization(paths=["m/49h/0h/0h;m/84h/0h/0h"])
+
+
+def test_begin_xpub_authorization_normalises_paths_before_the_device_sees_them():
+    bridge = HWIBridge(skip_hwi_initialisation=True)
+    client = _FakeDiyClient("main")
+    with patch.object(bridge, "_get_client", return_value=_fake_client_cm(client)):
+        bridge.begin_xpub_authorization(paths=["m/49'/0'/0'", "m/84h/0h/0h"])
+    assert client.calls[0] == ("begin", ["m/49h/0h/0h", "m/84h/0h/0h"])
 
 
 @pytest.mark.skip()

--- a/tests/test_hwi_rpc.py
+++ b/tests/test_hwi_rpc.py
@@ -200,6 +200,52 @@ def test_begin_xpub_authorization_normalises_paths_before_the_device_sees_them()
     assert client.calls[0] == ("begin", ["m/49h/0h/0h", "m/84h/0h/0h"])
 
 
+class _OneShotClient:
+    def __init__(self, exc):
+        self.chain = None
+        self._exc = exc
+
+    def get_master_fingerprint(self):
+        return bytes.fromhex("00000000")
+
+    def get_pubkey_at_path(self, path):
+        raise self._exc
+
+
+def _extract_one(exc):
+    bridge = HWIBridge(skip_hwi_initialisation=True)
+    with patch.object(
+        bridge, "_get_client", return_value=_fake_client_cm(_OneShotClient(exc))
+    ):
+        return bridge.jsonrpc(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "extract_xpub",
+                "params": {"derivation": "m/84h/0h/0h", "device_type": "specter"},
+            }
+        )
+
+
+def test_extract_xpub_returns_none_when_the_user_cancels():
+    resp = _extract_one(ActionCanceledError("nope"))
+    assert "error" not in resp
+    assert resp["result"] is None  # caller reads this as "cancelled, stop"
+
+
+def test_extract_xpub_propagates_other_failures_instead_of_swallowing_them():
+    from cryptoadvance.specter.devices.hwi.specter_diy import (
+        SpecterDIYNetworkMismatchError,
+    )
+
+    for exc in (
+        SpecterDIYNetworkMismatchError("test", "switch the device to Mainnet"),
+        RuntimeError("transport blew up"),
+    ):
+        resp = _extract_one(exc)
+        assert "error" in resp  # reaches the UI, not an ambiguous None
+
+
 @pytest.mark.skip()
 def test_trezor(caplog, monkeypatch):
     """In order to get this test working, you have to run it with "-s":

--- a/tests/test_specter_diy_hwi.py
+++ b/tests/test_specter_diy_hwi.py
@@ -121,7 +121,9 @@ def test_get_pubkey_at_path_translates_network_mismatch_on_mainnet_client():
 
     err = excinfo.value
     assert err.device_network == "test"
+    # device's actual network, verbatim
     assert "Testnet" in str(err)
+    # the network the requested path implies (coin type 0')
     assert "Mainnet" in str(err)
 
 
@@ -136,6 +138,34 @@ def test_get_pubkey_at_path_translates_network_mismatch_on_testnet_client():
     err = excinfo.value
     assert err.device_network == "regtest"
     assert "Regtest" in str(err)
+
+
+def test_get_pubkey_at_path_names_the_requested_network_from_the_path_not_the_chain():
+    # the "switch to X" side comes from the requested path's coin type,
+    # so it is right even when the client's own chain wasn't set
+    client = _client_with_mocked_transport()
+    client.dev.query.return_value = "error: network mismatch: device is on main"
+
+    with pytest.raises(SpecterDIYNetworkMismatchError) as excinfo:
+        client.get_pubkey_at_path("m/84h/1h/0h")
+
+    msg = str(excinfo.value)
+    assert "currently set to Mainnet" in msg
+    assert "Testnet, Signet or Regtest" in msg
+
+
+def test_get_pubkey_at_path_names_liquid_on_a_liquid_coin_type_path():
+    # coin type 1776' is Liquid - unambiguous, and not expressible via the
+    # bitcoin-only Chain enum, so it has to come from the path
+    client = _client_with_mocked_transport()
+    client.dev.query.return_value = "error: network mismatch: device is on main"
+
+    with pytest.raises(SpecterDIYNetworkMismatchError) as excinfo:
+        client.get_pubkey_at_path("m/84h/1776h/0h")
+
+    msg = str(excinfo.value)
+    assert "currently set to Mainnet" in msg
+    assert "Liquid" in msg
 
 
 def test_get_pubkey_at_path_leaves_other_bad_argument_errors_alone():

--- a/tests/test_specter_diy_hwi.py
+++ b/tests/test_specter_diy_hwi.py
@@ -19,9 +19,12 @@ from unittest.mock import MagicMock
 
 import pytest
 from hwilib.common import Chain
-from hwilib.errors import ActionCanceledError
+from hwilib.errors import ActionCanceledError, BadArgumentError
 
-from cryptoadvance.specter.devices.hwi.specter_diy import SpecterClient
+from cryptoadvance.specter.devices.hwi.specter_diy import (
+    SpecterClient,
+    SpecterDIYNetworkMismatchError,
+)
 
 
 def _client_with_mocked_transport():
@@ -106,3 +109,47 @@ def test_begin_xpub_authorization_noop_for_empty_paths():
     client = _client_with_mocked_transport()
     assert client.begin_xpub_authorization([]) is False
     client.dev.query.assert_not_called()
+
+
+def test_get_pubkey_at_path_translates_network_mismatch_on_mainnet_client():
+    client = _client_with_mocked_transport()
+    client.chain = Chain.MAIN
+    client.dev.query.return_value = "error: network mismatch: device is on test"
+
+    with pytest.raises(SpecterDIYNetworkMismatchError) as excinfo:
+        client.get_pubkey_at_path("m/84h/0h/0h")
+
+    err = excinfo.value
+    assert err.device_network == "test"
+    assert "Testnet" in str(err)
+    assert "Mainnet" in str(err)
+
+
+def test_get_pubkey_at_path_translates_network_mismatch_on_testnet_client():
+    client = _client_with_mocked_transport()
+    client.chain = Chain.TEST
+    client.dev.query.return_value = "error: network mismatch: device is on regtest"
+
+    with pytest.raises(SpecterDIYNetworkMismatchError) as excinfo:
+        client.get_pubkey_at_path("m/84h/1h/0h")
+
+    err = excinfo.value
+    assert err.device_network == "regtest"
+    assert "Regtest" in str(err)
+
+
+def test_get_pubkey_at_path_leaves_other_bad_argument_errors_alone():
+    client = _client_with_mocked_transport()
+    client.dev.query.return_value = "error: Invalid path"
+
+    with pytest.raises(BadArgumentError) as excinfo:
+        client.get_pubkey_at_path("m/84h/0h/0h")
+
+    assert not isinstance(excinfo.value, SpecterDIYNetworkMismatchError)
+    assert "Invalid path" in str(excinfo.value)
+
+
+def test_network_mismatch_error_is_a_bad_argument_error():
+    # callers that only know about the generic HWI exception hierarchy
+    # (e.g. existing except BadArgumentError blocks) still catch it
+    assert issubclass(SpecterDIYNetworkMismatchError, BadArgumentError)

--- a/tests/test_specter_diy_hwi.py
+++ b/tests/test_specter_diy_hwi.py
@@ -6,12 +6,20 @@ returning an xpub, so get_pubkey_at_path() must not impose the old 3-second
 response timeout (it should wait indefinitely, like sign_tx() already does).
 get_master_fingerprint() stays non-interactive and keeps its short timeout.
 
+The same firmware also offers `xpubauth begin <scope>` / `xpubauth end` to
+authorize a whole set of derivation paths with a single confirmation;
+begin_xpub_authorization() wraps that, reports whether the device took the
+scope, and degrades gracefully on older firmware.
+
 These are pure unit tests against a mocked transport - no bitcoind, no real
 device, no network required.
 """
+
 from unittest.mock import MagicMock
 
+import pytest
 from hwilib.common import Chain
+from hwilib.errors import ActionCanceledError
 
 from cryptoadvance.specter.devices.hwi.specter_diy import SpecterClient
 
@@ -24,6 +32,15 @@ def _client_with_mocked_transport():
     return client
 
 
+def _timeout_of(call):
+    args, kwargs = call
+    return kwargs.get("timeout", args[1] if len(args) > 1 else None)
+
+
+def _sent(client):
+    return [c.args[0] for c in client.dev.query.call_args_list]
+
+
 def test_get_pubkey_at_path_does_not_pass_a_timeout():
     client = _client_with_mocked_transport()
     client.dev.query.return_value = (
@@ -31,16 +48,61 @@ def test_get_pubkey_at_path_does_not_pass_a_timeout():
         "shSCLtQ4pnyNSSVUXQfP7yzzKcVXBEeejuSsn7q"
     )
     client.get_pubkey_at_path("m/84h/0h/0h")
-    args, kwargs = client.dev.query.call_args
     # positional call: self.dev.query(data, timeout) - the timeout arg
     # (positional or via kwarg) must be None, i.e. "wait indefinitely"
-    passed_timeout = kwargs.get("timeout", args[1] if len(args) > 1 else None)
-    assert passed_timeout is None
+    assert _timeout_of(client.dev.query.call_args) is None
 
 
 def test_get_master_fingerprint_keeps_bounded_timeout():
     client = _client_with_mocked_transport()
     client.get_master_fingerprint()
-    args, kwargs = client.dev.query.call_args
-    passed_timeout = kwargs.get("timeout", args[1] if len(args) > 1 else None)
-    assert passed_timeout == SpecterClient.TIMEOUT
+    assert _timeout_of(client.dev.query.call_args) == SpecterClient.TIMEOUT
+
+
+def test_begin_xpub_authorization_sends_one_scoped_request_and_waits():
+    client = _client_with_mocked_transport()
+    client.dev.query.return_value = "success"
+
+    authorized = client.begin_xpub_authorization(
+        ["m/49h/0h/0h", "m/84h/0h/0h", "m/48h/0h/0h/2h"]
+    )
+
+    assert authorized is True
+    # one begin, every path joined by ";", and no response timeout
+    assert _sent(client) == ["xpubauth begin m/49h/0h/0h;m/84h/0h/0h;m/48h/0h/0h/2h"]
+    assert _timeout_of(client.dev.query.call_args) is None
+
+
+def test_end_xpub_authorization_sends_end():
+    client = _client_with_mocked_transport()
+    client.dev.query.return_value = "success"
+    client.end_xpub_authorization()
+    assert _sent(client) == ["xpubauth end"]
+
+
+def test_begin_xpub_authorization_returns_false_on_firmware_without_xpubauth():
+    client = _client_with_mocked_transport()
+    client.dev.query.return_value = "error: Unknown command xpubauth"
+    assert client.begin_xpub_authorization(["m/84h/0h/0h"]) is False
+
+
+def test_begin_xpub_authorization_returns_false_when_scope_is_rejected():
+    client = _client_with_mocked_transport()
+    # e.g. the scope's coin type doesn't match the device's active network
+    client.dev.query.return_value = (
+        "error: Scope entry does not match the active network (main): m/84h/1h/0h"
+    )
+    assert client.begin_xpub_authorization(["m/84h/1h/0h"]) is False
+
+
+def test_begin_xpub_authorization_propagates_a_cancellation():
+    client = _client_with_mocked_transport()
+    client.dev.query.return_value = "error: User cancelled"
+    with pytest.raises(ActionCanceledError):
+        client.begin_xpub_authorization(["m/84h/0h/0h"])
+
+
+def test_begin_xpub_authorization_noop_for_empty_paths():
+    client = _client_with_mocked_transport()
+    assert client.begin_xpub_authorization([]) is False
+    client.dev.query.assert_not_called()

--- a/tests/test_specter_diy_hwi.py
+++ b/tests/test_specter_diy_hwi.py
@@ -183,3 +183,52 @@ def test_network_mismatch_error_is_a_bad_argument_error():
     # callers that only know about the generic HWI exception hierarchy
     # (e.g. existing except BadArgumentError blocks) still catch it
     assert issubclass(SpecterDIYNetworkMismatchError, BadArgumentError)
+
+
+def test_network_mismatch_message_never_echoes_the_device_string():
+    # the device controls the "<network>" token and the message is
+    # rendered (not escaped) in the UI - an unrecognized value must be
+    # replaced with a fixed phrase, not reflected
+    client = _client_with_mocked_transport()
+    payload = "<img src=x onerror=alert(1)>"
+    client.dev.query.return_value = "error: network mismatch: device is on " + payload
+
+    with pytest.raises(SpecterDIYNetworkMismatchError) as excinfo:
+        client.get_pubkey_at_path("m/84h/0h/0h")
+
+    err = excinfo.value
+    assert err.device_network == payload  # raw value kept for callers
+    assert payload not in str(err)
+    assert "<" not in str(err) and ">" not in str(err)
+    assert "an unknown network" in str(err)
+
+
+def test_network_mismatch_does_not_guess_a_target_for_an_unnamed_coin_type():
+    # standard purpose, but coin type 2' has no known network name - the
+    # firmware's own screen just says "the matching network" here, so the
+    # desktop message must not invent one from client.chain either
+    client = _client_with_mocked_transport()
+    client.chain = Chain.MAIN
+    client.dev.query.return_value = "error: network mismatch: device is on main"
+
+    with pytest.raises(SpecterDIYNetworkMismatchError) as excinfo:
+        client.get_pubkey_at_path("m/84h/2h/0h")
+
+    msg = str(excinfo.value)
+    assert "which doesn't match the requested derivation" in msg
+    assert "share a Mainnet key" not in msg  # no contradictory suggestion
+
+
+def test_network_mismatch_ignores_a_non_hardened_path_for_the_hint():
+    # firmware reads network semantics only from a hardened purpose/coin
+    # type; a non-hardened path must not drive the "switch to X" hint
+    client = _client_with_mocked_transport()
+    client.chain = Chain.MAIN
+    client.dev.query.return_value = "error: network mismatch: device is on test"
+
+    with pytest.raises(SpecterDIYNetworkMismatchError) as excinfo:
+        client.get_pubkey_at_path("m/84/1/0")  # no hardening markers
+
+    msg = str(excinfo.value)
+    assert "which doesn't match the requested derivation" in msg
+    assert "Testnet, Signet or Regtest" not in msg

--- a/tests/test_specter_diy_hwi.py
+++ b/tests/test_specter_diy_hwi.py
@@ -1,0 +1,44 @@
+"""
+Regression tests for cryptoadvance.specter.devices.hwi.specter_diy.SpecterClient.
+
+Specter DIY firmware now requires an on-device user confirmation before
+returning an xpub, so get_pubkey_at_path() must not impose the old 3-second
+response timeout (it should wait indefinitely, like sign_tx() already does).
+get_master_fingerprint() stays non-interactive and keeps its short timeout.
+
+These are pure unit tests against a mocked transport - no bitcoind, no real
+device, no network required.
+"""
+from unittest.mock import MagicMock
+
+from cryptoadvance.specter.devices.hwi.specter_diy import SpecterClient
+
+
+def _client_with_mocked_transport():
+    # ":" in the path selects the (non-connecting-on-init) simulator transport
+    client = SpecterClient("127.0.0.1:9999")
+    client.chain = "main"
+    client.dev.query = MagicMock(return_value="deadbeef")
+    return client
+
+
+def test_get_pubkey_at_path_does_not_pass_a_timeout():
+    client = _client_with_mocked_transport()
+    client.dev.query.return_value = (
+        "tpubD6NzVbkrYhZ4WZaiWHz59q5EQ61bd6dUYfU4ggRWAtNAyyYRNWT6ktJ7UHJEXURvSCVW"
+        "shSCLtQ4pnyNSSVUXQfP7yzzKcVXBEeejuSsn7q"
+    )
+    client.get_pubkey_at_path("m/84h/0h/0h")
+    args, kwargs = client.dev.query.call_args
+    # positional call: self.dev.query(data, timeout) - the timeout arg
+    # (positional or via kwarg) must be None, i.e. "wait indefinitely"
+    passed_timeout = kwargs.get("timeout", args[1] if len(args) > 1 else None)
+    assert passed_timeout is None
+
+
+def test_get_master_fingerprint_keeps_bounded_timeout():
+    client = _client_with_mocked_transport()
+    client.get_master_fingerprint()
+    args, kwargs = client.dev.query.call_args
+    passed_timeout = kwargs.get("timeout", args[1] if len(args) > 1 else None)
+    assert passed_timeout == SpecterClient.TIMEOUT

--- a/tests/test_specter_diy_hwi.py
+++ b/tests/test_specter_diy_hwi.py
@@ -11,13 +11,15 @@ device, no network required.
 """
 from unittest.mock import MagicMock
 
+from hwilib.common import Chain
+
 from cryptoadvance.specter.devices.hwi.specter_diy import SpecterClient
 
 
 def _client_with_mocked_transport():
     # ":" in the path selects the (non-connecting-on-init) simulator transport
     client = SpecterClient("127.0.0.1:9999")
-    client.chain = "main"
+    client.chain = Chain.MAIN
     client.dev.query = MagicMock(return_value="deadbeef")
     return client
 


### PR DESCRIPTION
## Background

Newer Specter-DIY firmware (see cryptoadvance/specter-diy#381) asks the
user to confirm every `xpub` export on the trusted display — a deliberate
privacy property (any process that can reach the serial port could
otherwise enumerate wallet keys silently).

Problems importing such a device into Specter:

1. **Timeout.** `SpecterClient.get_pubkey_at_path()` passed
   `timeout=self.TIMEOUT` (3 s). A human confirming on-device easily
   needs longer, so the import failed with `DeviceBusyError: Timeout` and
   a closed serial port.
2. **One confirmation per key, some for the wrong network.**
   `new_device_keys.jinja` ("Get via USB") fetches one xpub per table
   row, each its own request / serial connection / on-device prompt — 4
   taps for a single-sig + multisig account. `_extract_xpubs_from_client`
   does the same for 8 (4 mainnet + 4 testnet), prompting for a network
   the device isn't even on.

## What this PR does

- **`get_pubkey_at_path()` passes no timeout** — it waits indefinitely,
  like `sign_tx()` already does. `get_master_fingerprint()` keeps its
  short bounded timeout.

- **Batch authorization via the firmware's `xpubauth` protocol**:
  - `SpecterClient.begin_xpub_authorization(paths)` /
    `end_xpub_authorization()` wrap `xpubauth begin <scope>` /
    `xpubauth end`: one scoped request authorizes a whole set of paths
    with a single on-device confirmation, after which the individual
    `xpub` reads return without a prompt.
  - New `HWIBridge` RPC methods of the same name (paths parsed and
    canonically re-serialised at the RPC boundary), plus `hwi.js` /
    `hwi.jinja` wrappers, so the **actual "Get via USB" flow** authorizes
    all pending table rows up front, then loops as before — each
    `getXpub()` returns near-instantly. A **Cancel** on the device
    aborts the whole import instead of falling through to per-key
    prompts.
  - `_extract_xpubs_from_client()` gets the same treatment for its 8-key
    fetch, and **skips the network the device isn't on** (a rejected
    scope for one network's standard paths tells us the device is on the
    other).

- **Clear message when the device is on the wrong network.**
  `get_pubkey_at_path()` recognizes `error: network mismatch: device is
  on <network>` and raises `SpecterDIYNetworkMismatchError` (a
  `BadArgumentError` subclass). The "switch to X" network is derived from
  the requested path's coin type (Mainnet / Liquid / the shared
  testnet-ish group), so it's right even for Liquid. `extract_xpub()`
  re-raises it instead of swallowing it; `handleHWIError()` unwraps the
  JSON-RPC `"Internal error:"` prefix for just that message.

- **Graceful fallback everywhere.** Clients without
  `begin_xpub_authorization` (every non-DIY device) and old DIY firmware
  without `xpubauth` keep the existing per-request flow, unchanged.

## Security hardening (separate commit)

From a code review, independent of the `xpubauth` flow:

- **`handleHWIError()` HTML-escapes the error string** before
  `showError()` (which renders via `innerHTML`). An HWI error can carry
  text straight off a connected wallet (the firmware echoes `error:
  <...>` through, HWI does the same for other devices). Static-message
  `handleHWIError()` call sites were switched to `showError()` so it only
  ever gets a caught error.
- **`_network_mismatch_error()` never reflects the device string** - only
  a whitelisted label ("an unknown network" otherwise). The hint
  requires a hardened purpose/coin type, and for an unrecognized coin
  type it says "switch to the network that derivation is for" rather than
  guessing from `client.chain`.
- **`extract_xpub()` returns `None` only on cancellation** - the
  network-mismatch error and every real failure now propagate to the UI
  instead of being logged and swallowed to an ambiguous `None`.
- The USB transport read loop sleeps 10ms on an empty read instead of
  spinning during the confirmation.

## Test plan

- [x] `black --check` (v22.3.0) on the changed files
- [x] `pytest tests/test_specter_diy_hwi.py tests/test_hwi_rpc.py` — 20
  passed, 2 skipped (timeout contract; `xpubauth` client wrapper
  authorize / old-firmware / rejected-scope / cancel / empty; RPC-level
  path normalization; the network-skip logic; `SpecterDIYNetworkMismatchError`
  translation for mainnet / testnet / liquid; cancellation propagates and
  the client is closed).
- [x] Real Specter-DIY hardware, through the actual "Get via USB" flow:
  one ~4 s `xpubauth begin` confirmation, four fast unprompted `xpub`
  reads, `xpubauth end`; device on the wrong network → refusal screen +
  a "switch the device to X" toast in Specter.

## Companion

Pairs with cryptoadvance/specter-diy#381 (the on-device confirmation, the
`xpubauth` scope protocol, and the individual-request network guard).

