### PR TITLE
Add Taproot support flag for BitBox02

### DIFF
--- a/src/cryptoadvance/specter/devices/bitbox02.py
+++ b/src/cryptoadvance/specter/devices/bitbox02.py
@@ -6,6 +6,7 @@ class BitBox02(HWIDevice):
     name = "BitBox02"
     icon = "img/devices/bitbox02_icon.svg"
     supports_hwi_multisig_display_address = True
+    taproot_support = True
 
     @classmethod
     def get_client(cls, *args, **kwargs):

--- a/tests/test_util_reflection.py
+++ b/tests/test_util_reflection.py
@@ -77,6 +77,10 @@ def test_get_classlist_from_importlist(caplog):
     assert BitBox02 in classlist
 
 
+def test_bitbox02_supports_taproot():
+    assert BitBox02.taproot_support is True
+
+
 def test_get_classlist_skips_missing_module(caplog):
     """Missing modules should be skipped with a warning when skip_missing=True.
     Regression test for #2496."""


### PR DESCRIPTION
Fixes #2425

## Summary
- Enables the existing `taproot_support` capability flag for BitBox02 devices
- Adds a regression assertion so the capability remains enabled

## Test
- `.venv-heartbeat/bin/python -m pytest tests/test_util_reflection.py -q`

Result: 13 passed, 2 warnings.